### PR TITLE
4.3.0: fix iOS/macOS KVO crashes and onCreateWindow return value

### DIFF
--- a/zikzak_inappwebview/CHANGELOG.md
+++ b/zikzak_inappwebview/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 4.3.0 - 2026-06-03
+
+- Fixed: iOS `onCreateWindow` not respecting client return value — now returns `nil` when
+  the client handles the window creation, preventing WebKit from creating an unused
+  window WebView (#107)
+- Fixed: iOS crash on `InAppWebView.dispose()` when KVO observers fire after disposal —
+  added `isDisposed` guard to `observeValue`, made `dispose()` idempotent with
+  `isDisposed = true`, added `dispose()` call in `deinit` (#120, #129)
+- Fixed: macOS SIGSEGV crash in `callAsyncJavaScript` — added `isDisposed` guard to
+  `observeValue`, added optional chaining on `channel?.invokeMethod` calls (#126)
+- Chore: Updated minimum iOS build version to 16.0
+
 ## 4.2.4 - 2026-06-03
 
 - Feature: WebAuthn (passkey) support — added `webAuthenticationSupport` setting +

--- a/zikzak_inappwebview/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/zikzak_inappwebview/example/ios/Runner.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>

--- a/zikzak_inappwebview/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/zikzak_inappwebview/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PreviewsEnabled</key>
-	<false/>
-</dict>
-</plist>

--- a/zikzak_inappwebview/example/macos/Podfile.lock
+++ b/zikzak_inappwebview/example/macos/Podfile.lock
@@ -1,21 +1,15 @@
 PODS:
   - FlutterMacOS (1.0.0)
-  - zikzak_inappwebview_macos (4.0.10):
-    - FlutterMacOS
 
 DEPENDENCIES:
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - zikzak_inappwebview_macos (from `Flutter/ephemeral/.symlinks/plugins/zikzak_inappwebview_macos/macos`)
 
 EXTERNAL SOURCES:
   FlutterMacOS:
     :path: Flutter/ephemeral
-  zikzak_inappwebview_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/zikzak_inappwebview_macos/macos
 
 SPEC CHECKSUMS:
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
-  zikzak_inappwebview_macos: f9a9442e17c576da67224fb469929bb91bee8527
 
 PODFILE CHECKSUM: 1e95c36afbfd1cb6423ceca4de7a8e1b256fb6ac
 

--- a/zikzak_inappwebview/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/zikzak_inappwebview/example/macos/Runner.xcodeproj/project.pbxproj
@@ -28,8 +28,8 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
-		EF93278544FA38CE76BB9217 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03324944087469F19C4C53DD /* Pods_Runner.framework */; };
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
+		EF93278544FA38CE76BB9217 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03324944087469F19C4C53DD /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -83,13 +83,13 @@
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		340C561FBEC0109694BD1ADB /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		752EEF3454B792AE2375CB51 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		8DC56A05E93AD56CE8F6BEF4 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		C86342FECEEFB30F695CCF26 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		ED942C79EF407D3F029F6F0D /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		F7BCC9C1096DED6FE9E6FA8A /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -234,9 +234,6 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		33CC10EC2044A3C60003C045 /* Runner */ = {
-			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
-			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -246,7 +243,6 @@
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
-				841AF9B82FAE204F8E661444 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -254,6 +250,9 @@
 				33CC11202044C79F0003C045 /* PBXTargetDependency */,
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 33CC10ED2044A3C60003C045 /* zikzak_inappwebview_example.app */;
 			productType = "com.apple.product-type.application";
@@ -262,9 +261,6 @@
 
 /* Begin PBXProject section */
 		33CC10E52044A3C60003C045 /* Project object */ = {
-			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
-			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -301,6 +297,9 @@
 				Base,
 			);
 			mainGroup = 33CC10E42044A3C60003C045;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 33CC10EE2044A3C60003C045 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -390,23 +389,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		841AF9B82FAE204F8E661444 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9ECFCDCC2E264401F96DBFCC /* [CP] Check Pods Manifest.lock */ = {
@@ -840,12 +822,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/zikzak_inappwebview/example/pubspec.lock
+++ b/zikzak_inappwebview/example/pubspec.lock
@@ -486,66 +486,58 @@ packages:
   zikzak_inappwebview_android:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_android
-      sha256: "87c82158d71b9d5009fdc802fbda05ad4614c4cde8ea5d74697a54f0adf5e4b0"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_android"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: c0432ea3eee7cb2dfec36eae7afb19bbe04fd82314ec4040e236120d4f7e4152
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_ios:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_ios
-      sha256: "25402c6bbfb9ccfb35432132b5b7d12ba99f53f844632e796ea235c215daf45f"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_ios"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_linux:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_linux
-      sha256: "1a5d4e77f15416e446b6a380643da37d52652f481869bb288e74ff5c6c112c54"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_linux"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_macos:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_macos
-      sha256: cbe0dc87b169dccedc316c64614f20317dd2bae6ffb22049171d7bbeb6f6ec8f
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_macos"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_platform_interface:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: d7ee03c83bfb767155f66ca1476a115cb31d983aafd7f402da5c9a3ffa79a3ce
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_web:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_web
-      sha256: f7a95221b654ea34b95a8953d5cb5fe0d66aaf6e010ccdc288261b7b53f9ca94
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_web"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_windows:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_windows
-      sha256: "8f0c89dbfcf95ca982f92957200677799e22b8ad01ddf2f9c9507fe05995023a"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_windows"
+      relative: true
+    source: path
     version: "4.2.4"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview/pubspec.yaml
+++ b/zikzak_inappwebview/pubspec.yaml
@@ -18,13 +18,20 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
-  zikzak_inappwebview_android: ^4.2.4
-  zikzak_inappwebview_ios: ^4.2.4
-  zikzak_inappwebview_macos: ^4.2.4
-  zikzak_inappwebview_web: ^4.2.4
-  zikzak_inappwebview_windows: ^4.2.4
-  zikzak_inappwebview_linux: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_android:
+    path: ../zikzak_inappwebview_android
+  zikzak_inappwebview_ios:
+    path: ../zikzak_inappwebview_ios
+  zikzak_inappwebview_macos:
+    path: ../zikzak_inappwebview_macos
+  zikzak_inappwebview_web:
+    path: ../zikzak_inappwebview_web
+  zikzak_inappwebview_windows:
+    path: ../zikzak_inappwebview_windows
+  zikzak_inappwebview_linux:
+    path: ../zikzak_inappwebview_linux
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -526,10 +526,16 @@ public final class InAppWebView
                 WebViewFeature.FORCE_DARK_STRATEGY
             )
         ) {
-            WebSettingsCompat.setForceDarkStrategy(
-                settings,
-                customSettings.forceDarkStrategy
-            );
+            try {
+                WebSettingsCompat.setForceDarkStrategy(
+                    settings,
+                    customSettings.forceDarkStrategy
+                );
+            } catch (ClassCastException e) {
+                // Some OEM WebView implementations (e.g. Huawei/Honor) use a
+                // WebSettingsWrapper that cannot be cast to ContentSettingsAdapter.
+                // Silently skip setForceDarkStrategy on those devices.
+            }
         }
         settings.setGeolocationEnabled(customSettings.geolocationEnabled);
         if (customSettings.layoutAlgorithm != null) {
@@ -1700,10 +1706,16 @@ public final class InAppWebView
                 WebViewFeature.FORCE_DARK_STRATEGY
             )
         ) {
-            WebSettingsCompat.setForceDarkStrategy(
-                settings,
-                newCustomSettings.forceDarkStrategy
-            );
+            try {
+                WebSettingsCompat.setForceDarkStrategy(
+                    settings,
+                    newCustomSettings.forceDarkStrategy
+                );
+            } catch (ClassCastException e) {
+                // Some OEM WebView implementations (e.g. Huawei/Honor) use a
+                // WebSettingsWrapper that cannot be cast to ContentSettingsAdapter.
+                // Silently skip setForceDarkStrategy on those devices.
+            }
         }
 
         if (

--- a/zikzak_inappwebview_android/pubspec.yaml
+++ b/zikzak_inappwebview_android/pubspec.yaml
@@ -18,7 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_ios/build_ios_xcframework.sh
+++ b/zikzak_inappwebview_ios/build_ios_xcframework.sh
@@ -39,7 +39,7 @@ IOS_SDK="iphoneos"
 SIMULATOR_SDK="iphonesimulator"
 
 # Minimum supported iOS version. Keep this in sync with the podspec.
-MIN_IOS_VERSION="13.0"
+MIN_IOS_VERSION="16.0"
 
 ###############################################################################
 # Helpers

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Package.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "zikzak_inappwebview_ios",
     platforms: [
-        .iOS("16.0"),
+        .iOS("16.0")
     ],
     products: [
         .library(name: "zikzak-inappwebview-ios", targets: ["zikzak_inappwebview_ios"])

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -10,17 +10,18 @@ import Foundation
 import WebKit
 
 public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
-                            WKNavigationDelegate, WKScriptMessageHandler, UIGestureRecognizerDelegate,
-                            WKDownloadDelegate,
-                            PullToRefreshDelegate,
-                            Disposable {
+    WKNavigationDelegate, WKScriptMessageHandler, UIGestureRecognizerDelegate,
+    WKDownloadDelegate,
+    PullToRefreshDelegate,
+    Disposable
+{
     static let METHOD_CHANNEL_NAME_PREFIX = "wtf.zikzak/zikzak_inappwebview_"
 
-    var id: Any? // viewId
+    var id: Any?  // viewId
     var plugin: SwiftFlutterPlugin?
     var windowId: Int64?
     var windowCreated = false
-    var windowBeforeCreatedCallbacks: [() -> ()] = []
+    var windowBeforeCreatedCallbacks: [() -> Void] = []
     var inAppBrowserDelegate: InAppBrowserDelegate?
     var channelDelegate: WebViewChannelDelegate?
     var settings: InAppWebViewSettings?
@@ -31,8 +32,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     var currentOriginalUrl: URL?
     var inFullscreen = false
     var preventGestureDelay = false
+    private var isDisposed = false
 
-    private static var sslCertificatesMap: [String: SslCertificate] = [:] // [URL host name : SslCertificate]
+    private static var sslCertificatesMap: [String: SslCertificate] = [:]  // [URL host name : SslCertificate]
     private static var credentialsProposed: [URLCredential] = []
 
     var lastScrollX: CGFloat = 0
@@ -63,20 +65,23 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
     var customIMPs: [IMP] = []
 
-    var callAsyncJavaScriptBelowIOS14Results: [String:((Any?) -> Void)] = [:]
+    var callAsyncJavaScriptBelowIOS14Results: [String: ((Any?) -> Void)] = [:]
 
     var oldZoomScale = Float(1.0)
 
     fileprivate var interceptOnlyAsyncAjaxRequestsPluginScript: PluginScript?
 
-    init(id: Any?, plugin: SwiftFlutterPlugin?, frame: CGRect, configuration: WKWebViewConfiguration,
-         contextMenu: [String: Any]?, userScripts: [UserScript] = []) {
+    init(
+        id: Any?, plugin: SwiftFlutterPlugin?, frame: CGRect, configuration: WKWebViewConfiguration,
+        contextMenu: [String: Any]?, userScripts: [UserScript] = []
+    ) {
         super.init(frame: frame, configuration: configuration)
         self.id = id
         self.plugin = plugin
         if let id = id, let registrar = plugin?.registrar {
-            let channel = FlutterMethodChannel(name: InAppWebView.METHOD_CHANNEL_NAME_PREFIX + String(describing: id),
-                                               binaryMessenger: registrar.messenger())
+            let channel = FlutterMethodChannel(
+                name: InAppWebView.METHOD_CHANNEL_NAME_PREFIX + String(describing: id),
+                binaryMessenger: registrar.messenger())
             self.channelDelegate = WebViewChannelDelegate(webView: self, channel: channel)
         }
         self.contextMenu = contextMenu
@@ -89,7 +94,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         longPressRecognizer.addTarget(self, action: #selector(longPressGestureDetected))
         recognizerForDisablingContextMenuOnLinks = UILongPressGestureRecognizer()
         recognizerForDisablingContextMenuOnLinks.delegate = self
-        recognizerForDisablingContextMenuOnLinks.addTarget(self, action: #selector(longPressGestureDetected))
+        recognizerForDisablingContextMenuOnLinks.addTarget(
+            self, action: #selector(longPressGestureDetected))
         recognizerForDisablingContextMenuOnLinks?.minimumPressDuration = 0.45
         panGestureRecognizer = UIPanGestureRecognizer()
         panGestureRecognizer.delegate = self
@@ -107,10 +113,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             if #available(iOS 11, *) {
                 // Above iOS 11, adjust contentInset to compensate the adjustedContentInset so the sum will
                 // always be 0.
-                if (scrollView.adjustedContentInset != UIEdgeInsets.zero) {
+                if scrollView.adjustedContentInset != UIEdgeInsets.zero {
                     let insetToAdjust = self.scrollView.adjustedContentInset
-                    scrollView.contentInset = UIEdgeInsets(top: -insetToAdjust.top, left: -insetToAdjust.left,
-                                                                bottom: -insetToAdjust.bottom, right: -insetToAdjust.right)
+                    scrollView.contentInset = UIEdgeInsets(
+                        top: -insetToAdjust.top, left: -insetToAdjust.left,
+                        bottom: -insetToAdjust.bottom, right: -insetToAdjust.right)
                 }
             }
         }
@@ -120,7 +127,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         super.init(coder: aDecoder)!
     }
 
-    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+    public func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
         return true
     }
 
@@ -139,19 +149,27 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     private func replaceWebViewLongPress() {
         // WebKit installs gesture handlers async. If `replaceWebViewLongPress` is called after a wkwebview in most cases a small delay is sufficient
         // See also https://bugs.webkit.org/show_bug.cgi?id=193366
-        nativeHighlightLongPressRecognizer = gestureRecognizerWithDescriptionFragment("action=_highlightLongPressRecognized:")
+        nativeHighlightLongPressRecognizer = gestureRecognizerWithDescriptionFragment(
+            "action=_highlightLongPressRecognized:")
         nativeLoupeGesture = gestureRecognizerWithDescriptionFragment("action=loupeGesture:")
 
-        if let nativeLongPressRecognizer = gestureRecognizerWithDescriptionFragment("action=_longPressRecognized:") {
+        if let nativeLongPressRecognizer = gestureRecognizerWithDescriptionFragment(
+            "action=_longPressRecognized:")
+        {
             nativeLongPressRecognizer.removeTarget(nil, action: nil)
-            nativeLongPressRecognizer.addTarget(self, action: #selector(self.longPressGestureDetected))
+            nativeLongPressRecognizer.addTarget(
+                self, action: #selector(self.longPressGestureDetected))
         }
     }
 
-    private func gestureRecognizerWithDescriptionFragment(_ descriptionFragment: String) -> UILongPressGestureRecognizer? {
-        let result = self.scrollView.subviews.compactMap({ $0.gestureRecognizers }).joined().first(where: {
-            return (($0 as? UILongPressGestureRecognizer) != nil) && $0.description.contains(descriptionFragment)
-        })
+    private func gestureRecognizerWithDescriptionFragment(_ descriptionFragment: String)
+        -> UILongPressGestureRecognizer?
+    {
+        let result = self.scrollView.subviews.compactMap({ $0.gestureRecognizers }).joined().first(
+            where: {
+                return (($0 as? UILongPressGestureRecognizer) != nil)
+                    && $0.description.contains(descriptionFragment)
+            })
         return result as? UILongPressGestureRecognizer
     }
 
@@ -165,7 +183,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if sender == recognizerForDisablingContextMenuOnLinks,
-           let settings = settings, !settings.disableLongPressContextMenuOnLinks {
+            let settings = settings, !settings.disableLongPressContextMenuOnLinks
+        {
             return
         }
 
@@ -174,7 +193,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             // `_highlightLongPressRecognizer`. This preserves the original behavior as seen here:
             // https://github.com/WebKit/webkit/blob/d591647baf54b4b300ca5501c21a68455429e182/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm#L1600-L1614
             if let nativeHighlightLongPressRecognizer = nativeHighlightLongPressRecognizer,
-                nativeHighlightLongPressRecognizer.isEnabled {
+                nativeHighlightLongPressRecognizer.isEnabled
+            {
                 nativeHighlightLongPressRecognizer.isEnabled = false
                 nativeHighlightLongPressRecognizer.isEnabled = true
             }
@@ -189,25 +209,31 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
         lastLongPressTouchPoint = touchLocation
 
-        evaluateJavaScript("window.\(JAVASCRIPT_BRIDGE_NAME)._findElementsAtPoint(\(touchLocation.x),\(touchLocation.y))", completionHandler: {(value, error) in
-            if error != nil {
-                print("Long press gesture recognizer error: \(error?.localizedDescription ?? "")")
-            } else if let value = value as? [String: Any?] {
-                let hitTestResult = HitTestResult.fromMap(map: value)!
-                self.nativeLoupeGesture = self.gestureRecognizerWithDescriptionFragment("action=loupeGesture:")
+        evaluateJavaScript(
+            "window.\(JAVASCRIPT_BRIDGE_NAME)._findElementsAtPoint(\(touchLocation.x),\(touchLocation.y))",
+            completionHandler: { (value, error) in
+                if error != nil {
+                    print(
+                        "Long press gesture recognizer error: \(error?.localizedDescription ?? "")")
+                } else if let value = value as? [String: Any?] {
+                    let hitTestResult = HitTestResult.fromMap(map: value)!
+                    self.nativeLoupeGesture = self.gestureRecognizerWithDescriptionFragment(
+                        "action=loupeGesture:")
 
-                if sender == self.recognizerForDisablingContextMenuOnLinks,
-                   hitTestResult.type.rawValue > HitTestResultType.unknownType.rawValue,
-                   hitTestResult.type.rawValue < HitTestResultType.editTextType.rawValue {
-                    self.nativeLoupeGesture?.isEnabled = false
-                    self.nativeLoupeGesture?.isEnabled = true
-                } else {
-                    self.channelDelegate?.onLongPressHitTestResult(hitTestResult: hitTestResult)
+                    if sender == self.recognizerForDisablingContextMenuOnLinks,
+                        hitTestResult.type.rawValue > HitTestResultType.unknownType.rawValue,
+                        hitTestResult.type.rawValue < HitTestResultType.editTextType.rawValue
+                    {
+                        self.nativeLoupeGesture?.isEnabled = false
+                        self.nativeLoupeGesture?.isEnabled = true
+                    } else {
+                        self.channelDelegate?.onLongPressHitTestResult(hitTestResult: hitTestResult)
+                    }
+                } else if sender == self.longPressRecognizer {
+                    self.channelDelegate?.onLongPressHitTestResult(
+                        hitTestResult: HitTestResult(type: .unknownType, extra: nil))
                 }
-            } else if sender == self.longPressRecognizer {
-                self.channelDelegate?.onLongPressHitTestResult(hitTestResult: HitTestResult(type: .unknownType, extra: nil))
-            }
-        })
+            })
     }
 
     public override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
@@ -218,24 +244,29 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         // re-build context menu items for the current webview
         UIMenuController.shared.menuItems = []
         if let menu = self.contextMenu {
-            if let menuItems = menu["menuItems"] as? [[String : Any]] {
+            if let menuItems = menu["menuItems"] as? [[String: Any]] {
                 for menuItem in menuItems {
                     let id = menuItem["id"]!
                     let title = menuItem["title"] as! String
-                    let targetMethodName = "onContextMenuActionItemClicked-" + String(self.hash) + "-" +
-                                            (id is Int64 ? String(id as! Int64) : id as! String)
+                    let targetMethodName =
+                        "onContextMenuActionItemClicked-" + String(self.hash) + "-"
+                        + (id is Int64 ? String(id as! Int64) : id as! String)
                     if !self.responds(to: Selector(targetMethodName)) {
                         let customAction: () -> Void = {
-                            self.channelDelegate?.onContextMenuActionItemClicked(id: id, title: title)
+                            self.channelDelegate?.onContextMenuActionItemClicked(
+                                id: id, title: title)
                             if #available(iOS 16.0, *) {
                                 if #unavailable(iOS 16.4) {
                                     self.onHideContextMenu()
                                 }
                             }
                         }
-                        let castedCustomAction: AnyObject = unsafeBitCast(customAction as @convention(block) () -> Void, to: AnyObject.self)
+                        let castedCustomAction: AnyObject = unsafeBitCast(
+                            customAction as @convention(block) () -> Void, to: AnyObject.self)
                         let swizzledImplementation = imp_implementationWithBlock(castedCustomAction)
-                        class_addMethod(InAppWebView.self, Selector(targetMethodName), swizzledImplementation, nil)
+                        class_addMethod(
+                            InAppWebView.self, Selector(targetMethodName), swizzledImplementation,
+                            nil)
                         self.customIMPs.append(swizzledImplementation)
                     }
                     let item = UIMenuItem(title: title, action: Selector(targetMethodName))
@@ -279,12 +310,18 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     }
 
     @available(iOS 16.4, *)
-    public func webView(_ webView: WKWebView, willPresentEditMenuWithAnimator animator: UIEditMenuInteractionAnimating) {
+    public func webView(
+        _ webView: WKWebView,
+        willPresentEditMenuWithAnimator animator: UIEditMenuInteractionAnimating
+    ) {
         onCreateContextMenu()
     }
 
     @available(iOS 16.4, *)
-    public func webView(_ webView: WKWebView, willDismissEditMenuWithAnimator animator: UIEditMenuInteractionAnimating) {
+    public func webView(
+        _ webView: WKWebView,
+        willDismissEditMenuWithAnimator animator: UIEditMenuInteractionAnimating
+    ) {
         onHideContextMenu()
     }
 
@@ -308,13 +345,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 let contextMenuSettings = ContextMenuSettings()
                 if let contextMenuSettingsMap = menu["settings"] as? [String: Any?] {
                     let _ = contextMenuSettings.parse(settings: contextMenuSettingsMap)
-                    if !action.description.starts(with: "onContextMenuActionItemClicked-") && contextMenuSettings.hideDefaultSystemContextMenuItems {
+                    if !action.description.starts(with: "onContextMenuActionItemClicked-")
+                        && contextMenuSettings.hideDefaultSystemContextMenuItems
+                    {
                         return false
                     }
                 }
             }
 
-            if contextMenuIsShowing, !action.description.starts(with: "onContextMenuActionItemClicked-") {
+            if contextMenuIsShowing,
+                !action.description.starts(with: "onContextMenuActionItemClicked-")
+            {
                 let id = action.description.compactMap({ $0.asciiValue?.description }).joined()
                 channelDelegate?.onContextMenuActionItemClicked(id: id, title: action.description)
                 if #available(iOS 16.0, *) {
@@ -334,7 +375,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if panGestureRecognizer.state == .ended {
             // fix for pull-to-refresh jittering when the touch drag event is held
             if let pullToRefreshControl = pullToRefreshControl,
-               pullToRefreshControl.shouldCallOnRefresh {
+                pullToRefreshControl.shouldCallOnRefresh
+            {
                 pullToRefreshControl.onRefresh()
             }
         }
@@ -344,32 +386,42 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         scrollView.addGestureRecognizer(self.longPressRecognizer)
         scrollView.addGestureRecognizer(self.recognizerForDisablingContextMenuOnLinks)
         scrollView.addGestureRecognizer(self.panGestureRecognizer)
-        scrollView.addObserver(self, forKeyPath: #keyPath(UIScrollView.contentOffset), options: [.new, .old], context: nil)
-        scrollView.addObserver(self, forKeyPath: #keyPath(UIScrollView.zoomScale), options: [.new, .old], context: nil)
-        scrollView.addObserver(self, forKeyPath: #keyPath(UIScrollView.contentSize), options: [.new, .old], context: nil)
+        scrollView.addObserver(
+            self, forKeyPath: #keyPath(UIScrollView.contentOffset), options: [.new, .old],
+            context: nil)
+        scrollView.addObserver(
+            self, forKeyPath: #keyPath(UIScrollView.zoomScale), options: [.new, .old], context: nil)
+        scrollView.addObserver(
+            self, forKeyPath: #keyPath(UIScrollView.contentSize), options: [.new, .old],
+            context: nil)
 
-        addObserver(self,
-                    forKeyPath: #keyPath(WKWebView.estimatedProgress),
-                    options: .new,
-                    context: nil)
+        addObserver(
+            self,
+            forKeyPath: #keyPath(WKWebView.estimatedProgress),
+            options: .new,
+            context: nil)
 
-        addObserver(self,
-                    forKeyPath: #keyPath(WKWebView.url),
-                    options: [.new, .old],
-                    context: nil)
+        addObserver(
+            self,
+            forKeyPath: #keyPath(WKWebView.url),
+            options: [.new, .old],
+            context: nil)
 
-        addObserver(self,
+        addObserver(
+            self,
             forKeyPath: #keyPath(WKWebView.title),
             options: [.new, .old],
             context: nil)
 
         if #available(iOS 15.0, *) {
-            addObserver(self,
+            addObserver(
+                self,
                 forKeyPath: #keyPath(WKWebView.cameraCaptureState),
                 options: [.new, .old],
                 context: nil)
 
-            addObserver(self,
+            addObserver(
+                self,
                 forKeyPath: #keyPath(WKWebView.microphoneCaptureState),
                 options: [.new, .old],
                 context: nil)
@@ -390,24 +442,26 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         // TODO: Still not working on iOS 16.0!
-//        if #available(iOS 16.0, *) {
-//            addObserver(self,
-//                        forKeyPath: #keyPath(WKWebView.fullscreenState),
-//                        options: .new,
-//                context: nil)
-//        } else {
-            // listen for videos playing in fullscreen
-            NotificationCenter.default.addObserver(self,
-                                                   selector: #selector(onEnterFullscreen(_:)),
-                                                   name: UIWindow.didBecomeVisibleNotification,
-                                                   object: window)
+        //        if #available(iOS 16.0, *) {
+        //            addObserver(self,
+        //                        forKeyPath: #keyPath(WKWebView.fullscreenState),
+        //                        options: .new,
+        //                context: nil)
+        //        } else {
+        // listen for videos playing in fullscreen
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onEnterFullscreen(_:)),
+            name: UIWindow.didBecomeVisibleNotification,
+            object: window)
 
-            // listen for videos stopping to play in fullscreen
-            NotificationCenter.default.addObserver(self,
-                                                   selector: #selector(onExitFullscreen(_:)),
-                                                   name: UIWindow.didBecomeHiddenNotification,
-                                                   object: window)
-//        }
+        // listen for videos stopping to play in fullscreen
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(onExitFullscreen(_:)),
+            name: UIWindow.didBecomeHiddenNotification,
+            object: window)
+        //        }
 
         if let settings = settings {
             if settings.transparentBackground {
@@ -420,8 +474,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             if settings.disallowOverScroll {
                 if responds(to: #selector(getter: scrollView)) {
                     scrollView.bounces = false
-                }
-                else {
+                } else {
                     for subview: UIView in subviews {
                         if subview is UIScrollView {
                             (subview as! UIScrollView).bounces = false
@@ -433,7 +486,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             if #available(iOS 11.0, *) {
                 accessibilityIgnoresInvertColors = settings.accessibilityIgnoresInvertColors
                 scrollView.contentInsetAdjustmentBehavior =
-                    UIScrollView.ContentInsetAdjustmentBehavior.init(rawValue: settings.contentInsetAdjustmentBehavior)!
+                    UIScrollView.ContentInsetAdjustmentBehavior.init(
+                        rawValue: settings.contentInsetAdjustmentBehavior)!
             }
 
             allowsBackForwardNavigationGestures = settings.allowsBackForwardNavigationGestures
@@ -445,14 +499,16 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
 
             if #available(iOS 13.0, *) {
-                scrollView.automaticallyAdjustsScrollIndicatorInsets = settings.automaticallyAdjustsScrollIndicatorInsets
+                scrollView.automaticallyAdjustsScrollIndicatorInsets =
+                    settings.automaticallyAdjustsScrollIndicatorInsets
             }
 
             scrollView.showsVerticalScrollIndicator = !settings.disableVerticalScroll
             scrollView.showsHorizontalScrollIndicator = !settings.disableHorizontalScroll
             scrollView.showsVerticalScrollIndicator = settings.verticalScrollBarEnabled
             scrollView.showsHorizontalScrollIndicator = settings.horizontalScrollBarEnabled
-            scrollView.isScrollEnabled = !(settings.disableVerticalScroll && settings.disableHorizontalScroll)
+            scrollView.isScrollEnabled =
+                !(settings.disableVerticalScroll && settings.disableHorizontalScroll)
             scrollView.isDirectionalLockEnabled = settings.isDirectionalLockEnabled
 
             scrollView.decelerationRate = Util.getDecelerationRate(type: settings.decelerationRate)
@@ -476,14 +532,19 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
 
             if #available(iOS 15.0, *) {
-                if let underPageBackgroundColor = settings.underPageBackgroundColor, !underPageBackgroundColor.isEmpty {
+                if let underPageBackgroundColor = settings.underPageBackgroundColor,
+                    !underPageBackgroundColor.isEmpty
+                {
                     self.underPageBackgroundColor = UIColor(hexString: underPageBackgroundColor)
                 }
             }
 
             if #available(iOS 15.5, *) {
-                if let minViewportInset = settings.minimumViewportInset, let maxViewportInset = settings.maximumViewportInset {
-                    setMinimumViewportInset(minViewportInset, maximumViewportInset: maxViewportInset)
+                if let minViewportInset = settings.minimumViewportInset,
+                    let maxViewportInset = settings.maximumViewportInset
+                {
+                    setMinimumViewportInset(
+                        minViewportInset, maximumViewportInset: maxViewportInset)
                 }
             }
 
@@ -513,28 +574,36 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if let settings = settings {
             if #available(iOS 9.0, *) {
                 configuration.allowsAirPlayForMediaPlayback = settings.allowsAirPlayForMediaPlayback
-                configuration.allowsPictureInPictureMediaPlayback = settings.allowsPictureInPictureMediaPlayback
+                configuration.allowsPictureInPictureMediaPlayback =
+                    settings.allowsPictureInPictureMediaPlayback
             }
 
-            configuration.preferences.javaScriptCanOpenWindowsAutomatically = settings.javaScriptCanOpenWindowsAutomatically
+            configuration.preferences.javaScriptCanOpenWindowsAutomatically =
+                settings.javaScriptCanOpenWindowsAutomatically
             configuration.preferences.minimumFontSize = CGFloat(settings.minimumFontSize)
 
             if #available(iOS 13.0, *) {
-                configuration.preferences.isFraudulentWebsiteWarningEnabled = settings.isFraudulentWebsiteWarningEnabled
-                configuration.defaultWebpagePreferences.preferredContentMode = WKWebpagePreferences.ContentMode(rawValue: settings.preferredContentMode)!
+                configuration.preferences.isFraudulentWebsiteWarningEnabled =
+                    settings.isFraudulentWebsiteWarningEnabled
+                configuration.defaultWebpagePreferences.preferredContentMode =
+                    WKWebpagePreferences.ContentMode(rawValue: settings.preferredContentMode)!
             }
 
             configuration.preferences.javaScriptEnabled = settings.javaScriptEnabled
             if #available(iOS 14.0, *) {
-                configuration.defaultWebpagePreferences.allowsContentJavaScript = settings.javaScriptEnabled
+                configuration.defaultWebpagePreferences.allowsContentJavaScript =
+                    settings.javaScriptEnabled
             }
 
             if #available(iOS 15.0, *) {
-                configuration.preferences.isTextInteractionEnabled = settings.isTextInteractionEnabled
+                configuration.preferences.isTextInteractionEnabled =
+                    settings.isTextInteractionEnabled
             }
             if #available(iOS 15.4, *) {
-                configuration.preferences.isSiteSpecificQuirksModeEnabled = settings.isSiteSpecificQuirksModeEnabled
-                configuration.preferences.isElementFullscreenEnabled = settings.isElementFullscreenEnabled
+                configuration.preferences.isSiteSpecificQuirksModeEnabled =
+                    settings.isSiteSpecificQuirksModeEnabled
+                configuration.preferences.isElementFullscreenEnabled =
+                    settings.isElementFullscreenEnabled
             }
             if #available(iOS 16.4, *) {
                 configuration.preferences.shouldPrintBackgrounds = settings.shouldPrintBackgrounds
@@ -542,7 +611,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func prepareAndAddUserScripts() -> Void {
+    public func prepareAndAddUserScripts() {
         if windowId != nil {
             // The new created window webview has the same WKWebViewConfiguration variable reference.
             // So, we cannot set another WKWebViewConfiguration for it unfortunately!
@@ -563,40 +632,59 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         configuration.userContentController.addPluginScript(ON_WINDOW_BLUR_EVENT_JS_PLUGIN_SCRIPT)
         configuration.userContentController.addPluginScript(ON_WINDOW_FOCUS_EVENT_JS_PLUGIN_SCRIPT)
         configuration.userContentController.addPluginScript(FIND_ELEMENTS_AT_POINT_JS_PLUGIN_SCRIPT)
-        configuration.userContentController.addPluginScript(LAST_TOUCHED_ANCHOR_OR_IMAGE_JS_PLUGIN_SCRIPT)
+        configuration.userContentController.addPluginScript(
+            LAST_TOUCHED_ANCHOR_OR_IMAGE_JS_PLUGIN_SCRIPT)
         configuration.userContentController.addPluginScript(FIND_TEXT_HIGHLIGHT_JS_PLUGIN_SCRIPT)
-        configuration.userContentController.addPluginScript(ORIGINAL_VIEWPORT_METATAG_CONTENT_JS_PLUGIN_SCRIPT)
+        configuration.userContentController.addPluginScript(
+            ORIGINAL_VIEWPORT_METATAG_CONTENT_JS_PLUGIN_SCRIPT)
         if let settings = settings {
-            interceptOnlyAsyncAjaxRequestsPluginScript = createInterceptOnlyAsyncAjaxRequestsPluginScript(onlyAsync: settings.interceptOnlyAsyncAjaxRequests)
+            interceptOnlyAsyncAjaxRequestsPluginScript =
+                createInterceptOnlyAsyncAjaxRequestsPluginScript(
+                    onlyAsync: settings.interceptOnlyAsyncAjaxRequests)
             if settings.useShouldInterceptAjaxRequest {
-                if let interceptOnlyAsyncAjaxRequestsPluginScript = interceptOnlyAsyncAjaxRequestsPluginScript {
-                    configuration.userContentController.addPluginScript(interceptOnlyAsyncAjaxRequestsPluginScript)
+                if let interceptOnlyAsyncAjaxRequestsPluginScript =
+                    interceptOnlyAsyncAjaxRequestsPluginScript
+                {
+                    configuration.userContentController.addPluginScript(
+                        interceptOnlyAsyncAjaxRequestsPluginScript)
                 }
-                configuration.userContentController.addPluginScript(INTERCEPT_AJAX_REQUEST_JS_PLUGIN_SCRIPT)
+                configuration.userContentController.addPluginScript(
+                    INTERCEPT_AJAX_REQUEST_JS_PLUGIN_SCRIPT)
             }
             if settings.useShouldInterceptFetchRequest {
-                configuration.userContentController.addPluginScript(INTERCEPT_FETCH_REQUEST_JS_PLUGIN_SCRIPT)
+                configuration.userContentController.addPluginScript(
+                    INTERCEPT_FETCH_REQUEST_JS_PLUGIN_SCRIPT)
             }
             if settings.useOnLoadResource {
-                configuration.userContentController.addPluginScript(ON_LOAD_RESOURCE_JS_PLUGIN_SCRIPT)
+                configuration.userContentController.addPluginScript(
+                    ON_LOAD_RESOURCE_JS_PLUGIN_SCRIPT)
             }
             if !settings.supportZoom {
-                configuration.userContentController.addPluginScript(NOT_SUPPORT_ZOOM_JS_PLUGIN_SCRIPT)
+                configuration.userContentController.addPluginScript(
+                    NOT_SUPPORT_ZOOM_JS_PLUGIN_SCRIPT)
             } else if settings.enableViewportScale {
-                configuration.userContentController.addPluginScript(ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
+                configuration.userContentController.addPluginScript(
+                    ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
             }
         }
-        configuration.userContentController.removeScriptMessageHandler(forName: "onCallAsyncJavaScriptResultBelowIOS14Received")
-        configuration.userContentController.add(self, name: "onCallAsyncJavaScriptResultBelowIOS14Received")
-        configuration.userContentController.removeScriptMessageHandler(forName: "onWebMessagePortMessageReceived")
+        configuration.userContentController.removeScriptMessageHandler(
+            forName: "onCallAsyncJavaScriptResultBelowIOS14Received")
+        configuration.userContentController.add(
+            self, name: "onCallAsyncJavaScriptResultBelowIOS14Received")
+        configuration.userContentController.removeScriptMessageHandler(
+            forName: "onWebMessagePortMessageReceived")
         configuration.userContentController.add(self, name: "onWebMessagePortMessageReceived")
-        configuration.userContentController.removeScriptMessageHandler(forName: "onWebMessageListenerPostMessageReceived")
-        configuration.userContentController.add(self, name: "onWebMessageListenerPostMessageReceived")
+        configuration.userContentController.removeScriptMessageHandler(
+            forName: "onWebMessageListenerPostMessageReceived")
+        configuration.userContentController.add(
+            self, name: "onWebMessageListenerPostMessageReceived")
         configuration.userContentController.addUserOnlyScripts(initialUserScripts)
         configuration.userContentController.sync(scriptMessageHandler: self)
     }
 
-    public static func preWKWebViewConfiguration(settings: InAppWebViewSettings?) -> WKWebViewConfiguration {
+    public static func preWKWebViewConfiguration(settings: InAppWebViewSettings?)
+        -> WKWebViewConfiguration
+    {
         let configuration = WKWebViewConfiguration()
 
         configuration.processPool = WKProcessPoolManager.sharedProcessPool
@@ -604,14 +692,18 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if let settings = settings {
             configuration.allowsInlineMediaPlayback = settings.allowsInlineMediaPlayback
             configuration.suppressesIncrementalRendering = settings.suppressesIncrementalRendering
-            configuration.selectionGranularity = WKSelectionGranularity.init(rawValue: settings.selectionGranularity)!
+            configuration.selectionGranularity = WKSelectionGranularity.init(
+                rawValue: settings.selectionGranularity)!
 
             if settings.allowUniversalAccessFromFileURLs {
-                configuration.setValue(settings.allowUniversalAccessFromFileURLs, forKey: "allowUniversalAccessFromFileURLs")
+                configuration.setValue(
+                    settings.allowUniversalAccessFromFileURLs,
+                    forKey: "allowUniversalAccessFromFileURLs")
             }
 
             if settings.allowFileAccessFromFileURLs {
-                configuration.preferences.setValue(settings.allowFileAccessFromFileURLs, forKey: "allowFileAccessFromFileURLs")
+                configuration.preferences.setValue(
+                    settings.allowFileAccessFromFileURLs, forKey: "allowFileAccessFromFileURLs")
             }
 
             if #available(iOS 9.0, *) {
@@ -622,7 +714,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 }
                 if !settings.applicationNameForUserAgent.isEmpty {
                     if let applicationNameForUserAgent = configuration.applicationNameForUserAgent {
-                        configuration.applicationNameForUserAgent = applicationNameForUserAgent + " " + settings.applicationNameForUserAgent
+                        configuration.applicationNameForUserAgent =
+                            applicationNameForUserAgent + " " + settings.applicationNameForUserAgent
                     }
                 }
             }
@@ -633,14 +726,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 var dataDetectorTypes = WKDataDetectorTypes.init(rawValue: 0)
                 for type in settings.dataDetectorTypes {
                     let dataDetectorType = Util.getDataDetectorType(type: type)
-                    dataDetectorTypes = WKDataDetectorTypes(rawValue: dataDetectorTypes.rawValue | dataDetectorType.rawValue)
+                    dataDetectorTypes = WKDataDetectorTypes(
+                        rawValue: dataDetectorTypes.rawValue | dataDetectorType.rawValue)
                 }
                 configuration.dataDetectorTypes = dataDetectorTypes
 
-                configuration.mediaTypesRequiringUserActionForPlayback = settings.mediaPlaybackRequiresUserGesture ? .all : []
+                configuration.mediaTypesRequiringUserActionForPlayback =
+                    settings.mediaPlaybackRequiresUserGesture ? .all : []
             } else {
                 // Fallback on earlier versions
-                configuration.mediaPlaybackRequiresUserAction = settings.mediaPlaybackRequiresUserGesture
+                configuration.mediaPlaybackRequiresUserAction =
+                    settings.mediaPlaybackRequiresUserGesture
             }
 
             if #available(iOS 11.0, *) {
@@ -653,17 +749,19 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     // Set Cookies in iOS 11 and above, initialize websiteDataStore before setting cookies
                     // See also https://forums.developer.apple.com/thread/97194
                     // check if websiteDataStore has not been initialized before
-                    if(!settings.incognito && !settings.cacheEnabled) {
+                    if !settings.incognito && !settings.cacheEnabled {
                         configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                     }
                     for cookie in HTTPCookieStorage.shared.cookies ?? [] {
-                        configuration.websiteDataStore.httpCookieStore.setCookie(cookie, completionHandler: nil)
+                        configuration.websiteDataStore.httpCookieStore.setCookie(
+                            cookie, completionHandler: nil)
                     }
                 }
             }
 
             if #available(iOS 14.0, *) {
-                configuration.limitsNavigationsToAppBoundDomains = settings.limitsNavigationsToAppBoundDomains
+                configuration.limitsNavigationsToAppBoundDomains =
+                    settings.limitsNavigationsToAppBoundDomains
             }
 
             if #available(iOS 15.0, *) {
@@ -676,7 +774,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
     @objc func onCreateContextMenu() {
         let mapSorted = SharedLastTouchPointTimestamp.sorted { $0.value > $1.value }
-        if (mapSorted.first?.key != self) {
+        if mapSorted.first?.key != self {
             return
         }
 
@@ -686,15 +784,20 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
         if let lastLongPressTouhLocation = lastLongPressTouchPoint {
             if configuration.preferences.javaScriptEnabled {
-                self.evaluateJavaScript("window.\(JAVASCRIPT_BRIDGE_NAME)._findElementsAtPoint(\(lastLongPressTouhLocation.x),\(lastLongPressTouhLocation.y))", completionHandler: {(value, error) in
-                    if error != nil {
-                        print("Long press gesture recognizer error: \(error?.localizedDescription ?? "")")
-                    } else if let value = value as? [String: Any?] {
-                        self.channelDelegate?.onCreateContextMenu(hitTestResult: HitTestResult.fromMap(map: value) ?? hitTestResult)
-                    } else {
-                        self.channelDelegate?.onCreateContextMenu(hitTestResult: hitTestResult)
-                    }
-                })
+                self.evaluateJavaScript(
+                    "window.\(JAVASCRIPT_BRIDGE_NAME)._findElementsAtPoint(\(lastLongPressTouhLocation.x),\(lastLongPressTouhLocation.y))",
+                    completionHandler: { (value, error) in
+                        if error != nil {
+                            print(
+                                "Long press gesture recognizer error: \(error?.localizedDescription ?? "")"
+                            )
+                        } else if let value = value as? [String: Any?] {
+                            self.channelDelegate?.onCreateContextMenu(
+                                hitTestResult: HitTestResult.fromMap(map: value) ?? hitTestResult)
+                        } else {
+                            self.channelDelegate?.onCreateContextMenu(hitTestResult: hitTestResult)
+                        }
+                    })
             } else {
                 channelDelegate?.onCreateContextMenu(hitTestResult: hitTestResult)
             }
@@ -711,8 +814,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         channelDelegate?.onHideContextMenu()
     }
 
-    override public func observeValue(forKeyPath keyPath: String?, of object: Any?,
-                               change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    override public func observeValue(
+        forKeyPath keyPath: String?, of object: Any?,
+        change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?
+    ) {
+        guard !isDisposed else { return }
+
         if keyPath == #keyPath(WKWebView.estimatedProgress) {
             initializeWindowIdJS()
             let progress = Int(estimatedProgress * 100)
@@ -733,20 +840,23 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             let startedByUser = scrollView.isDragging || scrollView.isDecelerating
             if newContentOffset != oldContentOffset {
                 DispatchQueue.main.async {
-                    self.onScrollChanged(startedByUser: startedByUser, oldContentOffset: oldContentOffset)
+                    self.onScrollChanged(
+                        startedByUser: startedByUser, oldContentOffset: oldContentOffset)
                 }
             }
         } else if keyPath == #keyPath(UIScrollView.contentSize) {
             if let newContentSize = change?[.newKey] as? CGSize,
-               let oldContentSize = change?[.oldKey] as? CGSize,
-               newContentSize != oldContentSize {
+                let oldContentSize = change?[.oldKey] as? CGSize,
+                newContentSize != oldContentSize
+            {
                 DispatchQueue.main.async {
                     self.onContentSizeChanged(oldContentSize: oldContentSize)
                 }
             }
-        }
-        else if #available(iOS 15.0, *) {
-            if keyPath == #keyPath(WKWebView.cameraCaptureState) || keyPath == #keyPath(WKWebView.microphoneCaptureState) {
+        } else if #available(iOS 15.0, *) {
+            if keyPath == #keyPath(WKWebView.cameraCaptureState)
+                || keyPath == #keyPath(WKWebView.microphoneCaptureState)
+            {
                 var oldState: WKMediaCaptureState? = nil
                 if let oldValue = change?[.oldKey] as? Int {
                     oldState = WKMediaCaptureState.init(rawValue: oldValue)
@@ -757,21 +867,23 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 }
                 if oldState != newState {
                     if keyPath == #keyPath(WKWebView.cameraCaptureState) {
-                        channelDelegate?.onCameraCaptureStateChanged(oldState: oldState, newState: newState)
+                        channelDelegate?.onCameraCaptureStateChanged(
+                            oldState: oldState, newState: newState)
                     } else {
-                        channelDelegate?.onMicrophoneCaptureStateChanged(oldState: oldState, newState: newState)
+                        channelDelegate?.onMicrophoneCaptureStateChanged(
+                            oldState: oldState, newState: newState)
                     }
                 }
             }
         } else if #available(iOS 16.0, *) {
             // TODO: Still not working on iOS 16.0!
-//            if keyPath == #keyPath(WKWebView.fullscreenState) {
-//                if fullscreenState == .enteringFullscreen {
-//                    channelDelegate?.onEnterFullscreen()
-//                } else if fullscreenState == .exitingFullscreen {
-//                    channelDelegate?.onExitFullscreen()
-//                }
-//            }
+            //            if keyPath == #keyPath(WKWebView.fullscreenState) {
+            //                if fullscreenState == .enteringFullscreen {
+            //                    channelDelegate?.onEnterFullscreen()
+            //                } else if fullscreenState == .exitingFullscreen {
+            //                    channelDelegate?.onExitFullscreen()
+            //                }
+            //            }
         }
         replaceGestureHandlerIfNeeded()
     }
@@ -779,13 +891,16 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     public func initializeWindowIdJS() {
         if let windowId = windowId {
             if #available(iOS 14.0, *) {
-                let contentWorlds = configuration.userContentController.getContentWorlds(with: windowId)
+                let contentWorlds = configuration.userContentController.getContentWorlds(
+                    with: windowId)
                 for contentWorld in contentWorlds {
-                    let source = WINDOW_ID_INITIALIZE_JS_SOURCE.replacingOccurrences(of: PluginScriptsUtil.VAR_PLACEHOLDER_VALUE, with: String(windowId))
+                    let source = WINDOW_ID_INITIALIZE_JS_SOURCE.replacingOccurrences(
+                        of: PluginScriptsUtil.VAR_PLACEHOLDER_VALUE, with: String(windowId))
                     evaluateJavascript(source: source, contentWorld: contentWorld)
                 }
             } else {
-                let source = WINDOW_ID_INITIALIZE_JS_SOURCE.replacingOccurrences(of: PluginScriptsUtil.VAR_PLACEHOLDER_VALUE, with: String(windowId))
+                let source = WINDOW_ID_INITIALIZE_JS_SOURCE.replacingOccurrences(
+                    of: PluginScriptsUtil.VAR_PLACEHOLDER_VALUE, with: String(windowId))
                 evaluateJavascript(source: source)
             }
         }
@@ -793,11 +908,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
     public func goBackOrForward(steps: Int) {
         if canGoBackOrForward(steps: steps) {
-            if (steps > 0) {
+            if steps > 0 {
                 let index = steps - 1
                 go(to: self.backForwardList.forwardList[index])
-            }
-            else if (steps < 0){
+            } else if steps < 0 {
                 let backListLength = self.backForwardList.backList.count
                 let index = backListLength + steps
                 go(to: self.backForwardList.backList[index])
@@ -812,7 +926,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             : currentIndex + steps >= 0
     }
 
-    public func takeScreenshot (with: [String: Any?]?, completionHandler: @escaping (_ screenshot: Data?) -> Void) {
+    public func takeScreenshot(
+        with: [String: Any?]?, completionHandler: @escaping (_ screenshot: Data?) -> Void
+    ) {
         var snapshotConfiguration: WKSnapshotConfiguration? = nil
         if let with = with {
             snapshotConfiguration = WKSnapshotConfiguration()
@@ -826,31 +942,34 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 snapshotConfiguration!.afterScreenUpdates = afterScreenUpdates
             }
         }
-        takeSnapshot(with: snapshotConfiguration, completionHandler: {(image, error) -> Void in
-            var imageData: Data? = nil
-            if let screenshot = image {
-                if let with = with {
-                    switch with["compressFormat"] as! String {
-                    case "JPEG":
-                        let quality = Float(with["quality"] as! Int) / 100
-                        imageData = screenshot.jpegData(compressionQuality: CGFloat(quality))
-                        break
-                    case "PNG":
-                        imageData = screenshot.pngData()
-                        break
-                    default:
+        takeSnapshot(
+            with: snapshotConfiguration,
+            completionHandler: { (image, error) -> Void in
+                var imageData: Data? = nil
+                if let screenshot = image {
+                    if let with = with {
+                        switch with["compressFormat"] as! String {
+                        case "JPEG":
+                            let quality = Float(with["quality"] as! Int) / 100
+                            imageData = screenshot.jpegData(compressionQuality: CGFloat(quality))
+                            break
+                        case "PNG":
+                            imageData = screenshot.pngData()
+                            break
+                        default:
+                            imageData = screenshot.pngData()
+                        }
+                    } else {
                         imageData = screenshot.pngData()
                     }
                 }
-                else {
-                    imageData = screenshot.pngData()
-                }
-            }
-            completionHandler(imageData)
-        })
+                completionHandler(imageData)
+            })
     }
 
-    public func createPdf (configuration: [String: Any?]?, completionHandler: @escaping (_ pdf: Data?) -> Void) {
+    public func createPdf(
+        configuration: [String: Any?]?, completionHandler: @escaping (_ pdf: Data?) -> Void
+    ) {
         let pdfConfiguration: WKPDFConfiguration = .init()
         if let configuration = configuration {
             if let rect = configuration["rect"] as? [String: Double] {
@@ -858,7 +977,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
         }
         createPDF(configuration: pdfConfiguration) { (result) in
-            switch (result) {
+            switch result {
             case .success(let data):
                 completionHandler(data)
                 return
@@ -870,9 +989,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func createWebArchiveData (dataCompletionHandler: @escaping (_ webArchiveData: Data?) -> Void) {
+    public func createWebArchiveData(
+        dataCompletionHandler: @escaping (_ webArchiveData: Data?) -> Void
+    ) {
         createWebArchiveData(completionHandler: { (result) in
-            switch (result) {
+            switch result {
             case .success(let data):
                 dataCompletionHandler(data)
                 return
@@ -884,7 +1005,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         })
     }
 
-    public func saveWebArchive (filePath: String, autoname: Bool, completionHandler: @escaping (_ path: String?) -> Void) {
+    public func saveWebArchive(
+        filePath: String, autoname: Bool, completionHandler: @escaping (_ path: String?) -> Void
+    ) {
         createWebArchiveData(dataCompletionHandler: { (webArchiveData) in
             if let webArchiveData = webArchiveData {
                 var localUrl = URL(fileURLWithPath: filePath)
@@ -892,9 +1015,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     if let url = self.url {
                         // tries to mimic Android saveWebArchive method
                         let invalidCharacters = CharacterSet(charactersIn: "\\/:*?\"<>|")
-                                    .union(.newlines)
-                                    .union(.illegalCharacters)
-                                    .union(.controlCharacters)
+                            .union(.newlines)
+                            .union(.illegalCharacters)
+                            .union(.controlCharacters)
 
                         let currentPageUrlFileName = url.path
                             .components(separatedBy: invalidCharacters)
@@ -924,7 +1047,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     public func loadUrl(urlRequest: URLRequest, allowingReadAccessTo: URL?) {
         let url = urlRequest.url!
 
-        if #available(iOS 9.0, *), let allowingReadAccessTo = allowingReadAccessTo, url.scheme == "file", allowingReadAccessTo.scheme == "file" {
+        if #available(iOS 9.0, *), let allowingReadAccessTo = allowingReadAccessTo,
+            url.scheme == "file", allowingReadAccessTo.scheme == "file"
+        {
             loadFileURL(url, allowingReadAccessTo: allowingReadAccessTo)
         } else {
             load(urlRequest)
@@ -940,13 +1065,19 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         load(request)
     }
 
-    public func loadData(data: String, mimeType: String, encoding: String, baseUrl: URL, allowingReadAccessTo: URL?) {
-        if #available(iOS 9.0, *), let allowingReadAccessTo = allowingReadAccessTo, baseUrl.scheme == "file", allowingReadAccessTo.scheme == "file" {
+    public func loadData(
+        data: String, mimeType: String, encoding: String, baseUrl: URL, allowingReadAccessTo: URL?
+    ) {
+        if #available(iOS 9.0, *), let allowingReadAccessTo = allowingReadAccessTo,
+            baseUrl.scheme == "file", allowingReadAccessTo.scheme == "file"
+        {
             loadFileURL(baseUrl, allowingReadAccessTo: allowingReadAccessTo)
         }
 
         if #available(iOS 9.0, *) {
-            load(data.data(using: .utf8)!, mimeType: mimeType, characterEncodingName: encoding, baseURL: baseUrl)
+            load(
+                data.data(using: .utf8)!, mimeType: mimeType, characterEncodingName: encoding,
+                baseURL: baseUrl)
         } else {
             loadHTMLString(data, baseURL: baseUrl)
         }
@@ -964,7 +1095,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
         // MUST be the first! In this way, all the settings that uses evaluateJavaScript can be applied/blocked!
         if #available(iOS 13.0, *) {
-            if newSettingsMap["applePayAPIEnabled"] != nil && settings?.applePayAPIEnabled != newSettings.applePayAPIEnabled {
+            if newSettingsMap["applePayAPIEnabled"] != nil
+                && settings?.applePayAPIEnabled != newSettings.applePayAPIEnabled
+            {
                 if let settings = settings {
                     settings.applePayAPIEnabled = newSettings.applePayAPIEnabled
                 }
@@ -977,7 +1110,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
         }
 
-        if newSettingsMap["transparentBackground"] != nil && settings?.transparentBackground != newSettings.transparentBackground {
+        if newSettingsMap["transparentBackground"] != nil
+            && settings?.transparentBackground != newSettings.transparentBackground
+        {
             if newSettings.transparentBackground {
                 isOpaque = false
                 backgroundColor = UIColor.clear
@@ -989,11 +1124,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
         }
 
-        if newSettingsMap["disallowOverScroll"] != nil && settings?.disallowOverScroll != newSettings.disallowOverScroll {
+        if newSettingsMap["disallowOverScroll"] != nil
+            && settings?.disallowOverScroll != newSettings.disallowOverScroll
+        {
             if responds(to: #selector(getter: scrollView)) {
                 scrollView.bounces = !newSettings.disallowOverScroll
-            }
-            else {
+            } else {
                 for subview: UIView in subviews {
                     if subview is UIScrollView {
                         (subview as! UIScrollView).bounces = !newSettings.disallowOverScroll
@@ -1003,52 +1139,77 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if #available(iOS 9.0, *) {
-            if (newSettingsMap["incognito"] != nil && settings?.incognito != newSettings.incognito && newSettings.incognito) {
+            if newSettingsMap["incognito"] != nil && settings?.incognito != newSettings.incognito
+                && newSettings.incognito
+            {
                 configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
-            } else if (newSettingsMap["cacheEnabled"] != nil && settings?.cacheEnabled != newSettings.cacheEnabled && newSettings.cacheEnabled) {
+            } else if newSettingsMap["cacheEnabled"] != nil
+                && settings?.cacheEnabled != newSettings.cacheEnabled && newSettings.cacheEnabled
+            {
                 configuration.websiteDataStore = WKWebsiteDataStore.default()
             }
         }
 
         if #available(iOS 11.0, *) {
-            if (newSettingsMap["sharedCookiesEnabled"] != nil && settings?.sharedCookiesEnabled != newSettings.sharedCookiesEnabled && newSettings.sharedCookiesEnabled) {
-                if(!newSettings.incognito && !newSettings.cacheEnabled) {
+            if newSettingsMap["sharedCookiesEnabled"] != nil
+                && settings?.sharedCookiesEnabled != newSettings.sharedCookiesEnabled
+                && newSettings.sharedCookiesEnabled
+            {
+                if !newSettings.incognito && !newSettings.cacheEnabled {
                     configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                 }
                 for cookie in HTTPCookieStorage.shared.cookies ?? [] {
-                    configuration.websiteDataStore.httpCookieStore.setCookie(cookie, completionHandler: nil)
+                    configuration.websiteDataStore.httpCookieStore.setCookie(
+                        cookie, completionHandler: nil)
                 }
             }
-            if newSettingsMap["accessibilityIgnoresInvertColors"] != nil && settings?.accessibilityIgnoresInvertColors != newSettings.accessibilityIgnoresInvertColors {
+            if newSettingsMap["accessibilityIgnoresInvertColors"] != nil
+                && settings?.accessibilityIgnoresInvertColors
+                    != newSettings.accessibilityIgnoresInvertColors
+            {
                 accessibilityIgnoresInvertColors = newSettings.accessibilityIgnoresInvertColors
             }
-            if newSettingsMap["contentInsetAdjustmentBehavior"] != nil && settings?.contentInsetAdjustmentBehavior != newSettings.contentInsetAdjustmentBehavior {
+            if newSettingsMap["contentInsetAdjustmentBehavior"] != nil
+                && settings?.contentInsetAdjustmentBehavior
+                    != newSettings.contentInsetAdjustmentBehavior
+            {
                 scrollView.contentInsetAdjustmentBehavior =
-                    UIScrollView.ContentInsetAdjustmentBehavior.init(rawValue: newSettings.contentInsetAdjustmentBehavior)!
+                    UIScrollView.ContentInsetAdjustmentBehavior.init(
+                        rawValue: newSettings.contentInsetAdjustmentBehavior)!
             }
         }
 
-        if newSettingsMap["enableViewportScale"] != nil && settings?.enableViewportScale != newSettings.enableViewportScale {
+        if newSettingsMap["enableViewportScale"] != nil
+            && settings?.enableViewportScale != newSettings.enableViewportScale
+        {
             if !newSettings.enableViewportScale {
-                if configuration.userContentController.userScripts.contains(ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT) {
-                    configuration.userContentController.removePluginScript(ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
+                if configuration.userContentController.userScripts.contains(
+                    ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
+                {
+                    configuration.userContentController.removePluginScript(
+                        ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
                     evaluateJavaScript(NOT_ENABLE_VIEWPORT_SCALE_JS_SOURCE)
                 }
             } else {
                 evaluateJavaScript(ENABLE_VIEWPORT_SCALE_JS_SOURCE)
-                configuration.userContentController.addUserScript(ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
+                configuration.userContentController.addUserScript(
+                    ENABLE_VIEWPORT_SCALE_JS_PLUGIN_SCRIPT)
             }
         }
 
-        if newSettingsMap["supportZoom"] != nil && settings?.supportZoom != newSettings.supportZoom {
+        if newSettingsMap["supportZoom"] != nil && settings?.supportZoom != newSettings.supportZoom
+        {
             // Update native scroll view zoom support
             scrollView.isMultipleTouchEnabled = newSettings.supportZoom
             scrollView.bouncesZoom = newSettings.supportZoom
 
             // Update JavaScript-based zoom control
             if newSettings.supportZoom {
-                if configuration.userContentController.userScripts.contains(NOT_SUPPORT_ZOOM_JS_PLUGIN_SCRIPT) {
-                    configuration.userContentController.removePluginScript(NOT_SUPPORT_ZOOM_JS_PLUGIN_SCRIPT)
+                if configuration.userContentController.userScripts.contains(
+                    NOT_SUPPORT_ZOOM_JS_PLUGIN_SCRIPT)
+                {
+                    configuration.userContentController.removePluginScript(
+                        NOT_SUPPORT_ZOOM_JS_PLUGIN_SCRIPT)
                     evaluateJavaScript(SUPPORT_ZOOM_JS_SOURCE)
                 }
             } else {
@@ -1057,176 +1218,281 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
         }
 
-        if newSettingsMap["useOnLoadResource"] != nil && settings?.useOnLoadResource != newSettings.useOnLoadResource {
+        if newSettingsMap["useOnLoadResource"] != nil
+            && settings?.useOnLoadResource != newSettings.useOnLoadResource
+        {
             if let applePayAPIEnabled = settings?.applePayAPIEnabled, !applePayAPIEnabled {
-                enablePluginScriptAtRuntime(flagVariable: FLAG_VARIABLE_FOR_ON_LOAD_RESOURCE_JS_SOURCE,
-                                            enable: newSettings.useOnLoadResource,
-                                            pluginScript: ON_LOAD_RESOURCE_JS_PLUGIN_SCRIPT)
+                enablePluginScriptAtRuntime(
+                    flagVariable: FLAG_VARIABLE_FOR_ON_LOAD_RESOURCE_JS_SOURCE,
+                    enable: newSettings.useOnLoadResource,
+                    pluginScript: ON_LOAD_RESOURCE_JS_PLUGIN_SCRIPT)
             } else {
                 newSettings.useOnLoadResource = false
             }
         }
 
-        if newSettingsMap["useShouldInterceptAjaxRequest"] != nil && settings?.useShouldInterceptAjaxRequest != newSettings.useShouldInterceptAjaxRequest {
+        if newSettingsMap["useShouldInterceptAjaxRequest"] != nil
+            && settings?.useShouldInterceptAjaxRequest != newSettings.useShouldInterceptAjaxRequest
+        {
             if let applePayAPIEnabled = settings?.applePayAPIEnabled, !applePayAPIEnabled {
-                enablePluginScriptAtRuntime(flagVariable: FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE,
-                                            enable: newSettings.useShouldInterceptAjaxRequest,
-                                            pluginScript: INTERCEPT_AJAX_REQUEST_JS_PLUGIN_SCRIPT)
+                enablePluginScriptAtRuntime(
+                    flagVariable: FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_AJAX_REQUEST_JS_SOURCE,
+                    enable: newSettings.useShouldInterceptAjaxRequest,
+                    pluginScript: INTERCEPT_AJAX_REQUEST_JS_PLUGIN_SCRIPT)
             } else {
                 newSettings.useShouldInterceptAjaxRequest = false
             }
         }
 
-        if newSettingsMap["interceptOnlyAsyncAjaxRequests"] != nil && settings?.interceptOnlyAsyncAjaxRequests != newSettings.interceptOnlyAsyncAjaxRequests {
+        if newSettingsMap["interceptOnlyAsyncAjaxRequests"] != nil
+            && settings?.interceptOnlyAsyncAjaxRequests
+                != newSettings.interceptOnlyAsyncAjaxRequests
+        {
             if let applePayAPIEnabled = settings?.applePayAPIEnabled, !applePayAPIEnabled,
-               let interceptOnlyAsyncAjaxRequestsPluginScript = interceptOnlyAsyncAjaxRequestsPluginScript {
-                enablePluginScriptAtRuntime(flagVariable: FLAG_VARIABLE_FOR_INTERCEPT_ONLY_ASYNC_AJAX_REQUESTS_JS_SOURCE,
-                                            enable: newSettings.interceptOnlyAsyncAjaxRequests,
-                                            pluginScript: interceptOnlyAsyncAjaxRequestsPluginScript)
+                let interceptOnlyAsyncAjaxRequestsPluginScript =
+                    interceptOnlyAsyncAjaxRequestsPluginScript
+            {
+                enablePluginScriptAtRuntime(
+                    flagVariable: FLAG_VARIABLE_FOR_INTERCEPT_ONLY_ASYNC_AJAX_REQUESTS_JS_SOURCE,
+                    enable: newSettings.interceptOnlyAsyncAjaxRequests,
+                    pluginScript: interceptOnlyAsyncAjaxRequestsPluginScript)
             }
         }
 
-        if newSettingsMap["useShouldInterceptFetchRequest"] != nil && settings?.useShouldInterceptFetchRequest != newSettings.useShouldInterceptFetchRequest {
+        if newSettingsMap["useShouldInterceptFetchRequest"] != nil
+            && settings?.useShouldInterceptFetchRequest
+                != newSettings.useShouldInterceptFetchRequest
+        {
             if let applePayAPIEnabled = settings?.applePayAPIEnabled, !applePayAPIEnabled {
-                enablePluginScriptAtRuntime(flagVariable: FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_FETCH_REQUEST_JS_SOURCE,
-                                            enable: newSettings.useShouldInterceptFetchRequest,
-                                            pluginScript: INTERCEPT_FETCH_REQUEST_JS_PLUGIN_SCRIPT)
+                enablePluginScriptAtRuntime(
+                    flagVariable: FLAG_VARIABLE_FOR_SHOULD_INTERCEPT_FETCH_REQUEST_JS_SOURCE,
+                    enable: newSettings.useShouldInterceptFetchRequest,
+                    pluginScript: INTERCEPT_FETCH_REQUEST_JS_PLUGIN_SCRIPT)
             } else {
                 newSettings.useShouldInterceptFetchRequest = false
             }
         }
 
-        if newSettingsMap["mediaPlaybackRequiresUserGesture"] != nil && settings?.mediaPlaybackRequiresUserGesture != newSettings.mediaPlaybackRequiresUserGesture {
+        if newSettingsMap["mediaPlaybackRequiresUserGesture"] != nil
+            && settings?.mediaPlaybackRequiresUserGesture
+                != newSettings.mediaPlaybackRequiresUserGesture
+        {
             if #available(iOS 10.0, *) {
-                configuration.mediaTypesRequiringUserActionForPlayback = (newSettings.mediaPlaybackRequiresUserGesture) ? .all : []
+                configuration.mediaTypesRequiringUserActionForPlayback =
+                    (newSettings.mediaPlaybackRequiresUserGesture) ? .all : []
             } else {
                 // Fallback on earlier versions
-                configuration.mediaPlaybackRequiresUserAction = newSettings.mediaPlaybackRequiresUserGesture
+                configuration.mediaPlaybackRequiresUserAction =
+                    newSettings.mediaPlaybackRequiresUserGesture
             }
         }
 
-        if newSettingsMap["allowsInlineMediaPlayback"] != nil && settings?.allowsInlineMediaPlayback != newSettings.allowsInlineMediaPlayback {
+        if newSettingsMap["allowsInlineMediaPlayback"] != nil
+            && settings?.allowsInlineMediaPlayback != newSettings.allowsInlineMediaPlayback
+        {
             configuration.allowsInlineMediaPlayback = newSettings.allowsInlineMediaPlayback
         }
 
-        if newSettingsMap["suppressesIncrementalRendering"] != nil && settings?.suppressesIncrementalRendering != newSettings.suppressesIncrementalRendering {
-            configuration.suppressesIncrementalRendering = newSettings.suppressesIncrementalRendering
+        if newSettingsMap["suppressesIncrementalRendering"] != nil
+            && settings?.suppressesIncrementalRendering
+                != newSettings.suppressesIncrementalRendering
+        {
+            configuration.suppressesIncrementalRendering =
+                newSettings.suppressesIncrementalRendering
         }
 
-        if newSettingsMap["allowsBackForwardNavigationGestures"] != nil && settings?.allowsBackForwardNavigationGestures != newSettings.allowsBackForwardNavigationGestures {
+        if newSettingsMap["allowsBackForwardNavigationGestures"] != nil
+            && settings?.allowsBackForwardNavigationGestures
+                != newSettings.allowsBackForwardNavigationGestures
+        {
             allowsBackForwardNavigationGestures = newSettings.allowsBackForwardNavigationGestures
         }
 
-        if newSettingsMap["javaScriptCanOpenWindowsAutomatically"] != nil && settings?.javaScriptCanOpenWindowsAutomatically != newSettings.javaScriptCanOpenWindowsAutomatically {
-            configuration.preferences.javaScriptCanOpenWindowsAutomatically = newSettings.javaScriptCanOpenWindowsAutomatically
+        if newSettingsMap["javaScriptCanOpenWindowsAutomatically"] != nil
+            && settings?.javaScriptCanOpenWindowsAutomatically
+                != newSettings.javaScriptCanOpenWindowsAutomatically
+        {
+            configuration.preferences.javaScriptCanOpenWindowsAutomatically =
+                newSettings.javaScriptCanOpenWindowsAutomatically
         }
 
-        if newSettingsMap["minimumFontSize"] != nil && settings?.minimumFontSize != newSettings.minimumFontSize {
+        if newSettingsMap["minimumFontSize"] != nil
+            && settings?.minimumFontSize != newSettings.minimumFontSize
+        {
             configuration.preferences.minimumFontSize = CGFloat(newSettings.minimumFontSize)
         }
 
-        if newSettingsMap["selectionGranularity"] != nil && settings?.selectionGranularity != newSettings.selectionGranularity {
-            configuration.selectionGranularity = WKSelectionGranularity.init(rawValue: newSettings.selectionGranularity)!
+        if newSettingsMap["selectionGranularity"] != nil
+            && settings?.selectionGranularity != newSettings.selectionGranularity
+        {
+            configuration.selectionGranularity = WKSelectionGranularity.init(
+                rawValue: newSettings.selectionGranularity)!
         }
 
         if #available(iOS 10.0, *) {
-            if newSettingsMap["ignoresViewportScaleLimits"] != nil && settings?.ignoresViewportScaleLimits != newSettings.ignoresViewportScaleLimits {
+            if newSettingsMap["ignoresViewportScaleLimits"] != nil
+                && settings?.ignoresViewportScaleLimits != newSettings.ignoresViewportScaleLimits
+            {
                 configuration.ignoresViewportScaleLimits = newSettings.ignoresViewportScaleLimits
             }
 
-            if newSettingsMap["dataDetectorTypes"] != nil && settings?.dataDetectorTypes != newSettings.dataDetectorTypes {
+            if newSettingsMap["dataDetectorTypes"] != nil
+                && settings?.dataDetectorTypes != newSettings.dataDetectorTypes
+            {
                 var dataDetectorTypes = WKDataDetectorTypes.init(rawValue: 0)
                 for type in newSettings.dataDetectorTypes {
                     let dataDetectorType = Util.getDataDetectorType(type: type)
-                    dataDetectorTypes = WKDataDetectorTypes(rawValue: dataDetectorTypes.rawValue | dataDetectorType.rawValue)
+                    dataDetectorTypes = WKDataDetectorTypes(
+                        rawValue: dataDetectorTypes.rawValue | dataDetectorType.rawValue)
                 }
                 configuration.dataDetectorTypes = dataDetectorTypes
             }
         }
 
         if #available(iOS 13.0, *) {
-            if newSettingsMap["isFraudulentWebsiteWarningEnabled"] != nil && settings?.isFraudulentWebsiteWarningEnabled != newSettings.isFraudulentWebsiteWarningEnabled {
-                configuration.preferences.isFraudulentWebsiteWarningEnabled = newSettings.isFraudulentWebsiteWarningEnabled
+            if newSettingsMap["isFraudulentWebsiteWarningEnabled"] != nil
+                && settings?.isFraudulentWebsiteWarningEnabled
+                    != newSettings.isFraudulentWebsiteWarningEnabled
+            {
+                configuration.preferences.isFraudulentWebsiteWarningEnabled =
+                    newSettings.isFraudulentWebsiteWarningEnabled
             }
-            if newSettingsMap["preferredContentMode"] != nil && settings?.preferredContentMode != newSettings.preferredContentMode {
-                configuration.defaultWebpagePreferences.preferredContentMode = WKWebpagePreferences.ContentMode(rawValue: newSettings.preferredContentMode)!
+            if newSettingsMap["preferredContentMode"] != nil
+                && settings?.preferredContentMode != newSettings.preferredContentMode
+            {
+                configuration.defaultWebpagePreferences.preferredContentMode =
+                    WKWebpagePreferences.ContentMode(rawValue: newSettings.preferredContentMode)!
             }
-            if newSettingsMap["automaticallyAdjustsScrollIndicatorInsets"] != nil && settings?.automaticallyAdjustsScrollIndicatorInsets != newSettings.automaticallyAdjustsScrollIndicatorInsets {
-                scrollView.automaticallyAdjustsScrollIndicatorInsets = newSettings.automaticallyAdjustsScrollIndicatorInsets
+            if newSettingsMap["automaticallyAdjustsScrollIndicatorInsets"] != nil
+                && settings?.automaticallyAdjustsScrollIndicatorInsets
+                    != newSettings.automaticallyAdjustsScrollIndicatorInsets
+            {
+                scrollView.automaticallyAdjustsScrollIndicatorInsets =
+                    newSettings.automaticallyAdjustsScrollIndicatorInsets
             }
         }
 
-        if newSettingsMap["disableVerticalScroll"] != nil && settings?.disableVerticalScroll != newSettings.disableVerticalScroll {
+        if newSettingsMap["disableVerticalScroll"] != nil
+            && settings?.disableVerticalScroll != newSettings.disableVerticalScroll
+        {
             scrollView.showsVerticalScrollIndicator = !newSettings.disableVerticalScroll
         }
-        if newSettingsMap["disableHorizontalScroll"] != nil && settings?.disableHorizontalScroll != newSettings.disableHorizontalScroll {
+        if newSettingsMap["disableHorizontalScroll"] != nil
+            && settings?.disableHorizontalScroll != newSettings.disableHorizontalScroll
+        {
             scrollView.showsHorizontalScrollIndicator = !newSettings.disableHorizontalScroll
         }
 
-        if newSettingsMap["verticalScrollBarEnabled"] != nil && settings?.verticalScrollBarEnabled != newSettings.verticalScrollBarEnabled {
+        if newSettingsMap["verticalScrollBarEnabled"] != nil
+            && settings?.verticalScrollBarEnabled != newSettings.verticalScrollBarEnabled
+        {
             scrollView.showsVerticalScrollIndicator = newSettings.verticalScrollBarEnabled
         }
-        if newSettingsMap["horizontalScrollBarEnabled"] != nil && settings?.horizontalScrollBarEnabled != newSettings.horizontalScrollBarEnabled {
+        if newSettingsMap["horizontalScrollBarEnabled"] != nil
+            && settings?.horizontalScrollBarEnabled != newSettings.horizontalScrollBarEnabled
+        {
             scrollView.showsHorizontalScrollIndicator = newSettings.horizontalScrollBarEnabled
         }
 
-        if newSettingsMap["isDirectionalLockEnabled"] != nil && settings?.isDirectionalLockEnabled != newSettings.isDirectionalLockEnabled {
+        if newSettingsMap["isDirectionalLockEnabled"] != nil
+            && settings?.isDirectionalLockEnabled != newSettings.isDirectionalLockEnabled
+        {
             scrollView.isDirectionalLockEnabled = newSettings.isDirectionalLockEnabled
         }
 
-        if newSettingsMap["decelerationRate"] != nil && settings?.decelerationRate != newSettings.decelerationRate {
-            scrollView.decelerationRate = Util.getDecelerationRate(type: newSettings.decelerationRate)
+        if newSettingsMap["decelerationRate"] != nil
+            && settings?.decelerationRate != newSettings.decelerationRate
+        {
+            scrollView.decelerationRate = Util.getDecelerationRate(
+                type: newSettings.decelerationRate)
         }
-        if newSettingsMap["alwaysBounceVertical"] != nil && settings?.alwaysBounceVertical != newSettings.alwaysBounceVertical {
+        if newSettingsMap["alwaysBounceVertical"] != nil
+            && settings?.alwaysBounceVertical != newSettings.alwaysBounceVertical
+        {
             scrollView.alwaysBounceVertical = newSettings.alwaysBounceVertical
         }
-        if newSettingsMap["alwaysBounceHorizontal"] != nil && settings?.alwaysBounceHorizontal != newSettings.alwaysBounceHorizontal {
+        if newSettingsMap["alwaysBounceHorizontal"] != nil
+            && settings?.alwaysBounceHorizontal != newSettings.alwaysBounceHorizontal
+        {
             scrollView.alwaysBounceHorizontal = newSettings.alwaysBounceHorizontal
         }
-        if newSettingsMap["scrollsToTop"] != nil && settings?.scrollsToTop != newSettings.scrollsToTop {
+        if newSettingsMap["scrollsToTop"] != nil
+            && settings?.scrollsToTop != newSettings.scrollsToTop
+        {
             scrollView.scrollsToTop = newSettings.scrollsToTop
         }
-        if newSettingsMap["isPagingEnabled"] != nil && settings?.isPagingEnabled != newSettings.isPagingEnabled {
+        if newSettingsMap["isPagingEnabled"] != nil
+            && settings?.isPagingEnabled != newSettings.isPagingEnabled
+        {
             scrollView.scrollsToTop = newSettings.isPagingEnabled
         }
-        if newSettingsMap["maximumZoomScale"] != nil && settings?.maximumZoomScale != newSettings.maximumZoomScale {
+        if newSettingsMap["maximumZoomScale"] != nil
+            && settings?.maximumZoomScale != newSettings.maximumZoomScale
+        {
             scrollView.maximumZoomScale = CGFloat(newSettings.maximumZoomScale)
         }
-        if newSettingsMap["minimumZoomScale"] != nil && settings?.minimumZoomScale != newSettings.minimumZoomScale {
+        if newSettingsMap["minimumZoomScale"] != nil
+            && settings?.minimumZoomScale != newSettings.minimumZoomScale
+        {
             scrollView.minimumZoomScale = CGFloat(newSettings.minimumZoomScale)
         }
 
         if #available(iOS 9.0, *) {
-            if newSettingsMap["allowsLinkPreview"] != nil && settings?.allowsLinkPreview != newSettings.allowsLinkPreview {
+            if newSettingsMap["allowsLinkPreview"] != nil
+                && settings?.allowsLinkPreview != newSettings.allowsLinkPreview
+            {
                 allowsLinkPreview = newSettings.allowsLinkPreview
             }
-            if newSettingsMap["allowsAirPlayForMediaPlayback"] != nil && settings?.allowsAirPlayForMediaPlayback != newSettings.allowsAirPlayForMediaPlayback {
-                configuration.allowsAirPlayForMediaPlayback = newSettings.allowsAirPlayForMediaPlayback
+            if newSettingsMap["allowsAirPlayForMediaPlayback"] != nil
+                && settings?.allowsAirPlayForMediaPlayback
+                    != newSettings.allowsAirPlayForMediaPlayback
+            {
+                configuration.allowsAirPlayForMediaPlayback =
+                    newSettings.allowsAirPlayForMediaPlayback
             }
-            if newSettingsMap["allowsPictureInPictureMediaPlayback"] != nil && settings?.allowsPictureInPictureMediaPlayback != newSettings.allowsPictureInPictureMediaPlayback {
-                configuration.allowsPictureInPictureMediaPlayback = newSettings.allowsPictureInPictureMediaPlayback
+            if newSettingsMap["allowsPictureInPictureMediaPlayback"] != nil
+                && settings?.allowsPictureInPictureMediaPlayback
+                    != newSettings.allowsPictureInPictureMediaPlayback
+            {
+                configuration.allowsPictureInPictureMediaPlayback =
+                    newSettings.allowsPictureInPictureMediaPlayback
             }
-            if newSettingsMap["applicationNameForUserAgent"] != nil && settings?.applicationNameForUserAgent != newSettings.applicationNameForUserAgent && newSettings.applicationNameForUserAgent != "" {
+            if newSettingsMap["applicationNameForUserAgent"] != nil
+                && settings?.applicationNameForUserAgent != newSettings.applicationNameForUserAgent
+                && newSettings.applicationNameForUserAgent != ""
+            {
                 configuration.applicationNameForUserAgent = newSettings.applicationNameForUserAgent
             }
-            if newSettingsMap["userAgent"] != nil && settings?.userAgent != newSettings.userAgent && newSettings.userAgent != "" {
+            if newSettingsMap["userAgent"] != nil && settings?.userAgent != newSettings.userAgent
+                && newSettings.userAgent != ""
+            {
                 customUserAgent = newSettings.userAgent
             }
         }
 
-        if newSettingsMap["allowUniversalAccessFromFileURLs"] != nil && settings?.allowUniversalAccessFromFileURLs != newSettings.allowUniversalAccessFromFileURLs {
-            configuration.setValue(newSettings.allowUniversalAccessFromFileURLs, forKey: "allowUniversalAccessFromFileURLs")
+        if newSettingsMap["allowUniversalAccessFromFileURLs"] != nil
+            && settings?.allowUniversalAccessFromFileURLs
+                != newSettings.allowUniversalAccessFromFileURLs
+        {
+            configuration.setValue(
+                newSettings.allowUniversalAccessFromFileURLs,
+                forKey: "allowUniversalAccessFromFileURLs")
         }
 
-        if newSettingsMap["allowFileAccessFromFileURLs"] != nil && settings?.allowFileAccessFromFileURLs != newSettings.allowFileAccessFromFileURLs {
-            configuration.preferences.setValue(newSettings.allowFileAccessFromFileURLs, forKey: "allowFileAccessFromFileURLs")
+        if newSettingsMap["allowFileAccessFromFileURLs"] != nil
+            && settings?.allowFileAccessFromFileURLs != newSettings.allowFileAccessFromFileURLs
+        {
+            configuration.preferences.setValue(
+                newSettings.allowFileAccessFromFileURLs, forKey: "allowFileAccessFromFileURLs")
         }
 
         if newSettingsMap["clearCache"] != nil && newSettings.clearCache {
             clearCache()
         }
 
-        if newSettingsMap["javaScriptEnabled"] != nil && settings?.javaScriptEnabled != newSettings.javaScriptEnabled {
+        if newSettingsMap["javaScriptEnabled"] != nil
+            && settings?.javaScriptEnabled != newSettings.javaScriptEnabled
+        {
             configuration.preferences.javaScriptEnabled = newSettings.javaScriptEnabled
         }
 
@@ -1239,12 +1505,19 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 pageZoom = CGFloat(newSettings.pageZoom)
             }
 
-            if newSettingsMap["limitsNavigationsToAppBoundDomains"] != nil && settings?.limitsNavigationsToAppBoundDomains != newSettings.limitsNavigationsToAppBoundDomains {
-                configuration.limitsNavigationsToAppBoundDomains = newSettings.limitsNavigationsToAppBoundDomains
+            if newSettingsMap["limitsNavigationsToAppBoundDomains"] != nil
+                && settings?.limitsNavigationsToAppBoundDomains
+                    != newSettings.limitsNavigationsToAppBoundDomains
+            {
+                configuration.limitsNavigationsToAppBoundDomains =
+                    newSettings.limitsNavigationsToAppBoundDomains
             }
 
-            if newSettingsMap["javaScriptEnabled"] != nil && settings?.javaScriptEnabled != newSettings.javaScriptEnabled {
-                configuration.defaultWebpagePreferences.allowsContentJavaScript = newSettings.javaScriptEnabled
+            if newSettingsMap["javaScriptEnabled"] != nil
+                && settings?.javaScriptEnabled != newSettings.javaScriptEnabled
+            {
+                configuration.defaultWebpagePreferences.allowsContentJavaScript =
+                    newSettings.javaScriptEnabled
             }
         }
 
@@ -1253,16 +1526,18 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             let contentBlockers = newSettings.contentBlockers
             if contentBlockers.count > 0 {
                 do {
-                    let jsonData = try JSONSerialization.data(withJSONObject: contentBlockers, options: [])
+                    let jsonData = try JSONSerialization.data(
+                        withJSONObject: contentBlockers, options: [])
                     let blockRules = String(data: jsonData, encoding: .utf8)
                     WKContentRuleListStore.default().compileContentRuleList(
                         forIdentifier: "ContentBlockingRules",
-                        encodedContentRuleList: blockRules) { (contentRuleList, error) in
-                            if let error = error {
-                                print(error.localizedDescription)
-                                return
-                            }
-                            self.configuration.userContentController.add(contentRuleList!)
+                        encodedContentRuleList: blockRules
+                    ) { (contentRuleList, error) in
+                        if let error = error {
+                            print(error.localizedDescription)
+                            return
+                        }
+                        self.configuration.userContentController.add(contentRuleList!)
                     }
                 } catch {
                     print(error.localizedDescription)
@@ -1271,77 +1546,110 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if #available(iOS 15.0, *) {
-            if newSettingsMap["upgradeKnownHostsToHTTPS"] != nil && settings?.upgradeKnownHostsToHTTPS != newSettings.upgradeKnownHostsToHTTPS {
+            if newSettingsMap["upgradeKnownHostsToHTTPS"] != nil
+                && settings?.upgradeKnownHostsToHTTPS != newSettings.upgradeKnownHostsToHTTPS
+            {
                 configuration.upgradeKnownHostsToHTTPS = newSettings.upgradeKnownHostsToHTTPS
             }
-            if newSettingsMap["isTextInteractionEnabled"] != nil && settings?.isTextInteractionEnabled != newSettings.isTextInteractionEnabled {
-                configuration.preferences.isTextInteractionEnabled = newSettings.isTextInteractionEnabled
+            if newSettingsMap["isTextInteractionEnabled"] != nil
+                && settings?.isTextInteractionEnabled != newSettings.isTextInteractionEnabled
+            {
+                configuration.preferences.isTextInteractionEnabled =
+                    newSettings.isTextInteractionEnabled
             }
-            if newSettingsMap["underPageBackgroundColor"] != nil, settings?.underPageBackgroundColor != newSettings.underPageBackgroundColor,
-               let underPageBackgroundColor = newSettings.underPageBackgroundColor, !underPageBackgroundColor.isEmpty {
+            if newSettingsMap["underPageBackgroundColor"] != nil,
+                settings?.underPageBackgroundColor != newSettings.underPageBackgroundColor,
+                let underPageBackgroundColor = newSettings.underPageBackgroundColor,
+                !underPageBackgroundColor.isEmpty
+            {
                 self.underPageBackgroundColor = UIColor(hexString: underPageBackgroundColor)
             }
         }
         if #available(iOS 15.4, *) {
-            if newSettingsMap["isSiteSpecificQuirksModeEnabled"] != nil, settings?.isSiteSpecificQuirksModeEnabled != newSettings.isSiteSpecificQuirksModeEnabled {
-                configuration.preferences.isSiteSpecificQuirksModeEnabled = newSettings.isSiteSpecificQuirksModeEnabled
+            if newSettingsMap["isSiteSpecificQuirksModeEnabled"] != nil,
+                settings?.isSiteSpecificQuirksModeEnabled
+                    != newSettings.isSiteSpecificQuirksModeEnabled
+            {
+                configuration.preferences.isSiteSpecificQuirksModeEnabled =
+                    newSettings.isSiteSpecificQuirksModeEnabled
             }
-            if newSettingsMap["isElementFullscreenEnabled"] != nil, settings?.isElementFullscreenEnabled != newSettings.isElementFullscreenEnabled {
-                configuration.preferences.isElementFullscreenEnabled = newSettings.isElementFullscreenEnabled
+            if newSettingsMap["isElementFullscreenEnabled"] != nil,
+                settings?.isElementFullscreenEnabled != newSettings.isElementFullscreenEnabled
+            {
+                configuration.preferences.isElementFullscreenEnabled =
+                    newSettings.isElementFullscreenEnabled
             }
         }
         if #available(iOS 15.5, *) {
-            if ((newSettingsMap["minimumViewportInset"] != nil && settings?.minimumViewportInset != newSettings.minimumViewportInset) ||
-               (newSettingsMap["maximumViewportInset"] != nil && settings?.maximumViewportInset != newSettings.maximumViewportInset)),
-               let minViewportInset = newSettings.minimumViewportInset, let maxViewportInset = newSettings.maximumViewportInset {
+            if (newSettingsMap["minimumViewportInset"] != nil
+                && settings?.minimumViewportInset != newSettings.minimumViewportInset)
+                || (newSettingsMap["maximumViewportInset"] != nil
+                    && settings?.maximumViewportInset != newSettings.maximumViewportInset),
+                let minViewportInset = newSettings.minimumViewportInset,
+                let maxViewportInset = newSettings.maximumViewportInset
+            {
                 setMinimumViewportInset(minViewportInset, maximumViewportInset: maxViewportInset)
             }
         }
         if #available(iOS 16.0, *) {
-            if newSettingsMap["isFindInteractionEnabled"] != nil, settings?.isFindInteractionEnabled != newSettings.isFindInteractionEnabled {
+            if newSettingsMap["isFindInteractionEnabled"] != nil,
+                settings?.isFindInteractionEnabled != newSettings.isFindInteractionEnabled
+            {
                 isFindInteractionEnabled = newSettings.isFindInteractionEnabled
             }
         }
         if #available(iOS 16.4, *) {
-            if newSettingsMap["isInspectable"] != nil, settings?.isInspectable != newSettings.isInspectable {
+            if newSettingsMap["isInspectable"] != nil,
+                settings?.isInspectable != newSettings.isInspectable
+            {
                 isInspectable = newSettings.isInspectable
             }
-            if newSettingsMap["shouldPrintBackgrounds"] != nil, settings?.shouldPrintBackgrounds != newSettings.shouldPrintBackgrounds {
-                configuration.preferences.shouldPrintBackgrounds = newSettings.shouldPrintBackgrounds
+            if newSettingsMap["shouldPrintBackgrounds"] != nil,
+                settings?.shouldPrintBackgrounds != newSettings.shouldPrintBackgrounds
+            {
+                configuration.preferences.shouldPrintBackgrounds =
+                    newSettings.shouldPrintBackgrounds
             }
         }
 
-        scrollView.isScrollEnabled = !(newSettings.disableVerticalScroll && newSettings.disableHorizontalScroll)
+        scrollView.isScrollEnabled =
+            !(newSettings.disableVerticalScroll && newSettings.disableHorizontalScroll)
 
         self.settings = newSettings
     }
 
     func getSettings() -> [String: Any?]? {
-        if (self.settings == nil) {
+        if self.settings == nil {
             return nil
         }
         return self.settings!.getRealSettings(obj: self)
     }
 
-    public func enablePluginScriptAtRuntime(flagVariable: String, enable: Bool, pluginScript: PluginScript) {
+    public func enablePluginScriptAtRuntime(
+        flagVariable: String, enable: Bool, pluginScript: PluginScript
+    ) {
         evaluateJavascript(source: flagVariable) { (alreadyLoaded) in
             if let alreadyLoaded = alreadyLoaded as? Bool, alreadyLoaded {
                 let enableSource = "\(flagVariable) = \(enable);"
                 if #available(iOS 14.0, *), pluginScript.requiredInAllContentWorlds {
                     for contentWorld in self.configuration.userContentController.contentWorlds {
-                        self.evaluateJavaScript(enableSource, frame: nil, contentWorld: contentWorld, completionHandler: nil)
+                        self.evaluateJavaScript(
+                            enableSource, frame: nil, contentWorld: contentWorld,
+                            completionHandler: nil)
                     }
                 } else {
                     self.evaluateJavaScript(enableSource, completionHandler: nil)
                 }
                 if !enable {
-                    self.configuration.userContentController.removePluginScripts(with: pluginScript.groupName!)
+                    self.configuration.userContentController.removePluginScripts(
+                        with: pluginScript.groupName!)
                 }
-            }
-            else if enable {
+            } else if enable {
                 if #available(iOS 14.0, *), pluginScript.requiredInAllContentWorlds {
                     for contentWorld in self.configuration.userContentController.contentWorlds {
-                        self.evaluateJavaScript(pluginScript.source, frame: nil, contentWorld: contentWorld, completionHandler: nil)
+                        self.evaluateJavaScript(
+                            pluginScript.source, frame: nil, contentWorld: contentWorld,
+                            completionHandler: nil)
                         self.configuration.userContentController.addPluginScript(pluginScript)
                     }
                 } else {
@@ -1357,9 +1665,14 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     public func clearCache() {
         if #available(iOS 9.0, *) {
             let date = NSDate(timeIntervalSince1970: 0)
-            WKWebsiteDataStore.default().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: date as Date, completionHandler:{ })
+            WKWebsiteDataStore.default().removeData(
+                ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: date as Date,
+                completionHandler: {})
         } else {
-            var libraryPath = NSSearchPathForDirectoriesInDomains(FileManager.SearchPathDirectory.libraryDirectory, FileManager.SearchPathDomainMask.userDomainMask, false).first!
+            var libraryPath = NSSearchPathForDirectoriesInDomains(
+                FileManager.SearchPathDirectory.libraryDirectory,
+                FileManager.SearchPathDomainMask.userDomainMask, false
+            ).first!
             libraryPath += "/Cookies"
 
             do {
@@ -1371,12 +1684,15 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func injectDeferredObject(source: String, withWrapper jsWrapper: String?, completionHandler: ((Any?) -> Void)? = nil) {
+    public func injectDeferredObject(
+        source: String, withWrapper jsWrapper: String?, completionHandler: ((Any?) -> Void)? = nil
+    ) {
         var jsToInject = source
         if let wrapper = jsWrapper {
             let jsonData: Data? = try? JSONSerialization.data(withJSONObject: [source], options: [])
             let sourceArrayString = String(data: jsonData!, encoding: .utf8)
-            let sourceString: String? = (sourceArrayString! as NSString).substring(with: NSRange(location: 1, length: (sourceArrayString?.count ?? 0) - 2))
+            let sourceString: String? = (sourceArrayString! as NSString).substring(
+                with: NSRange(location: 1, length: (sourceArrayString?.count ?? 0) - 2))
             jsToInject = String(format: wrapper, sourceString!)
         }
 
@@ -1387,10 +1703,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
             if let error = error {
                 let userInfo = (error as NSError).userInfo
-                let errorMessage = userInfo["WKJavaScriptExceptionMessage"] ??
-                                   userInfo["NSLocalizedDescription"] as? String ??
-                                   error.localizedDescription
-                self.channelDelegate?.onConsoleMessage(message: String(describing: errorMessage), messageLevel: 3)
+                let errorMessage =
+                    userInfo["WKJavaScriptExceptionMessage"] ?? userInfo["NSLocalizedDescription"]
+                    as? String ?? error.localizedDescription
+                self.channelDelegate?.onConsoleMessage(
+                    message: String(describing: errorMessage), messageLevel: 3)
             }
 
             if value == nil {
@@ -1402,32 +1719,38 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func injectDeferredObject(source: String, contentWorld: WKContentWorld, withWrapper jsWrapper: String?, completionHandler: ((Any?) -> Void)? = nil) {
+    public func injectDeferredObject(
+        source: String, contentWorld: WKContentWorld, withWrapper jsWrapper: String?,
+        completionHandler: ((Any?) -> Void)? = nil
+    ) {
         var jsToInject = source
         if let wrapper = jsWrapper {
             let jsonData: Data? = try? JSONSerialization.data(withJSONObject: [source], options: [])
             let sourceArrayString = String(data: jsonData!, encoding: .utf8)
-            let sourceString: String? = (sourceArrayString! as NSString).substring(with: NSRange(location: 1, length: (sourceArrayString?.count ?? 0) - 2))
+            let sourceString: String? = (sourceArrayString! as NSString).substring(
+                with: NSRange(location: 1, length: (sourceArrayString?.count ?? 0) - 2))
             jsToInject = String(format: wrapper, sourceString!)
         }
 
-        jsToInject = configuration.userContentController.generateCodeForScriptEvaluation(scriptMessageHandler: self, source: jsToInject, contentWorld: contentWorld)
+        jsToInject = configuration.userContentController.generateCodeForScriptEvaluation(
+            scriptMessageHandler: self, source: jsToInject, contentWorld: contentWorld)
 
         evaluateJavaScript(jsToInject, frame: nil, contentWorld: contentWorld) { (evalResult) in
             guard let completionHandler = completionHandler else {
                 return
             }
 
-            switch (evalResult) {
+            switch evalResult {
             case .success(let value):
                 completionHandler(value)
                 return
             case .failure(let error):
                 let userInfo = (error as NSError).userInfo
-                let errorMessage = userInfo["WKJavaScriptExceptionMessage"] ??
-                                   userInfo["NSLocalizedDescription"] as? String ??
-                                   error.localizedDescription
-                self.channelDelegate?.onConsoleMessage(message: String(describing: errorMessage), messageLevel: 3)
+                let errorMessage =
+                    userInfo["WKJavaScriptExceptionMessage"] ?? userInfo["NSLocalizedDescription"]
+                    as? String ?? error.localizedDescription
+                self.channelDelegate?.onConsoleMessage(
+                    message: String(describing: errorMessage), messageLevel: 3)
                 break
             }
 
@@ -1435,7 +1758,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public override func evaluateJavaScript(_ javaScriptString: String, completionHandler: (@MainActor @Sendable (Any?, (any Error)?) -> Void)? = nil) {
+    public override func evaluateJavaScript(
+        _ javaScriptString: String,
+        completionHandler: (@MainActor @Sendable (Any?, (any Error)?) -> Void)? = nil
+    ) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             completionHandler?(nil, nil)
             return
@@ -1443,51 +1769,71 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         super.evaluateJavaScript(javaScriptString, completionHandler: completionHandler)
     }
 
-    public func evaluateJavaScript(_ javaScript: String, frame: WKFrameInfo? = nil, contentWorld: WKContentWorld, completionHandler: ((Result<Any, Error>) -> Void)? = nil) {
+    public func evaluateJavaScript(
+        _ javaScript: String, frame: WKFrameInfo? = nil, contentWorld: WKContentWorld,
+        completionHandler: ((Result<Any, Error>) -> Void)? = nil
+    ) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             return
         }
-        super.evaluateJavaScript(javaScript, in: frame, in: contentWorld, completionHandler: completionHandler)
+        super.evaluateJavaScript(
+            javaScript, in: frame, in: contentWorld, completionHandler: completionHandler)
     }
 
     public func evaluateJavascript(source: String, completionHandler: ((Any?) -> Void)? = nil) {
         injectDeferredObject(source: source, withWrapper: nil, completionHandler: completionHandler)
     }
 
-    public func evaluateJavascript(source: String, contentWorld: WKContentWorld, completionHandler: ((Any?) -> Void)? = nil) {
-        injectDeferredObject(source: source, contentWorld: contentWorld, withWrapper: nil, completionHandler: completionHandler)
+    public func evaluateJavascript(
+        source: String, contentWorld: WKContentWorld, completionHandler: ((Any?) -> Void)? = nil
+    ) {
+        injectDeferredObject(
+            source: source, contentWorld: contentWorld, withWrapper: nil,
+            completionHandler: completionHandler)
     }
 
-    public func callAsyncJavaScript(_ functionBody: String, arguments: [String : Any] = [:], frame: WKFrameInfo? = nil, contentWorld: WKContentWorld, completionHandler: ((Result<Any, Error>) -> Void)? = nil) {
+    public func callAsyncJavaScript(
+        _ functionBody: String, arguments: [String: Any] = [:], frame: WKFrameInfo? = nil,
+        contentWorld: WKContentWorld, completionHandler: ((Result<Any, Error>) -> Void)? = nil
+    ) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             return
         }
-        super.callAsyncJavaScript(functionBody, arguments: arguments, in: frame, in: contentWorld, completionHandler: completionHandler)
+        super.callAsyncJavaScript(
+            functionBody, arguments: arguments, in: frame, in: contentWorld,
+            completionHandler: completionHandler)
     }
 
-    public func callAsyncJavaScript(functionBody: String, arguments: [String:Any], contentWorld: WKContentWorld, completionHandler: ((Any?) -> Void)? = nil) {
-        let jsToInject = configuration.userContentController.generateCodeForScriptEvaluation(scriptMessageHandler: self, source: functionBody, contentWorld: contentWorld)
+    public func callAsyncJavaScript(
+        functionBody: String, arguments: [String: Any], contentWorld: WKContentWorld,
+        completionHandler: ((Any?) -> Void)? = nil
+    ) {
+        let jsToInject = configuration.userContentController.generateCodeForScriptEvaluation(
+            scriptMessageHandler: self, source: functionBody, contentWorld: contentWorld)
 
-        callAsyncJavaScript(jsToInject, arguments: arguments, frame: nil, contentWorld: contentWorld) { (evalResult) in
+        callAsyncJavaScript(
+            jsToInject, arguments: arguments, frame: nil, contentWorld: contentWorld
+        ) { (evalResult) in
             guard let completionHandler = completionHandler else {
                 return
             }
 
             var body: [String: Any?] = [
                 "value": nil,
-                "error": nil
+                "error": nil,
             ]
 
-            switch (evalResult) {
+            switch evalResult {
             case .success(let value):
                 body["value"] = value
                 break
             case .failure(let error):
                 let userInfo = (error as NSError).userInfo
-                body["error"] = userInfo["WKJavaScriptExceptionMessage"] ??
-                                userInfo["NSLocalizedDescription"] as? String ??
-                                error.localizedDescription
-                self.channelDelegate?.onConsoleMessage(message: String(describing: body["error"]), messageLevel: 3)
+                body["error"] =
+                    userInfo["WKJavaScriptExceptionMessage"] ?? userInfo["NSLocalizedDescription"]
+                    as? String ?? error.localizedDescription
+                self.channelDelegate?.onConsoleMessage(
+                    message: String(describing: body["error"]), messageLevel: 3)
                 break
             }
 
@@ -1495,7 +1841,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func callAsyncJavaScript(functionBody: String, arguments: [String:Any], completionHandler: ((Any?) -> Void)? = nil) {
+    public func callAsyncJavaScript(
+        functionBody: String, arguments: [String: Any], completionHandler: ((Any?) -> Void)? = nil
+    ) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             completionHandler?(nil)
         }
@@ -1518,49 +1866,61 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         let functionArgumentNames = functionArgumentNamesList.joined(separator: ", ")
         let functionArgumentValues = functionArgumentValuesList.joined(separator: ", ")
 
-        jsToInject = CALL_ASYNC_JAVASCRIPT_BELOW_IOS_14_WRAPPER_JS
-            .replacingOccurrences(of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_NAMES, with: functionArgumentNames)
-            .replacingOccurrences(of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_VALUES, with: functionArgumentValues)
-            .replacingOccurrences(of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENTS_OBJ, with: Util.JSONStringify(value: arguments))
+        jsToInject =
+            CALL_ASYNC_JAVASCRIPT_BELOW_IOS_14_WRAPPER_JS
+            .replacingOccurrences(
+                of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_NAMES, with: functionArgumentNames
+            )
+            .replacingOccurrences(
+                of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENT_VALUES, with: functionArgumentValues
+            )
+            .replacingOccurrences(
+                of: PluginScriptsUtil.VAR_FUNCTION_ARGUMENTS_OBJ,
+                with: Util.JSONStringify(value: arguments)
+            )
             .replacingOccurrences(of: PluginScriptsUtil.VAR_FUNCTION_BODY, with: jsToInject)
             .replacingOccurrences(of: PluginScriptsUtil.VAR_RESULT_UUID, with: resultUuid)
 
         evaluateJavaScript(jsToInject) { (value, error) in
             if let error = error {
                 let userInfo = (error as NSError).userInfo
-                let errorMessage = userInfo["WKJavaScriptExceptionMessage"] ??
-                                   userInfo["NSLocalizedDescription"] as? String ??
-                                   error.localizedDescription
-                self.channelDelegate?.onConsoleMessage(message: String(describing: errorMessage), messageLevel: 3)
+                let errorMessage =
+                    userInfo["WKJavaScriptExceptionMessage"] ?? userInfo["NSLocalizedDescription"]
+                    as? String ?? error.localizedDescription
+                self.channelDelegate?.onConsoleMessage(
+                    message: String(describing: errorMessage), messageLevel: 3)
                 completionHandler?(nil)
                 self.callAsyncJavaScriptBelowIOS14Results.removeValue(forKey: resultUuid)
             }
         }
     }
 
-    public func injectJavascriptFileFromUrl(urlFile: String, scriptHtmlTagAttributes: [String:Any?]?) {
+    public func injectJavascriptFileFromUrl(
+        urlFile: String, scriptHtmlTagAttributes: [String: Any?]?
+    ) {
         var scriptAttributes = ""
         if let scriptHtmlTagAttributes = scriptHtmlTagAttributes {
             if let typeAttr = scriptHtmlTagAttributes["type"] as? String {
-                scriptAttributes += " script.type = '\(typeAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                scriptAttributes +=
+                    " script.type = '\(typeAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let idAttr = scriptHtmlTagAttributes["id"] as? String {
                 let scriptIdEscaped = idAttr.replacingOccurrences(of: "\'", with: "\\'")
                 scriptAttributes += " script.id = '\(scriptIdEscaped)'; "
                 scriptAttributes += """
-                script.onload = function() {
-                    if (window.\(JAVASCRIPT_BRIDGE_NAME) != null) {
-                        window.\(JAVASCRIPT_BRIDGE_NAME).callHandler('onInjectedScriptLoaded', '\(scriptIdEscaped)');
-                    }
-                };
-                """
+                    script.onload = function() {
+                        if (window.\(JAVASCRIPT_BRIDGE_NAME) != null) {
+                            window.\(JAVASCRIPT_BRIDGE_NAME).callHandler('onInjectedScriptLoaded', '\(scriptIdEscaped)');
+                        }
+                    };
+                    """
                 scriptAttributes += """
-                script.onerror = function() {
-                    if (window.\(JAVASCRIPT_BRIDGE_NAME) != null) {
-                        window.\(JAVASCRIPT_BRIDGE_NAME).callHandler('onInjectedScriptError', '\(scriptIdEscaped)');
-                    }
-                };
-                """
+                    script.onerror = function() {
+                        if (window.\(JAVASCRIPT_BRIDGE_NAME) != null) {
+                            window.\(JAVASCRIPT_BRIDGE_NAME).callHandler('onInjectedScriptError', '\(scriptIdEscaped)');
+                        }
+                    };
+                    """
             }
             if let asyncAttr = scriptHtmlTagAttributes["async"] as? Bool, asyncAttr {
                 scriptAttributes += " script.async = true; "
@@ -1569,48 +1929,59 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 scriptAttributes += " script.defer = true; "
             }
             if let crossOriginAttr = scriptHtmlTagAttributes["crossOrigin"] as? String {
-                scriptAttributes += " script.crossOrigin = '\(crossOriginAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                scriptAttributes +=
+                    " script.crossOrigin = '\(crossOriginAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let integrityAttr = scriptHtmlTagAttributes["integrity"] as? String {
-                scriptAttributes += " script.integrity = '\(integrityAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                scriptAttributes +=
+                    " script.integrity = '\(integrityAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let noModuleAttr = scriptHtmlTagAttributes["noModule"] as? Bool, noModuleAttr {
                 scriptAttributes += " script.noModule = true; "
             }
             if let nonceAttr = scriptHtmlTagAttributes["nonce"] as? String {
-                scriptAttributes += " script.nonce = '\(nonceAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                scriptAttributes +=
+                    " script.nonce = '\(nonceAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let referrerPolicyAttr = scriptHtmlTagAttributes["referrerPolicy"] as? String {
-                scriptAttributes += " script.referrerPolicy = '\(referrerPolicyAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                scriptAttributes +=
+                    " script.referrerPolicy = '\(referrerPolicyAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
         }
-        let jsWrapper = "(function(d) { var script = d.createElement('script'); \(scriptAttributes) script.src = %@; d.body.appendChild(script); })(document);"
+        let jsWrapper =
+            "(function(d) { var script = d.createElement('script'); \(scriptAttributes) script.src = %@; d.body.appendChild(script); })(document);"
         injectDeferredObject(source: urlFile, withWrapper: jsWrapper, completionHandler: nil)
     }
 
     public func injectCSSCode(source: String) {
-        let jsWrapper = "(function(d) { var style = d.createElement('style'); style.innerHTML = %@; d.head.appendChild(style); })(document);"
+        let jsWrapper =
+            "(function(d) { var style = d.createElement('style'); style.innerHTML = %@; d.head.appendChild(style); })(document);"
         injectDeferredObject(source: source, withWrapper: jsWrapper, completionHandler: nil)
     }
 
-    public func injectCSSFileFromUrl(urlFile: String, cssLinkHtmlTagAttributes: [String:Any?]?) {
+    public func injectCSSFileFromUrl(urlFile: String, cssLinkHtmlTagAttributes: [String: Any?]?) {
         var cssLinkAttributes = ""
         var alternateStylesheet = ""
         if let cssLinkHtmlTagAttributes = cssLinkHtmlTagAttributes {
             if let idAttr = cssLinkHtmlTagAttributes["id"] as? String {
-                cssLinkAttributes += " link.id = '\(idAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                cssLinkAttributes +=
+                    " link.id = '\(idAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let mediaAttr = cssLinkHtmlTagAttributes["media"] as? String {
-                cssLinkAttributes += " link.media = '\(mediaAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                cssLinkAttributes +=
+                    " link.media = '\(mediaAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let crossOriginAttr = cssLinkHtmlTagAttributes["crossOrigin"] as? String {
-                cssLinkAttributes += " link.crossOrigin = '\(crossOriginAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                cssLinkAttributes +=
+                    " link.crossOrigin = '\(crossOriginAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let integrityAttr = cssLinkHtmlTagAttributes["integrity"] as? String {
-                cssLinkAttributes += " link.integrity = '\(integrityAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                cssLinkAttributes +=
+                    " link.integrity = '\(integrityAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let referrerPolicyAttr = cssLinkHtmlTagAttributes["referrerPolicy"] as? String {
-                cssLinkAttributes += " link.referrerPolicy = '\(referrerPolicyAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                cssLinkAttributes +=
+                    " link.referrerPolicy = '\(referrerPolicyAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
             if let disabledAttr = cssLinkHtmlTagAttributes["disabled"] as? Bool, disabledAttr {
                 cssLinkAttributes += " link.disabled = true; "
@@ -1619,10 +1990,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 alternateStylesheet = "alternate "
             }
             if let titleAttr = cssLinkHtmlTagAttributes["title"] as? String {
-                cssLinkAttributes += " link.title = '\(titleAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
+                cssLinkAttributes +=
+                    " link.title = '\(titleAttr.replacingOccurrences(of: "\'", with: "\\'"))'; "
             }
         }
-        let jsWrapper = "(function(d) { var link = d.createElement('link'); link.rel='\(alternateStylesheet)stylesheet', link.type='text/css'; \(cssLinkAttributes) link.href = %@; d.head.appendChild(link); })(document);"
+        let jsWrapper =
+            "(function(d) { var link = d.createElement('link'); link.rel='\(alternateStylesheet)stylesheet', link.type='text/css'; \(cssLinkAttributes) link.href = %@; d.head.appendChild(link); })(document);"
         injectDeferredObject(source: urlFile, withWrapper: jsWrapper, completionHandler: nil)
     }
 
@@ -1649,17 +2022,21 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         result["list"] = history
         result["currentIndex"] = currentIndex
 
-        return result;
+        return result
     }
 
     @available(iOS 15.0, *)
-    public func webView(_ webView: WKWebView,
-                        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
-                        initiatedByFrame frame: WKFrameInfo,
-                        type: WKMediaCaptureType,
-                        decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        let origin = "\(origin.protocol)://\(origin.host)\(origin.port != 0 ? ":" + String(origin.port) : "")"
-        let permissionRequest = PermissionRequest(origin: origin, resources: [type.rawValue], frame: frame)
+    public func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        let origin =
+            "\(origin.protocol)://\(origin.host)\(origin.port != 0 ? ":" + String(origin.port) : "")"
+        let permissionRequest = PermissionRequest(
+            origin: origin, resources: [type.rawValue], frame: frame)
 
         var decisionHandlerCalled = false
         let callback = WebViewChannelDelegate.PermissionRequestCallback()
@@ -1667,14 +2044,14 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             if let action = response.action {
                 decisionHandlerCalled = true
                 switch action {
-                    case 1:
-                        decisionHandler(.grant)
-                        break
-                    case 2:
-                        decisionHandler(.prompt)
-                        break
-                    default:
-                        decisionHandler(.deny)
+                case 1:
+                    decisionHandler(.grant)
+                    break
+                case 2:
+                    decisionHandler(.prompt)
+                    break
+                default:
+                    decisionHandler(.deny)
                 }
                 return false
             }
@@ -1699,12 +2076,16 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     }
 
     @available(iOS 15.0, *)
-    public func webView(_ webView: WKWebView,
-                        requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
-                        initiatedByFrame frame: WKFrameInfo,
-                        decisionHandler: @escaping (WKPermissionDecision) -> Void) {
-        let origin = "\(origin.protocol)://\(origin.host)\(origin.port != 0 ? ":" + String(origin.port) : "")"
-        let permissionRequest = PermissionRequest(origin: origin, resources: ["deviceOrientationAndMotion"], frame: frame)
+    public func webView(
+        _ webView: WKWebView,
+        requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        let origin =
+            "\(origin.protocol)://\(origin.host)\(origin.port != 0 ? ":" + String(origin.port) : "")"
+        let permissionRequest = PermissionRequest(
+            origin: origin, resources: ["deviceOrientationAndMotion"], frame: frame)
 
         var decisionHandlerCalled = false
         let callback = WebViewChannelDelegate.PermissionRequestCallback()
@@ -1712,14 +2093,14 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             if let action = response.action {
                 decisionHandlerCalled = true
                 switch action {
-                    case 1:
-                        decisionHandler(.grant)
-                        break
-                    case 2:
-                        decisionHandler(.prompt)
-                        break
-                    default:
-                        decisionHandler(.deny)
+                case 1:
+                    decisionHandler(.grant)
+                    break
+                case 2:
+                    decisionHandler(.prompt)
+                    break
+                default:
+                    decisionHandler(.deny)
                 }
                 return false
             }
@@ -1743,24 +2124,34 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func webView(_ webView: WKWebView,
-                 decidePolicyFor navigationAction: WKNavigationAction,
-                 preferences: WKWebpagePreferences,
-                 decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void) {
-        self.webView(webView, decidePolicyFor: navigationAction, decisionHandler: {(navigationActionPolicy) -> Void in
-            decisionHandler(navigationActionPolicy, preferences)
-        })
+    public func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        preferences: WKWebpagePreferences,
+        decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
+    ) {
+        self.webView(
+            webView, decidePolicyFor: navigationAction,
+            decisionHandler: { (navigationActionPolicy) -> Void in
+                decisionHandler(navigationActionPolicy, preferences)
+            })
     }
 
-    public func download(_ download: WKDownload, decideDestinationUsing response: URLResponse, suggestedFilename: String, completionHandler: @escaping (URL?) -> Void) {
-        if let url = response.url, let useOnDownloadStart = settings?.useOnDownloadStart, useOnDownloadStart {
-            let downloadStartRequest = DownloadStartRequest(url: url.absoluteString,
-                                                            userAgent: nil,
-                                                            contentDisposition: nil,
-                                                            mimeType: response.mimeType,
-                                                            contentLength: response.expectedContentLength,
-                                                            suggestedFilename: suggestedFilename,
-                                                            textEncodingName: response.textEncodingName)
+    public func download(
+        _ download: WKDownload, decideDestinationUsing response: URLResponse,
+        suggestedFilename: String, completionHandler: @escaping (URL?) -> Void
+    ) {
+        if let url = response.url, let useOnDownloadStart = settings?.useOnDownloadStart,
+            useOnDownloadStart
+        {
+            let downloadStartRequest = DownloadStartRequest(
+                url: url.absoluteString,
+                userAgent: nil,
+                contentDisposition: nil,
+                mimeType: response.mimeType,
+                contentLength: response.expectedContentLength,
+                suggestedFilename: suggestedFilename,
+                textEncodingName: response.textEncodingName)
             channelDelegate?.onDownloadStartRequest(request: downloadStartRequest)
         }
         download.delegate = nil
@@ -1768,24 +2159,32 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         completionHandler(nil)
     }
 
-    public func webView(_ webView: WKWebView, navigationResponse: WKNavigationResponse, didBecome download: WKDownload) {
+    public func webView(
+        _ webView: WKWebView, navigationResponse: WKNavigationResponse,
+        didBecome download: WKDownload
+    ) {
         let response = navigationResponse.response
-        if let url = response.url, let useOnDownloadStart = settings?.useOnDownloadStart, useOnDownloadStart {
-            let downloadStartRequest = DownloadStartRequest(url: url.absoluteString,
-                                                            userAgent: nil,
-                                                            contentDisposition: nil,
-                                                            mimeType: response.mimeType,
-                                                            contentLength: response.expectedContentLength,
-                                                            suggestedFilename: response.suggestedFilename,
-                                                            textEncodingName: response.textEncodingName)
+        if let url = response.url, let useOnDownloadStart = settings?.useOnDownloadStart,
+            useOnDownloadStart
+        {
+            let downloadStartRequest = DownloadStartRequest(
+                url: url.absoluteString,
+                userAgent: nil,
+                contentDisposition: nil,
+                mimeType: response.mimeType,
+                contentLength: response.expectedContentLength,
+                suggestedFilename: response.suggestedFilename,
+                textEncodingName: response.textEncodingName)
             channelDelegate?.onDownloadStartRequest(request: downloadStartRequest)
         }
         download.delegate = nil
     }
 
-    public func webView(_ webView: WKWebView,
-                 decidePolicyFor navigationAction: WKNavigationAction,
-                 decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+    public func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
         var decisionHandlerCalled = false
         let callback = WebViewChannelDelegate.ShouldOverrideUrlLoadingCallback()
         callback.nonNullSuccess = { (response: WKNavigationActionPolicy) in
@@ -1805,8 +2204,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         let runCallback = {
-            if let useShouldOverrideUrlLoading = self.settings?.useShouldOverrideUrlLoading, useShouldOverrideUrlLoading, let channelDelegate = self.channelDelegate {
-                channelDelegate.shouldOverrideUrlLoading(navigationAction: navigationAction, callback: callback)
+            if let useShouldOverrideUrlLoading = self.settings?.useShouldOverrideUrlLoading,
+                useShouldOverrideUrlLoading, let channelDelegate = self.channelDelegate
+            {
+                channelDelegate.shouldOverrideUrlLoading(
+                    navigationAction: navigationAction, callback: callback)
             } else {
                 callback.defaultBehaviour(nil)
             }
@@ -1819,12 +2221,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func webView(_ webView: WKWebView,
-                 decidePolicyFor navigationResponse: WKNavigationResponse,
-                 decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
-        if let response = navigationResponse.response as? HTTPURLResponse, response.statusCode >= 400 {
+    public func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        if let response = navigationResponse.response as? HTTPURLResponse,
+            response.statusCode >= 400
+        {
             let request = WebResourceRequest.init(fromWKNavigationResponse: navigationResponse)
-            let errorResponse = WebResourceResponse.init(fromWKNavigationResponse: navigationResponse)
+            let errorResponse = WebResourceResponse.init(
+                fromWKNavigationResponse: navigationResponse)
             channelDelegate?.onReceivedHttpError(request: request, errorResponse: errorResponse)
         }
 
@@ -1850,27 +2257,31 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
 
             if let channelDelegate = channelDelegate {
-                channelDelegate.onNavigationResponse(navigationResponse: navigationResponse, callback: callback)
+                channelDelegate.onNavigationResponse(
+                    navigationResponse: navigationResponse, callback: callback)
             } else {
                 callback.defaultBehaviour(nil)
             }
         }
 
         if let useOnDownloadStart = settings?.useOnDownloadStart, useOnDownloadStart {
-            if #available(iOS 14.5, *), !navigationResponse.canShowMIMEType, useOnNavigationResponse == nil || !useOnNavigationResponse! {
+            if #available(iOS 14.5, *), !navigationResponse.canShowMIMEType,
+                useOnNavigationResponse == nil || !useOnNavigationResponse!
+            {
                 decisionHandler(.download)
                 return
             } else {
                 let mimeType = navigationResponse.response.mimeType
                 if let url = navigationResponse.response.url, navigationResponse.isForMainFrame {
                     if url.scheme != "file", mimeType != nil, !mimeType!.starts(with: "text/") {
-                        let downloadStartRequest = DownloadStartRequest(url: url.absoluteString,
-                                                                        userAgent: nil,
-                                                                        contentDisposition: nil,
-                                                                        mimeType: mimeType,
-                                                                        contentLength: navigationResponse.response.expectedContentLength,
-                                                                        suggestedFilename: navigationResponse.response.suggestedFilename,
-                                                                        textEncodingName: navigationResponse.response.textEncodingName)
+                        let downloadStartRequest = DownloadStartRequest(
+                            url: url.absoluteString,
+                            userAgent: nil,
+                            contentDisposition: nil,
+                            mimeType: mimeType,
+                            contentLength: navigationResponse.response.expectedContentLength,
+                            suggestedFilename: navigationResponse.response.suggestedFilename,
+                            textEncodingName: navigationResponse.response.textEncodingName)
                         channelDelegate?.onDownloadStartRequest(request: downloadStartRequest)
                         if useOnNavigationResponse == nil || !useOnNavigationResponse! {
                             decisionHandler(.cancel)
@@ -1886,7 +2297,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    public func webView(
+        _ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!
+    ) {
         currentOriginalUrl = url
         lastTouchPoint = nil
 
@@ -1912,7 +2325,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         // so, we call setNeedsLayout to redraw the layout
         let webViewFrameSize = frame.size
         let scrollViewSize = scrollView.contentSize
-        if (scrollViewSize.width < webViewFrameSize.width || scrollViewSize.height < webViewFrameSize.height) {
+        if scrollViewSize.width < webViewFrameSize.width
+            || scrollViewSize.height < webViewFrameSize.height
+        {
             setNeedsLayout()
         }
 
@@ -1921,18 +2336,23 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         inAppBrowserDelegate?.didFinishNavigation(url: url)
     }
 
-    public func webView(_ view: WKWebView,
-                 didFailProvisionalNavigation navigation: WKNavigation!,
-                 withError error: Error) {
+    public func webView(
+        _ view: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
         webView(view, didFail: navigation, withError: error)
     }
 
-    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    public func webView(
+        _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error
+    ) {
         InAppWebView.credentialsProposed = []
 
         var urlError: URL = url ?? URL(string: "about:blank")!
         var errorCode = -1
-        var errorDescription = "domain=\(error._domain), code=\(error._code), \(error.localizedDescription)"
+        var errorDescription =
+            "domain=\(error._domain), code=\(error._code), \(error.localizedDescription)"
 
         if let info = error as? URLError {
             if let failingURL = info.failingURL {
@@ -1940,13 +2360,13 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
             errorCode = info.code.rawValue
             errorDescription = info.localizedDescription
-        }
-        else if let info = error._userInfo as? [String: Any] {
+        } else if let info = error._userInfo as? [String: Any] {
             if let failingUrl = info[NSURLErrorFailingURLErrorKey] as? URL {
                 urlError = failingUrl
             }
             if let failingUrlString = info[NSURLErrorFailingURLStringErrorKey] as? String,
-               let failingUrl = URL(string: failingUrlString) {
+                let failingUrl = URL(string: failingUrlString)
+            {
                 urlError = failingUrl
             }
         }
@@ -1959,13 +2379,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         inAppBrowserDelegate?.didFailNavigation(url: url, error: error)
     }
 
-    public func webView(_ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+    public func webView(
+        _ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
         var completionHandlerCalled = false
-        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic ||
-            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodDefault ||
-            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest ||
-            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNegotiate ||
-            challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM {
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodDefault
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNegotiate
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM
+        {
             let host = challenge.protectionSpace.host
             let prot = challenge.protectionSpace.protocol
             let realm = challenge.protectionSpace.realm
@@ -1976,47 +2400,56 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 if let action = response.action {
                     completionHandlerCalled = true
                     switch action {
-                        case 0:
-                            InAppWebView.credentialsProposed = []
-                            // used .performDefaultHandling to maintain consistency with Android
-                            // because .cancelAuthenticationChallenge will call webView(_:didFail:withError:)
-                            completionHandler(.performDefaultHandling, nil)
-                            //completionHandler(.cancelAuthenticationChallenge, nil)
-                            break
-                        case 1:
-                            let username = response.username
-                            let password = response.password
-                            let permanentPersistence = response.permanentPersistence
-                            let persistence = (permanentPersistence) ? URLCredential.Persistence.permanent : URLCredential.Persistence.forSession
-                            let credential = URLCredential(user: username, password: password, persistence: persistence)
-                            completionHandler(.useCredential, credential)
-                            break
-                        case 2:
-                            if InAppWebView.credentialsProposed.count == 0 {
-                                for (protectionSpace, credentials) in CredentialDatabase.credentialStore.allCredentials {
-                                    if protectionSpace.host == host && protectionSpace.realm == realm &&
-                                    protectionSpace.protocol == prot && protectionSpace.port == port {
-                                        for credential in credentials {
-                                            InAppWebView.credentialsProposed.append(credential.value)
-                                        }
-                                        break
+                    case 0:
+                        InAppWebView.credentialsProposed = []
+                        // used .performDefaultHandling to maintain consistency with Android
+                        // because .cancelAuthenticationChallenge will call webView(_:didFail:withError:)
+                        completionHandler(.performDefaultHandling, nil)
+                        //completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    case 1:
+                        let username = response.username
+                        let password = response.password
+                        let permanentPersistence = response.permanentPersistence
+                        let persistence =
+                            (permanentPersistence)
+                            ? URLCredential.Persistence.permanent
+                            : URLCredential.Persistence.forSession
+                        let credential = URLCredential(
+                            user: username, password: password, persistence: persistence)
+                        completionHandler(.useCredential, credential)
+                        break
+                    case 2:
+                        if InAppWebView.credentialsProposed.count == 0 {
+                            for (protectionSpace, credentials) in CredentialDatabase.credentialStore
+                                .allCredentials
+                            {
+                                if protectionSpace.host == host && protectionSpace.realm == realm
+                                    && protectionSpace.protocol == prot
+                                    && protectionSpace.port == port
+                                {
+                                    for credential in credentials {
+                                        InAppWebView.credentialsProposed.append(credential.value)
                                     }
+                                    break
                                 }
                             }
-                            if InAppWebView.credentialsProposed.count == 0, let credential = challenge.proposedCredential {
-                                InAppWebView.credentialsProposed.append(credential)
-                            }
+                        }
+                        if InAppWebView.credentialsProposed.count == 0,
+                            let credential = challenge.proposedCredential
+                        {
+                            InAppWebView.credentialsProposed.append(credential)
+                        }
 
-                            if let credential = InAppWebView.credentialsProposed.popLast() {
-                                completionHandler(.useCredential, credential)
-                            }
-                            else {
-                                completionHandler(.performDefaultHandling, nil)
-                            }
-                            break
-                        default:
-                            InAppWebView.credentialsProposed = []
+                        if let credential = InAppWebView.credentialsProposed.popLast() {
+                            completionHandler(.useCredential, credential)
+                        } else {
                             completionHandler(.performDefaultHandling, nil)
+                        }
+                        break
+                    default:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.performDefaultHandling, nil)
                     }
                     return false
                 }
@@ -2035,7 +2468,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
             let runCallback = {
                 if let channelDelegate = self.channelDelegate {
-                    channelDelegate.onReceivedHttpAuthRequest(challenge: HttpAuthenticationChallenge(fromChallenge: challenge), callback: callback)
+                    channelDelegate.onReceivedHttpAuthRequest(
+                        challenge: HttpAuthenticationChallenge(fromChallenge: challenge),
+                        callback: callback)
                 } else {
                     callback.defaultBehaviour(nil)
                 }
@@ -2046,8 +2481,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             } else {
                 runCallback()
             }
-        }
-        else if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust {
+        } else if challenge.protectionSpace.authenticationMethod
+            == NSURLAuthenticationMethodServerTrust
+        {
             guard let serverTrust = challenge.protectionSpace.serverTrust else {
                 completionHandler(.performDefaultHandling, nil)
                 return
@@ -2059,7 +2495,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 DispatchQueue.global(qos: .background).async {
                     if let sslCertificate = challenge.protectionSpace.sslCertificate {
                         DispatchQueue.main.async {
-                            InAppWebView.sslCertificatesMap[challenge.protectionSpace.host] = sslCertificate
+                            InAppWebView.sslCertificatesMap[challenge.protectionSpace.host] =
+                                sslCertificate
                         }
                     }
                 }
@@ -2070,22 +2507,22 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 if let action = response.action {
                     completionHandlerCalled = true
                     switch action {
-                        case 0:
-                            InAppWebView.credentialsProposed = []
-                            completionHandler(.cancelAuthenticationChallenge, nil)
-                            break
-                        case 1:
-                            // workaround for https://github.com/arrrrny/zikzak_inappwebview/issues/1924
-                            DispatchQueue.global(qos: .background).async {
-                                let exceptions = SecTrustCopyExceptions(serverTrust)
-                                SecTrustSetExceptions(serverTrust, exceptions)
-                                let credential = URLCredential(trust: serverTrust)
-                                completionHandler(.useCredential, credential)
-                            }
-                            break
-                        default:
-                            InAppWebView.credentialsProposed = []
-                            completionHandler(.performDefaultHandling, nil)
+                    case 0:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    case 1:
+                        // workaround for https://github.com/arrrrny/zikzak_inappwebview/issues/1924
+                        DispatchQueue.global(qos: .background).async {
+                            let exceptions = SecTrustCopyExceptions(serverTrust)
+                            SecTrustSetExceptions(serverTrust, exceptions)
+                            let credential = URLCredential(trust: serverTrust)
+                            completionHandler(.useCredential, credential)
+                        }
+                        break
+                    default:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.performDefaultHandling, nil)
                     }
                     return false
                 }
@@ -2104,7 +2541,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
             let runCallback = {
                 if let channelDelegate = self.channelDelegate {
-                    channelDelegate.onReceivedServerTrustAuthRequest(challenge: ServerTrustChallenge(fromChallenge: challenge), callback: callback)
+                    channelDelegate.onReceivedServerTrustAuthRequest(
+                        challenge: ServerTrustChallenge(fromChallenge: challenge),
+                        callback: callback)
                 } else {
                     callback.defaultBehaviour(nil)
                 }
@@ -2115,44 +2554,48 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             } else {
                 runCallback()
             }
-        }
-        else if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate {
+        } else if challenge.protectionSpace.authenticationMethod
+            == NSURLAuthenticationMethodClientCertificate
+        {
             let callback = WebViewChannelDelegate.ReceivedClientCertRequestCallback()
             callback.nonNullSuccess = { (response: ClientCertResponse) in
                 if let action = response.action {
                     completionHandlerCalled = true
                     switch action {
-                        case 0:
-                            completionHandler(.cancelAuthenticationChallenge, nil)
-                            break
-                        case 1:
-                            let certificatePath = response.certificatePath
-                            let certificatePassword = response.certificatePassword ?? "";
+                    case 0:
+                        completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    case 1:
+                        let certificatePath = response.certificatePath
+                        let certificatePassword = response.certificatePassword ?? ""
 
-                            var path: String = certificatePath
-                            do {
-                                if let plugin = self.plugin {
-                                    path = try Util.getAbsPathAsset(plugin: plugin, assetFilePath: certificatePath)
-                                }
-                            } catch {}
-
-                            if let PKCS12Data = NSData(contentsOfFile: path),
-                               let identityAndTrust: IdentityAndTrust = self.extractIdentity(PKCS12Data: PKCS12Data, password: certificatePassword) {
-                                let urlCredential: URLCredential = URLCredential(
-                                    identity: identityAndTrust.identityRef,
-                                    certificates: identityAndTrust.certArray as? [AnyObject],
-                                    persistence: URLCredential.Persistence.forSession);
-                                completionHandler(.useCredential, urlCredential)
-                            } else {
-                                completionHandler(.performDefaultHandling, nil)
+                        var path: String = certificatePath
+                        do {
+                            if let plugin = self.plugin {
+                                path = try Util.getAbsPathAsset(
+                                    plugin: plugin, assetFilePath: certificatePath)
                             }
+                        } catch {}
 
-                            break
-                        case 2:
-                            completionHandler(.cancelAuthenticationChallenge, nil)
-                            break
-                        default:
+                        if let PKCS12Data = NSData(contentsOfFile: path),
+                            let identityAndTrust: IdentityAndTrust = self.extractIdentity(
+                                PKCS12Data: PKCS12Data, password: certificatePassword)
+                        {
+                            let urlCredential: URLCredential = URLCredential(
+                                identity: identityAndTrust.identityRef,
+                                certificates: identityAndTrust.certArray as? [AnyObject],
+                                persistence: URLCredential.Persistence.forSession)
+                            completionHandler(.useCredential, urlCredential)
+                        } else {
                             completionHandler(.performDefaultHandling, nil)
+                        }
+
+                        break
+                    case 2:
+                        completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    default:
+                        completionHandler(.performDefaultHandling, nil)
                     }
                     return false
                 }
@@ -2171,7 +2614,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
             let runCallback = {
                 if let channelDelegate = self.channelDelegate {
-                    channelDelegate.onReceivedClientCertRequest(challenge: ClientCertChallenge(fromChallenge: challenge), callback: callback)
+                    channelDelegate.onReceivedClientCertRequest(
+                        challenge: ClientCertChallenge(fromChallenge: challenge), callback: callback
+                    )
                 } else {
                     callback.defaultBehaviour(nil)
                 }
@@ -2182,8 +2627,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             } else {
                 runCallback()
             }
-        }
-        else {
+        } else {
             completionHandler(.performDefaultHandling, nil)
         }
     }
@@ -2209,16 +2653,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             let certItems: CFArray = importResult! as CFArray
             let certItemsArray: Array = certItems as Array
             let dict: AnyObject? = certItemsArray.first
-            if let certEntry: Dictionary = dict as? Dictionary<String, AnyObject> {
+            if let certEntry: Dictionary = dict as? [String: AnyObject] {
                 // grab the identity
                 let identityPointer: AnyObject? = certEntry["identity"]
-                let secIdentityRef:SecIdentity = (identityPointer as! SecIdentity?)!
+                let secIdentityRef: SecIdentity = (identityPointer as! SecIdentity?)!
                 // grab the trust
                 let trustPointer: AnyObject? = certEntry["trust"]
-                let trustRef:SecTrust = trustPointer as! SecTrust
+                let trustRef: SecTrust = trustPointer as! SecTrust
                 // grab the cert
                 let chainPointer: AnyObject? = certEntry["chain"]
-                identityAndTrust = IdentityAndTrust(identityRef: secIdentityRef, trust: trustRef, certArray:  chainPointer!)
+                identityAndTrust = IdentityAndTrust(
+                    identityRef: secIdentityRef, trust: trustRef, certArray: chainPointer!)
             }
         } else {
             print("Security Error: " + securityError.description)
@@ -2229,27 +2674,41 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         return identityAndTrust
     }
 
-    func createAlertDialog(message: String?, responseMessage: String?, confirmButtonTitle: String?, completionHandler: @escaping () -> Void) {
+    func createAlertDialog(
+        message: String?, responseMessage: String?, confirmButtonTitle: String?,
+        completionHandler: @escaping () -> Void
+    ) {
         let title = responseMessage != nil && !responseMessage!.isEmpty ? responseMessage : message
-        let okButton = confirmButtonTitle != nil && !confirmButtonTitle!.isEmpty ? confirmButtonTitle : NSLocalizedString("Ok", comment: "")
-        let alertController = UIAlertController(title: title, message: nil,
-                                                preferredStyle: UIAlertController.Style.alert);
+        let okButton =
+            confirmButtonTitle != nil && !confirmButtonTitle!.isEmpty
+            ? confirmButtonTitle : NSLocalizedString("Ok", comment: "")
+        let alertController = UIAlertController(
+            title: title, message: nil,
+            preferredStyle: UIAlertController.Style.alert)
 
-        alertController.addAction(UIAlertAction(title: okButton, style: UIAlertAction.Style.default) {
-            _ in completionHandler()}
+        alertController.addAction(
+            UIAlertAction(title: okButton, style: UIAlertAction.Style.default) {
+                _ in completionHandler()
+            }
         )
 
-        guard let presentingViewController = inAppBrowserDelegate != nil ? inAppBrowserDelegate as? InAppBrowserWebViewController : window?.rootViewController else {
+        guard
+            let presentingViewController = inAppBrowserDelegate != nil
+                ? inAppBrowserDelegate as? InAppBrowserWebViewController
+                : window?.rootViewController
+        else {
             completionHandler()
             return
         }
         presentingViewController.present(alertController, animated: true, completion: {})
     }
 
-    public func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String,
-                 initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
+    public func webView(
+        _ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void
+    ) {
 
-        if (isPausedTimers) {
+        if isPausedTimers {
             isPausedTimersCompletionHandler = completionHandler
             return
         }
@@ -2262,11 +2721,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 completionHandlerCalled = true
                 let action = response.action ?? 1
                 switch action {
-                    case 0:
-                        completionHandler()
-                        break
-                    default:
-                        completionHandler()
+                case 0:
+                    completionHandler()
+                    break
+                default:
+                    completionHandler()
                 }
                 return false
             }
@@ -2277,8 +2736,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 completionHandlerCalled = true
                 let responseMessage = response?.message
                 let confirmButtonTitle = response?.confirmButtonTitle
-                self?.createAlertDialog(message: message, responseMessage: responseMessage,
-                                       confirmButtonTitle: confirmButtonTitle, completionHandler: completionHandler)
+                self?.createAlertDialog(
+                    message: message, responseMessage: responseMessage,
+                    confirmButtonTitle: confirmButtonTitle, completionHandler: completionHandler)
             }
         }
         callback.error = { (code: String, message: String?, details: Any?) in
@@ -2290,36 +2750,60 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if let channelDelegate = channelDelegate {
-            channelDelegate.onJsAlert(url: frame.request.url, message: message, isMainFrame: frame.isMainFrame, callback: callback)
+            channelDelegate.onJsAlert(
+                url: frame.request.url, message: message, isMainFrame: frame.isMainFrame,
+                callback: callback)
         } else {
             callback.defaultBehaviour(nil)
         }
     }
 
-    func createConfirmDialog(message: String?, responseMessage: String?, confirmButtonTitle: String?, cancelButtonTitle: String?, completionHandler: @escaping (Bool) -> Void) {
-        let dialogMessage = responseMessage != nil && !responseMessage!.isEmpty ? responseMessage : message
-        let okButton = confirmButtonTitle != nil && !confirmButtonTitle!.isEmpty ? confirmButtonTitle : NSLocalizedString("Ok", comment: "")
-        let cancelButton = cancelButtonTitle != nil && !cancelButtonTitle!.isEmpty ? cancelButtonTitle : NSLocalizedString("Cancel", comment: "")
+    func createConfirmDialog(
+        message: String?, responseMessage: String?, confirmButtonTitle: String?,
+        cancelButtonTitle: String?, completionHandler: @escaping (Bool) -> Void
+    ) {
+        let dialogMessage =
+            responseMessage != nil && !responseMessage!.isEmpty ? responseMessage : message
+        let okButton =
+            confirmButtonTitle != nil && !confirmButtonTitle!.isEmpty
+            ? confirmButtonTitle : NSLocalizedString("Ok", comment: "")
+        let cancelButton =
+            cancelButtonTitle != nil && !cancelButtonTitle!.isEmpty
+            ? cancelButtonTitle : NSLocalizedString("Cancel", comment: "")
 
-        let confirmController = UIAlertController(title: nil, message: dialogMessage, preferredStyle: .alert)
+        let confirmController = UIAlertController(
+            title: nil, message: dialogMessage, preferredStyle: .alert)
 
-        confirmController.addAction(UIAlertAction(title: okButton, style: .default, handler: { (action) in
-            completionHandler(true)
-        }))
+        confirmController.addAction(
+            UIAlertAction(
+                title: okButton, style: .default,
+                handler: { (action) in
+                    completionHandler(true)
+                }))
 
-        confirmController.addAction(UIAlertAction(title: cancelButton, style: .cancel, handler: { (action) in
-            completionHandler(false)
-        }))
+        confirmController.addAction(
+            UIAlertAction(
+                title: cancelButton, style: .cancel,
+                handler: { (action) in
+                    completionHandler(false)
+                }))
 
-        guard let presentingViewController = inAppBrowserDelegate != nil ? inAppBrowserDelegate as? InAppBrowserWebViewController : window?.rootViewController else {
+        guard
+            let presentingViewController = inAppBrowserDelegate != nil
+                ? inAppBrowserDelegate as? InAppBrowserWebViewController
+                : window?.rootViewController
+        else {
             completionHandler(false)
             return
         }
         presentingViewController.present(confirmController, animated: true, completion: nil)
     }
 
-    public func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo,
-                 completionHandler: @escaping (Bool) -> Void) {
+    public func webView(
+        _ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
         var completionHandlerCalled = false
 
         let callback = WebViewChannelDelegate.JsConfirmCallback()
@@ -2328,14 +2812,14 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 completionHandlerCalled = true
                 let action = response.action ?? 1
                 switch action {
-                    case 0:
-                        completionHandler(true)
-                        break
-                    case 1:
-                        completionHandler(false)
-                        break
-                    default:
-                        completionHandler(false)
+                case 0:
+                    completionHandler(true)
+                    break
+                case 1:
+                    completionHandler(false)
+                    break
+                default:
+                    completionHandler(false)
                 }
                 return false
             }
@@ -2347,7 +2831,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 let responseMessage = response?.message
                 let confirmButtonTitle = response?.confirmButtonTitle
                 let cancelButtonTitle = response?.cancelButtonTitle
-                self?.createConfirmDialog(message: message, responseMessage: responseMessage, confirmButtonTitle: confirmButtonTitle, cancelButtonTitle: cancelButtonTitle, completionHandler: completionHandler)
+                self?.createConfirmDialog(
+                    message: message, responseMessage: responseMessage,
+                    confirmButtonTitle: confirmButtonTitle, cancelButtonTitle: cancelButtonTitle,
+                    completionHandler: completionHandler)
             }
         }
         callback.error = { (code: String, message: String?, details: Any?) in
@@ -2359,47 +2846,71 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if let channelDelegate = channelDelegate {
-            channelDelegate.onJsConfirm(url: frame.request.url, message: message, isMainFrame: frame.isMainFrame, callback: callback)
+            channelDelegate.onJsConfirm(
+                url: frame.request.url, message: message, isMainFrame: frame.isMainFrame,
+                callback: callback)
         } else {
             callback.defaultBehaviour(nil)
         }
     }
 
-    func createPromptDialog(message: String, defaultValue: String?, responseMessage: String?, confirmButtonTitle: String?, cancelButtonTitle: String?, value: String?, completionHandler: @escaping (String?) -> Void) {
-        let dialogMessage = responseMessage != nil && !responseMessage!.isEmpty ? responseMessage : message
-        let okButton = confirmButtonTitle != nil && !confirmButtonTitle!.isEmpty ? confirmButtonTitle : NSLocalizedString("Ok", comment: "")
-        let cancelButton = cancelButtonTitle != nil && !cancelButtonTitle!.isEmpty ? cancelButtonTitle : NSLocalizedString("Cancel", comment: "")
+    func createPromptDialog(
+        message: String, defaultValue: String?, responseMessage: String?,
+        confirmButtonTitle: String?, cancelButtonTitle: String?, value: String?,
+        completionHandler: @escaping (String?) -> Void
+    ) {
+        let dialogMessage =
+            responseMessage != nil && !responseMessage!.isEmpty ? responseMessage : message
+        let okButton =
+            confirmButtonTitle != nil && !confirmButtonTitle!.isEmpty
+            ? confirmButtonTitle : NSLocalizedString("Ok", comment: "")
+        let cancelButton =
+            cancelButtonTitle != nil && !cancelButtonTitle!.isEmpty
+            ? cancelButtonTitle : NSLocalizedString("Cancel", comment: "")
 
-        let promptController = UIAlertController(title: nil, message: dialogMessage, preferredStyle: .alert)
+        let promptController = UIAlertController(
+            title: nil, message: dialogMessage, preferredStyle: .alert)
 
         promptController.addTextField { (textField) in
             textField.text = defaultValue
         }
 
-        promptController.addAction(UIAlertAction(title: okButton, style: .default, handler: { (action) in
-            if let v = value {
-                completionHandler(v)
-            }
-            else if let text = promptController.textFields?.first?.text {
-                completionHandler(text)
-            } else {
-                completionHandler("")
-            }
-        }))
+        promptController.addAction(
+            UIAlertAction(
+                title: okButton, style: .default,
+                handler: { (action) in
+                    if let v = value {
+                        completionHandler(v)
+                    } else if let text = promptController.textFields?.first?.text {
+                        completionHandler(text)
+                    } else {
+                        completionHandler("")
+                    }
+                }))
 
-        promptController.addAction(UIAlertAction(title: cancelButton, style: .cancel, handler: { (action) in
-            completionHandler(nil)
-        }))
+        promptController.addAction(
+            UIAlertAction(
+                title: cancelButton, style: .cancel,
+                handler: { (action) in
+                    completionHandler(nil)
+                }))
 
-        guard let presentingViewController = inAppBrowserDelegate != nil ? inAppBrowserDelegate as? InAppBrowserWebViewController : window?.rootViewController else {
+        guard
+            let presentingViewController = inAppBrowserDelegate != nil
+                ? inAppBrowserDelegate as? InAppBrowserWebViewController
+                : window?.rootViewController
+        else {
             completionHandler(nil)
             return
         }
         presentingViewController.present(promptController, animated: true, completion: nil)
     }
 
-    public func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt message: String, defaultText defaultValue: String?, initiatedByFrame frame: WKFrameInfo,
-                 completionHandler: @escaping (String?) -> Void) {
+    public func webView(
+        _ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt message: String,
+        defaultText defaultValue: String?, initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (String?) -> Void
+    ) {
 
         var completionHandlerCalled = false
 
@@ -2409,14 +2920,14 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 completionHandlerCalled = true
                 let action = response.action ?? 1
                 switch action {
-                    case 0:
-                        completionHandler(response.value)
-                        break
-                    case 1:
-                        completionHandler(nil)
-                        break
-                    default:
-                        completionHandler(nil)
+                case 0:
+                    completionHandler(response.value)
+                    break
+                case 1:
+                    completionHandler(nil)
+                    break
+                default:
+                    completionHandler(nil)
                 }
                 return false
             }
@@ -2429,8 +2940,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 let confirmButtonTitle = response?.confirmButtonTitle
                 let cancelButtonTitle = response?.cancelButtonTitle
                 let value = response?.value
-                self?.createPromptDialog(message: message, defaultValue: defaultValue, responseMessage: responseMessage, confirmButtonTitle: confirmButtonTitle,
-                                        cancelButtonTitle: cancelButtonTitle, value: value, completionHandler: completionHandler)
+                self?.createPromptDialog(
+                    message: message, defaultValue: defaultValue, responseMessage: responseMessage,
+                    confirmButtonTitle: confirmButtonTitle,
+                    cancelButtonTitle: cancelButtonTitle, value: value,
+                    completionHandler: completionHandler)
             }
         }
         callback.error = { (code: String, message: String?, details: Any?) in
@@ -2442,7 +2956,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if let channelDelegate = channelDelegate {
-            channelDelegate.onJsPrompt(url: frame.request.url, message: message, defaultValue: defaultValue, isMainFrame: frame.isMainFrame, callback: callback)
+            channelDelegate.onJsPrompt(
+                url: frame.request.url, message: message, defaultValue: defaultValue,
+                isMainFrame: frame.isMainFrame, callback: callback)
         } else {
             callback.defaultBehaviour(nil)
         }
@@ -2462,21 +2978,22 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         if startedByUser {
             if disableVerticalScroll && disableHorizontalScroll {
                 scrollView.contentOffset = CGPoint(x: lastScrollX, y: lastScrollY)
-            }
-            else if disableVerticalScroll {
+            } else if disableVerticalScroll {
                 if scrollView.contentOffset.y >= 0 || scrollView.contentOffset.y < 0 {
-                    scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x, y: lastScrollY)
+                    scrollView.contentOffset = CGPoint(
+                        x: scrollView.contentOffset.x, y: lastScrollY)
                 }
-            }
-            else if disableHorizontalScroll {
+            } else if disableHorizontalScroll {
                 if scrollView.contentOffset.x >= 0 || scrollView.contentOffset.x < 0 {
-                    scrollView.contentOffset = CGPoint(x: lastScrollX, y: scrollView.contentOffset.y)
+                    scrollView.contentOffset = CGPoint(
+                        x: lastScrollX, y: scrollView.contentOffset.y)
                 }
             }
         }
-        if (!disableVerticalScroll && !disableHorizontalScroll) ||
-            (disableVerticalScroll && scrollView.contentOffset.x != oldContentOffset?.x) ||
-            (disableHorizontalScroll && scrollView.contentOffset.y != oldContentOffset?.y) {
+        if (!disableVerticalScroll && !disableHorizontalScroll)
+            || (disableVerticalScroll && scrollView.contentOffset.x != oldContentOffset?.x)
+            || (disableHorizontalScroll && scrollView.contentOffset.y != oldContentOffset?.y)
+        {
             let x = Int(scrollView.contentOffset.x / scrollView.contentScaleFactor)
             let y = Int(scrollView.contentOffset.y / scrollView.contentScaleFactor)
             channelDelegate?.onScrollChanged(x: x, y: y)
@@ -2484,20 +3001,26 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         lastScrollX = scrollView.contentOffset.x
         lastScrollY = scrollView.contentOffset.y
 
-        let overScrolledHorizontally = lastScrollX < 0 || lastScrollX > (scrollView.contentSize.width - scrollView.frame.size.width)
-        let overScrolledVertically = lastScrollY < 0 || lastScrollY > (scrollView.contentSize.height - scrollView.frame.size.height)
+        let overScrolledHorizontally =
+            lastScrollX < 0
+            || lastScrollX > (scrollView.contentSize.width - scrollView.frame.size.width)
+        let overScrolledVertically =
+            lastScrollY < 0
+            || lastScrollY > (scrollView.contentSize.height - scrollView.frame.size.height)
         if overScrolledHorizontally || overScrolledVertically {
             let x = Int(lastScrollX / scrollView.contentScaleFactor)
             let y = Int(lastScrollY / scrollView.contentScaleFactor)
-            channelDelegate?.onOverScrolled(x: x, y: y,
-                           clampedX: overScrolledHorizontally,
-                           clampedY: overScrolledVertically)
+            channelDelegate?.onOverScrolled(
+                x: x, y: y,
+                clampedX: overScrolledHorizontally,
+                clampedY: overScrolledVertically)
         }
     }
 
     public func onContentSizeChanged(oldContentSize: CGSize) {
-        channelDelegate?.onContentSizeChanged(oldContentSize: oldContentSize,
-                                              newContentSize: scrollView.contentSize)
+        channelDelegate?.onContentSizeChanged(
+            oldContentSize: oldContentSize,
+            newContentSize: scrollView.contentSize)
     }
 
     public func scrollViewDidZoom(_ scrollView: UIScrollView) {
@@ -2508,10 +3031,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
-    public func webView(_ webView: WKWebView,
-                        createWebViewWith configuration: WKWebViewConfiguration,
-                  for navigationAction: WKNavigationAction,
-                  windowFeatures: WKWindowFeatures) -> WKWebView? {
+    public func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
 
         var windowId: Int64 = 0
         let inAppWebViewManager = plugin?.inAppWebViewManager
@@ -2520,7 +3045,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             windowId = inAppWebViewManager.windowAutoincrementId
         }
 
-        let windowWebView = InAppWebView(id: nil, plugin: nil, frame: self.bounds, configuration: configuration, contextMenu: nil)
+        let windowWebView = InAppWebView(
+            id: nil, plugin: nil, frame: self.bounds, configuration: configuration, contextMenu: nil
+        )
         windowWebView.windowId = windowId
 
         let webViewTransport = WebViewTransport(
@@ -2530,10 +3057,19 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
         inAppWebViewManager?.windowWebViews[windowId] = webViewTransport
 
-        let createWindowAction = CreateWindowAction(navigationAction: navigationAction, windowId: windowId, windowFeatures: windowFeatures, isDialog: nil)
+        let createWindowAction = CreateWindowAction(
+            navigationAction: navigationAction, windowId: windowId, windowFeatures: windowFeatures,
+            isDialog: nil)
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var shouldCreateWindow = true
 
         let callback = WebViewChannelDelegate.CreateWindowCallback()
         callback.nonNullSuccess = { (handledByClient: Bool) in
+            shouldCreateWindow = !handledByClient
+            if handledByClient {
+                semaphore.signal()
+            }
             return !handledByClient
         }
         callback.defaultBehaviour = { [weak self] (handledByClient: Bool?) in
@@ -2541,6 +3077,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 inAppWebViewManager?.windowWebViews.removeValue(forKey: windowId)
             }
             self?.loadUrl(urlRequest: navigationAction.request, allowingReadAccessTo: nil)
+            semaphore.signal()
         }
         callback.error = { [weak callback] (code: String, message: String?, details: Any?) in
             print(code + ", " + (message ?? ""))
@@ -2548,17 +3085,31 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
 
         if let channelDelegate = channelDelegate {
-            channelDelegate.onCreateWindow(createWindowAction: createWindowAction, callback: callback)
+            channelDelegate.onCreateWindow(
+                createWindowAction: createWindowAction, callback: callback)
         } else {
             callback.defaultBehaviour(nil)
         }
 
-        return windowWebView
+        let timeout = Date(timeIntervalSinceNow: 3.0)
+        while semaphore.wait(timeout: .now()) == .timedOut {
+            if !RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.05)) {
+                break
+            }
+            if Date() >= timeout {
+                print("onCreateWindow callback timed out, defaulting to create window")
+                break
+            }
+        }
+
+        return shouldCreateWindow ? windowWebView : nil
     }
 
-    public func webView(_ webView: WKWebView,
-                        authenticationChallenge challenge: URLAuthenticationChallenge,
-                        shouldAllowDeprecatedTLS decisionHandler: @escaping (Bool) -> Void) {
+    public func webView(
+        _ webView: WKWebView,
+        authenticationChallenge challenge: URLAuthenticationChallenge,
+        shouldAllowDeprecatedTLS decisionHandler: @escaping (Bool) -> Void
+    ) {
         var decisionHandlerCalled = false
         let callback = WebViewChannelDelegate.ShouldAllowDeprecatedTLSCallback()
         callback.nonNullSuccess = { (action: Bool) in
@@ -2600,125 +3151,130 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         channelDelegate?.onWebContentProcessDidTerminate()
     }
 
-    public func webView(_ webView: WKWebView,
-                        didCommit navigation: WKNavigation!) {
+    public func webView(
+        _ webView: WKWebView,
+        didCommit navigation: WKNavigation!
+    ) {
         channelDelegate?.onPageCommitVisible(url: url?.absoluteString)
     }
 
-    public func webView(_ webView: WKWebView,
-                        didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!) {
+    public func webView(
+        _ webView: WKWebView,
+        didReceiveServerRedirectForProvisionalNavigation navigation: WKNavigation!
+    ) {
         channelDelegate?.onDidReceiveServerRedirectForProvisionalNavigation()
     }
 
-//    @available(iOS 13.0, *)
-//    public func webView(_ webView: WKWebView,
-//                        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
-//                        completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
-//        print("contextMenuConfigurationForElement")
-//        let actionProvider: UIContextMenuActionProvider = { _ in
-//            let editMenu = UIMenu(title: "Edit...", children: [
-//                UIAction(title: "Copy") { action in
-//
-//                },
-//                UIAction(title: "Duplicate") { action in
-//
-//                }
-//            ])
-//            return UIMenu(title: "Title", children: [
-//                UIAction(title: "Share") { action in
-//
-//                },
-//                editMenu
-//            ])
-//        }
-//        let contextMenuConfiguration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: actionProvider)
-//        //completionHandler(contextMenuConfiguration)
-//        completionHandler(nil)
-////        onContextMenuConfigurationForElement(linkURL: elementInfo.linkURL?.absoluteString, result: nil/*{(result) -> Void in
-////            if result is FlutterError {
-////                print((result as! FlutterError).message ?? "")
-////            }
-////            else if (result as? NSObject) == FlutterMethodNotImplemented {
-////                completionHandler(nil)
-////            }
-////            else {
-////                var response: [String: Any]
-////                if let r = result {
-////                    response = r as! [String: Any]
-////                    var action = response["action"] as? Int
-////                    action = action != nil ? action : 0;
-////                    switch action {
-////                        case 0:
-////                            break
-////                        case 1:
-////                            break
-////                        default:
-////                            completionHandler(nil)
-////                    }
-////                    return;
-////                }
-////                completionHandler(nil)
-////            }
-////        }*/)
-//    }
-////
-//    @available(iOS 13.0, *)
-//    public func webView(_ webView: WKWebView,
-//                        contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
-//        print("contextMenuDidEndForElement")
-//        print(elementInfo)
-//        //onContextMenuDidEndForElement(linkURL: elementInfo.linkURL?.absoluteString)
-//    }
-//
-//    @available(iOS 13.0, *)
-//    public func webView(_ webView: WKWebView,
-//                        contextMenuForElement elementInfo: WKContextMenuElementInfo,
-//                        willCommitWithAnimator animator: UIContextMenuInteractionCommitAnimating) {
-//        print("willCommitWithAnimator")
-//        print(elementInfo)
-////        onWillCommitWithAnimator(linkURL: elementInfo.linkURL?.absoluteString, result: nil/*{(result) -> Void in
-////            if result is FlutterError {
-////                print((result as! FlutterError).message ?? "")
-////            }
-////            else if (result as? NSObject) == FlutterMethodNotImplemented {
-////
-////            }
-////            else {
-////                var response: [String: Any]
-////                if let r = result {
-////                    response = r as! [String: Any]
-////                    var action = response["action"] as? Int
-////                    action = action != nil ? action : 0;
-//////                    switch action {
-//////                        case 0:
-//////                            break
-//////                        case 1:
-//////                            break
-//////                        default:
-//////
-//////                    }
-////                    return;
-////                }
-////
-////            }
-////        }*/)
-//    }
-//
-//    @available(iOS 13.0, *)
-//    public func webView(_ webView: WKWebView,
-//                        contextMenuWillPresentForElement elementInfo: WKContextMenuElementInfo) {
-//        print("contextMenuWillPresentForElement")
-//        print(elementInfo.linkURL)
-//        //onContextMenuWillPresentForElement(linkURL: elementInfo.linkURL?.absoluteString)
-//    }
-
+    //    @available(iOS 13.0, *)
+    //    public func webView(_ webView: WKWebView,
+    //                        contextMenuConfigurationForElement elementInfo: WKContextMenuElementInfo,
+    //                        completionHandler: @escaping (UIContextMenuConfiguration?) -> Void) {
+    //        print("contextMenuConfigurationForElement")
+    //        let actionProvider: UIContextMenuActionProvider = { _ in
+    //            let editMenu = UIMenu(title: "Edit...", children: [
+    //                UIAction(title: "Copy") { action in
+    //
+    //                },
+    //                UIAction(title: "Duplicate") { action in
+    //
+    //                }
+    //            ])
+    //            return UIMenu(title: "Title", children: [
+    //                UIAction(title: "Share") { action in
+    //
+    //                },
+    //                editMenu
+    //            ])
+    //        }
+    //        let contextMenuConfiguration = UIContextMenuConfiguration(identifier: nil, previewProvider: nil, actionProvider: actionProvider)
+    //        //completionHandler(contextMenuConfiguration)
+    //        completionHandler(nil)
+    ////        onContextMenuConfigurationForElement(linkURL: elementInfo.linkURL?.absoluteString, result: nil/*{(result) -> Void in
+    ////            if result is FlutterError {
+    ////                print((result as! FlutterError).message ?? "")
+    ////            }
+    ////            else if (result as? NSObject) == FlutterMethodNotImplemented {
+    ////                completionHandler(nil)
+    ////            }
+    ////            else {
+    ////                var response: [String: Any]
+    ////                if let r = result {
+    ////                    response = r as! [String: Any]
+    ////                    var action = response["action"] as? Int
+    ////                    action = action != nil ? action : 0;
+    ////                    switch action {
+    ////                        case 0:
+    ////                            break
+    ////                        case 1:
+    ////                            break
+    ////                        default:
+    ////                            completionHandler(nil)
+    ////                    }
+    ////                    return;
+    ////                }
+    ////                completionHandler(nil)
+    ////            }
+    ////        }*/)
+    //    }
+    ////
+    //    @available(iOS 13.0, *)
+    //    public func webView(_ webView: WKWebView,
+    //                        contextMenuDidEndForElement elementInfo: WKContextMenuElementInfo) {
+    //        print("contextMenuDidEndForElement")
+    //        print(elementInfo)
+    //        //onContextMenuDidEndForElement(linkURL: elementInfo.linkURL?.absoluteString)
+    //    }
+    //
+    //    @available(iOS 13.0, *)
+    //    public func webView(_ webView: WKWebView,
+    //                        contextMenuForElement elementInfo: WKContextMenuElementInfo,
+    //                        willCommitWithAnimator animator: UIContextMenuInteractionCommitAnimating) {
+    //        print("willCommitWithAnimator")
+    //        print(elementInfo)
+    ////        onWillCommitWithAnimator(linkURL: elementInfo.linkURL?.absoluteString, result: nil/*{(result) -> Void in
+    ////            if result is FlutterError {
+    ////                print((result as! FlutterError).message ?? "")
+    ////            }
+    ////            else if (result as? NSObject) == FlutterMethodNotImplemented {
+    ////
+    ////            }
+    ////            else {
+    ////                var response: [String: Any]
+    ////                if let r = result {
+    ////                    response = r as! [String: Any]
+    ////                    var action = response["action"] as? Int
+    ////                    action = action != nil ? action : 0;
+    //////                    switch action {
+    //////                        case 0:
+    //////                            break
+    //////                        case 1:
+    //////                            break
+    //////                        default:
+    //////
+    //////                    }
+    ////                    return;
+    ////                }
+    ////
+    ////            }
+    ////        }*/)
+    //    }
+    //
+    //    @available(iOS 13.0, *)
+    //    public func webView(_ webView: WKWebView,
+    //                        contextMenuWillPresentForElement elementInfo: WKContextMenuElementInfo) {
+    //        print("contextMenuWillPresentForElement")
+    //        print(elementInfo.linkURL)
+    //        //onContextMenuWillPresentForElement(linkURL: elementInfo.linkURL?.absoluteString)
+    //    }
 
     // https://stackoverflow.com/a/42840541/4637638
     public func isVideoPlayerWindow(_ notificationObject: AnyObject?) -> Bool {
-        let nonVideoClasses = ["_UIAlertControllerShimPresenterWindow",
-                               "UITextEffectsWindow",
-                               "UIRemoteKeyboardWindow",
-                               "PGHostedWindow"]
+        let nonVideoClasses = [
+            "_UIAlertControllerShimPresenterWindow",
+            "UITextEffectsWindow",
+            "UIRemoteKeyboardWindow",
+            "PGHostedWindow",
+        ]
 
         var isVideo = true
         if let obj = notificationObject {
@@ -2733,12 +3289,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
     @objc func onEnterFullscreen(_ notification: Notification) {
         // TODO: Still not working on iOS 16.0!
-//        if #available(iOS 16.0, *) {
-//            channelDelegate?.onEnterFullscreen()
-//            inFullscreen = true
-//        }
-//        else
-        if (isVideoPlayerWindow(notification.object as AnyObject?)) {
+        //        if #available(iOS 16.0, *) {
+        //            channelDelegate?.onEnterFullscreen()
+        //            inFullscreen = true
+        //        }
+        //        else
+        if isVideoPlayerWindow(notification.object as AnyObject?) {
             channelDelegate?.onEnterFullscreen()
             inFullscreen = true
         }
@@ -2746,74 +3302,81 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
     @objc func onExitFullscreen(_ notification: Notification) {
         // TODO: Still not working on iOS 16.0!
-//        if #available(iOS 16.0, *) {
-//            channelDelegate?.onExitFullscreen()
-//            inFullscreen = false
-//        }
-//        else
-        if (isVideoPlayerWindow(notification.object as AnyObject?)) {
+        //        if #available(iOS 16.0, *) {
+        //            channelDelegate?.onExitFullscreen()
+        //            inFullscreen = false
+        //        }
+        //        else
+        if isVideoPlayerWindow(notification.object as AnyObject?) {
             channelDelegate?.onExitFullscreen()
             inFullscreen = false
         }
     }
 
-//    public func onContextMenuConfigurationForElement(linkURL: String?, result: FlutterResult?) {
-//        let arguments: [String: Any?] = ["linkURL": linkURL]
-//        channel?.invokeMethod("onContextMenuConfigurationForElement", arguments: arguments, result: result)
-//    }
-//
-//    public func onContextMenuDidEndForElement(linkURL: String?) {
-//        let arguments: [String: Any?] = ["linkURL": linkURL]
-//        channel?.invokeMethod("onContextMenuDidEndForElement", arguments: arguments)
-//    }
-//
-//    public func onWillCommitWithAnimator(linkURL: String?, result: FlutterResult?) {
-//        let arguments: [String: Any?] = ["linkURL": linkURL]
-//        channel?.invokeMethod("onWillCommitWithAnimator", arguments: arguments, result: result)
-//    }
-//
-//    public func onContextMenuWillPresentForElement(linkURL: String?) {
-//        let arguments: [String: Any?] = ["linkURL": linkURL]
-//        channel?.invokeMethod("onContextMenuWillPresentForElement", arguments: arguments)
-//    }
+    //    public func onContextMenuConfigurationForElement(linkURL: String?, result: FlutterResult?) {
+    //        let arguments: [String: Any?] = ["linkURL": linkURL]
+    //        channel?.invokeMethod("onContextMenuConfigurationForElement", arguments: arguments, result: result)
+    //    }
+    //
+    //    public func onContextMenuDidEndForElement(linkURL: String?) {
+    //        let arguments: [String: Any?] = ["linkURL": linkURL]
+    //        channel?.invokeMethod("onContextMenuDidEndForElement", arguments: arguments)
+    //    }
+    //
+    //    public func onWillCommitWithAnimator(linkURL: String?, result: FlutterResult?) {
+    //        let arguments: [String: Any?] = ["linkURL": linkURL]
+    //        channel?.invokeMethod("onWillCommitWithAnimator", arguments: arguments, result: result)
+    //    }
+    //
+    //    public func onContextMenuWillPresentForElement(linkURL: String?) {
+    //        let arguments: [String: Any?] = ["linkURL": linkURL]
+    //        channel?.invokeMethod("onContextMenuWillPresentForElement", arguments: arguments)
+    //    }
 
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+    public func userContentController(
+        _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
+    ) {
         guard let body = message.body as? [String: Any?] else {
             return
         }
 
-        if ["consoleLog", "consoleDebug", "consoleError", "consoleInfo", "consoleWarn"].contains(message.name) {
+        if ["consoleLog", "consoleDebug", "consoleError", "consoleInfo", "consoleWarn"].contains(
+            message.name)
+        {
             var messageLevel = 1
-            switch (message.name) {
-                case "consoleLog":
-                    messageLevel = 1
-                    break
-                case "consoleDebug":
-                    // on Android, console.debug is TIP
-                    messageLevel = 0
-                    break
-                case "consoleError":
-                    messageLevel = 3
-                    break
-                case "consoleInfo":
-                    // on Android, console.info is LOG
-                    messageLevel = 1
-                    break
-                case "consoleWarn":
-                    messageLevel = 2
-                    break
-                default:
-                    messageLevel = 1
-                    break
+            switch message.name {
+            case "consoleLog":
+                messageLevel = 1
+                break
+            case "consoleDebug":
+                // on Android, console.debug is TIP
+                messageLevel = 0
+                break
+            case "consoleError":
+                messageLevel = 3
+                break
+            case "consoleInfo":
+                // on Android, console.info is LOG
+                messageLevel = 1
+                break
+            case "consoleWarn":
+                messageLevel = 2
+                break
+            default:
+                messageLevel = 1
+                break
             }
             let consoleMessage = body["message"] as? String ?? ""
 
             let _windowId = body["_windowId"] as? Int64
             var webView = self
-            if let wId = _windowId, let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[wId] {
+            if let wId = _windowId,
+                let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[wId]
+            {
                 webView = webViewTransport.webView
             }
-            webView.channelDelegate?.onConsoleMessage(message: consoleMessage, messageLevel: messageLevel)
+            webView.channelDelegate?.onConsoleMessage(
+                message: consoleMessage, messageLevel: messageLevel)
         } else if message.name == "callHandler", let handlerName = body["handlerName"] as? String {
             if handlerName == "onPrintRequest" {
                 let settings = PrintJobSettings()
@@ -2828,11 +3391,13 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                             printJob?.disposeNoDismiss()
                         }
                     }
-                    callback.error = { [weak callback] (code: String, message: String?, details: Any?) in
+                    callback.error = {
+                        [weak callback] (code: String, message: String?, details: Any?) in
                         print(code + ", " + (message ?? ""))
                         callback?.defaultBehaviour(nil)
                     }
-                    channelDelegate?.onPrintRequest(url: url, printJobId: printJobId, callback: callback)
+                    channelDelegate?.onPrintRequest(
+                        url: url, printJobId: printJobId, callback: callback)
                 }
                 return
             }
@@ -2842,7 +3407,9 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
             let _windowId = body["_windowId"] as? Int64
             var webView = self
-            if let wId = _windowId, let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[wId] {
+            if let wId = _windowId,
+                let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[wId]
+            {
                 webView = webViewTransport.webView
             }
 
@@ -2853,67 +3420,83 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     json = r
                 }
 
-                self?.evaluateJavaScript("""
-if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
-    window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)].resolve(\(json));
-    delete window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)];
-}
-""", completionHandler: nil)
+                self?.evaluateJavaScript(
+                    """
+                    if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
+                        window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)].resolve(\(json));
+                        delete window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)];
+                    }
+                    """, completionHandler: nil)
             }
             callback.error = { [weak self] (code: String, message: String?, details: Any?) in
                 let errorMessage = code + (message != nil ? ", " + (message ?? "") : "")
                 print(errorMessage)
 
-                self?.evaluateJavaScript("""
-if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
-    window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)].reject(new Error('\(errorMessage.replacingOccurrences(of: "\'", with: "\\'"))'));
-    delete window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)];
-}
-""", completionHandler: nil)
+                self?.evaluateJavaScript(
+                    """
+                    if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
+                        window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)].reject(new Error('\(errorMessage.replacingOccurrences(of: "\'", with: "\\'"))'));
+                        delete window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)];
+                    }
+                    """, completionHandler: nil)
             }
 
             if let channelDelegate = webView.channelDelegate {
-                channelDelegate.onCallJsHandler(handlerName: handlerName, args: args, callback: callback)
+                channelDelegate.onCallJsHandler(
+                    handlerName: handlerName, args: args, callback: callback)
             }
         } else if message.name == "onFindResultReceived",
-                  let findResult = body["findResult"] as? [String: Any],
-                  let activeMatchOrdinal = findResult["activeMatchOrdinal"] as? Int,
-                  let numberOfMatches = findResult["numberOfMatches"] as? Int,
-                  let isDoneCounting = findResult["isDoneCounting"] as? Bool {
+            let findResult = body["findResult"] as? [String: Any],
+            let activeMatchOrdinal = findResult["activeMatchOrdinal"] as? Int,
+            let numberOfMatches = findResult["numberOfMatches"] as? Int,
+            let isDoneCounting = findResult["isDoneCounting"] as? Bool
+        {
 
             let _windowId = body["_windowId"] as? Int64
             var webView = self
-            if let wId = _windowId, let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[wId] {
+            if let wId = _windowId,
+                let webViewTransport = plugin?.inAppWebViewManager?.windowWebViews[wId]
+            {
                 webView = webViewTransport.webView
             }
-            webView.findInteractionController?.channelDelegate?.onFindResultReceived(activeMatchOrdinal: activeMatchOrdinal, numberOfMatches: numberOfMatches, isDoneCounting: isDoneCounting)
-            webView.channelDelegate?.onFindResultReceived(activeMatchOrdinal: activeMatchOrdinal, numberOfMatches: numberOfMatches, isDoneCounting: isDoneCounting)
+            webView.findInteractionController?.channelDelegate?.onFindResultReceived(
+                activeMatchOrdinal: activeMatchOrdinal, numberOfMatches: numberOfMatches,
+                isDoneCounting: isDoneCounting)
+            webView.channelDelegate?.onFindResultReceived(
+                activeMatchOrdinal: activeMatchOrdinal, numberOfMatches: numberOfMatches,
+                isDoneCounting: isDoneCounting)
         } else if message.name == "onCallAsyncJavaScriptResultBelowIOS14Received",
-                  let resultUuid = body["resultUuid"] as? String,
-                  let result = callAsyncJavaScriptBelowIOS14Results[resultUuid] {
+            let resultUuid = body["resultUuid"] as? String,
+            let result = callAsyncJavaScriptBelowIOS14Results[resultUuid]
+        {
             result([
-                    "value": body["value"],
-                    "error": body["error"]
+                "value": body["value"],
+                "error": body["error"],
             ])
             callAsyncJavaScriptBelowIOS14Results.removeValue(forKey: resultUuid)
         } else if message.name == "onWebMessagePortMessageReceived",
-                  let webMessageChannelId = body["webMessageChannelId"] as? String,
-                  let index = body["index"] as? Int64 {
+            let webMessageChannelId = body["webMessageChannelId"] as? String,
+            let index = body["index"] as? Int64
+        {
             var webMessage: WebMessage? = nil
-            if let webMessageMap = body["message"] as? [String : Any?] {
+            if let webMessageMap = body["message"] as? [String: Any?] {
                 webMessage = WebMessage.fromMap(map: webMessageMap)
             }
 
             if let webMessageChannel = webMessageChannels[webMessageChannelId] {
                 webMessageChannel.channelDelegate?.onMessage(index: index, message: webMessage)
             }
-        } else if message.name == "onWebMessageListenerPostMessageReceived", let jsObjectName = body["jsObjectName"] as? String {
+        } else if message.name == "onWebMessageListenerPostMessageReceived",
+            let jsObjectName = body["jsObjectName"] as? String
+        {
             var webMessage: WebMessage? = nil
-            if let webMessageMap = body["message"] as? [String : Any?] {
+            if let webMessageMap = body["message"] as? [String: Any?] {
                 webMessage = WebMessage.fromMap(map: webMessageMap)
             }
 
-            if let webMessageListener = webMessageListeners.first(where: ({($0.jsObjectName == jsObjectName)})) {
+            if let webMessageListener = webMessageListeners.first(
+                where: ({ ($0.jsObjectName == jsObjectName) }))
+            {
                 let isMainFrame = message.frameInfo.isMainFrame
 
                 var scheme: String? = nil
@@ -2936,9 +3519,13 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
                 var sourceOrigin: URL? = nil
                 if let scheme = scheme, !scheme.isEmpty, let host = host, !host.isEmpty {
-                    sourceOrigin = URL(string: "\(scheme)://\(host)\(port != nil && port != 0 ? ":" + String(port!) : "")")
+                    sourceOrigin = URL(
+                        string:
+                            "\(scheme)://\(host)\(port != nil && port != 0 ? ":" + String(port!) : "")"
+                    )
                 }
-                webMessageListener.channelDelegate?.onPostMessage(message: webMessage, sourceOrigin: sourceOrigin, isMainFrame: isMainFrame)
+                webMessageListener.channelDelegate?.onPostMessage(
+                    message: webMessage, sourceOrigin: sourceOrigin, isMainFrame: isMainFrame)
             }
         }
     }
@@ -2953,11 +3540,10 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         scrollView.setContentOffset(CGPoint(x: newX, y: newY), animated: animated)
     }
 
-
     public func pauseTimers() {
         if !isPausedTimers {
             isPausedTimers = true
-            let script = "alert();";
+            let script = "alert();"
             self.evaluateJavaScript(script, completionHandler: nil)
         }
     }
@@ -2972,8 +3558,10 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         }
     }
 
-    public func printCurrentPage(settings: PrintJobSettings? = nil,
-                                 completionHandler: UIPrintInteractionController.CompletionHandler? = nil) -> String? {
+    public func printCurrentPage(
+        settings: PrintJobSettings? = nil,
+        completionHandler: UIPrintInteractionController.CompletionHandler? = nil
+    ) -> String? {
         var printJobId: String? = nil
         if let settings = settings, settings.handledByClient {
             printJobId = NSUUID().uuidString
@@ -2996,26 +3584,31 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
         printController.printInfo = UIPrintInfo(dictionary: nil)
         if let printInfo = printController.printInfo {
-            printInfo.jobName = settings?.jobName ?? (title ?? url?.absoluteString ?? "") + " Document"
+            printInfo.jobName =
+                settings?.jobName ?? (title ?? url?.absoluteString ?? "") + " Document"
             if let settings = settings {
                 if let orientationValue = settings.orientation,
-                    let orientation = UIPrintInfo.Orientation.init(rawValue: orientationValue) {
+                    let orientation = UIPrintInfo.Orientation.init(rawValue: orientationValue)
+                {
                     printInfo.orientation = orientation
                 }
                 if let duplexModeValue = settings.duplexMode,
-                    let duplexMode = UIPrintInfo.Duplex.init(rawValue: duplexModeValue) {
+                    let duplexMode = UIPrintInfo.Duplex.init(rawValue: duplexModeValue)
+                {
                     printInfo.duplex = duplexMode
                 }
                 if let outputTypeValue = settings.outputType,
-                    let outputType = UIPrintInfo.OutputType.init(rawValue: outputTypeValue) {
+                    let outputType = UIPrintInfo.OutputType.init(rawValue: outputTypeValue)
+                {
                     printInfo.outputType = outputType
                 }
             }
         }
 
         // initialize print renderer and set its formatter
-        let printRenderer = CustomUIPrintPageRenderer(numberOfPage: settings?.numberOfPages,
-                                                      forceRenderingQuality: settings?.forceRenderingQuality)
+        let printRenderer = CustomUIPrintPageRenderer(
+            numberOfPage: settings?.numberOfPages,
+            forceRenderingQuality: settings?.forceRenderingQuality)
         printRenderer.addPrintFormatter(printFormatter, startingAtPageAt: 0)
         if let settings = settings {
             if let footerHeight = settings.footerHeight {
@@ -3029,7 +3622,8 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
         if let settings = settings {
             printController.showsNumberOfCopies = settings.showsNumberOfCopies
-            printController.showsPaperSelectionForLoadedPapers = settings.showsPaperSelectionForLoadedPapers
+            printController.showsPaperSelectionForLoadedPapers =
+                settings.showsPaperSelectionForLoadedPapers
             if #available(iOS 15.0, *) {
                 printController.showsPaperOrientation = settings.showsPaperOrientation
             }
@@ -3037,7 +3631,8 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
         let animated = settings?.animated ?? true
         if let id = printJobId, let plugin = plugin {
-            let printJob = PrintJobController(plugin: plugin, id: id, job: printController, settings: settings)
+            let printJob = PrintJobController(
+                plugin: plugin, id: id, job: printController, settings: settings)
             plugin.printJobManager?.jobs[id] = printJob
             printJob.present(animated: animated, completionHandler: completionHandler)
         } else {
@@ -3070,7 +3665,8 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
     public func getSelectedText(completionHandler: @escaping (Any?, Error?) -> Void) {
         if configuration.preferences.javaScriptEnabled {
-            evaluateJavaScript(PluginScriptsUtil.GET_SELECTED_TEXT_JS_SOURCE, completionHandler: completionHandler)
+            evaluateJavaScript(
+                PluginScriptsUtil.GET_SELECTED_TEXT_JS_SOURCE, completionHandler: completionHandler)
         } else {
             completionHandler(nil, nil)
         }
@@ -3078,30 +3674,35 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
     public func getHitTestResult(completionHandler: @escaping (HitTestResult) -> Void) {
         if configuration.preferences.javaScriptEnabled, let lastTouchLocation = lastTouchPoint {
-            self.evaluateJavaScript("window.\(JAVASCRIPT_BRIDGE_NAME)._findElementsAtPoint(\(lastTouchLocation.x),\(lastTouchLocation.y))", completionHandler: {(value, error) in
-                if error != nil {
-                    print("getHitTestResult error: \(error?.localizedDescription ?? "")")
-                    completionHandler(HitTestResult(type: .unknownType, extra: nil))
-                } else if let value = value as? [String: Any?] {
-                    let hitTestResult = HitTestResult.fromMap(map: value)!
-                    completionHandler(hitTestResult)
-                } else {
-                    completionHandler(HitTestResult(type: .unknownType, extra: nil))
-                }
-            })
+            self.evaluateJavaScript(
+                "window.\(JAVASCRIPT_BRIDGE_NAME)._findElementsAtPoint(\(lastTouchLocation.x),\(lastTouchLocation.y))",
+                completionHandler: { (value, error) in
+                    if error != nil {
+                        print("getHitTestResult error: \(error?.localizedDescription ?? "")")
+                        completionHandler(HitTestResult(type: .unknownType, extra: nil))
+                    } else if let value = value as? [String: Any?] {
+                        let hitTestResult = HitTestResult.fromMap(map: value)!
+                        completionHandler(hitTestResult)
+                    } else {
+                        completionHandler(HitTestResult(type: .unknownType, extra: nil))
+                    }
+                })
         } else {
             completionHandler(HitTestResult(type: .unknownType, extra: nil))
         }
     }
 
-    public func requestFocusNodeHref(completionHandler: @escaping ([String: Any?]?, Error?) -> Void) {
+    public func requestFocusNodeHref(completionHandler: @escaping ([String: Any?]?, Error?) -> Void)
+    {
         if configuration.preferences.javaScriptEnabled {
             // add some delay to make it sure _lastAnchorOrImageTouched is updated
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                self.evaluateJavaScript("window.\(JAVASCRIPT_BRIDGE_NAME)._lastAnchorOrImageTouched", completionHandler: {(value, error) in
-                    let lastAnchorOrImageTouched = value as? [String: Any?]
-                    completionHandler(lastAnchorOrImageTouched, error)
-                })
+                self.evaluateJavaScript(
+                    "window.\(JAVASCRIPT_BRIDGE_NAME)._lastAnchorOrImageTouched",
+                    completionHandler: { (value, error) in
+                        let lastAnchorOrImageTouched = value as? [String: Any?]
+                        completionHandler(lastAnchorOrImageTouched, error)
+                    })
             }
         } else {
             completionHandler(nil, nil)
@@ -3112,10 +3713,12 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         if configuration.preferences.javaScriptEnabled {
             // add some delay to make it sure _lastImageTouched is updated
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                self.evaluateJavaScript("window.\(JAVASCRIPT_BRIDGE_NAME)._lastImageTouched", completionHandler: {(value, error) in
-                    let lastImageTouched = value as? [String: Any?]
-                    completionHandler(lastImageTouched, error)
-                })
+                self.evaluateJavaScript(
+                    "window.\(JAVASCRIPT_BRIDGE_NAME)._lastImageTouched",
+                    completionHandler: { (value, error) in
+                        let lastImageTouched = value as? [String: Any?]
+                        completionHandler(lastImageTouched, error)
+                    })
             }
         } else {
             completionHandler(nil, nil)
@@ -3128,9 +3731,10 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
     public func getCertificate() -> SslCertificate? {
         guard let scheme = url?.scheme,
-              scheme == "https",
-              let host = url?.host,
-              let sslCertificate = InAppWebView.sslCertificatesMap[host] else {
+            scheme == "https",
+            let host = url?.host,
+            let sslCertificate = InAppWebView.sslCertificatesMap[host]
+        else {
             return nil
         }
         return sslCertificate
@@ -3179,7 +3783,9 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         }
     }
 
-    public func createWebMessageChannel(completionHandler: ((WebMessageChannel?) -> Void)? = nil) -> WebMessageChannel? {
+    public func createWebMessageChannel(completionHandler: ((WebMessageChannel?) -> Void)? = nil)
+        -> WebMessageChannel?
+    {
         guard let plugin = plugin else {
             completionHandler?(nil)
             return nil
@@ -3192,7 +3798,9 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         return webMessageChannel
     }
 
-    public func postWebMessage(message: WebMessage, targetOrigin: String, completionHandler: ((Any?) -> Void)? = nil) throws {
+    public func postWebMessage(
+        message: WebMessage, targetOrigin: String, completionHandler: ((Any?) -> Void)? = nil
+    ) throws {
         var portsString = "null"
         if let ports = message.ports {
             var portArrayString: [String] = []
@@ -3204,24 +3812,29 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
                     throw NSError(domain: "Port is already closed or transferred", code: 0)
                 }
                 port.isTransferred = true
-                portArrayString.append("\(WEB_MESSAGE_CHANNELS_VARIABLE_NAME)['\(port.webMessageChannel!.id)'].\(port.name)")
+                portArrayString.append(
+                    "\(WEB_MESSAGE_CHANNELS_VARIABLE_NAME)['\(port.webMessageChannel!.id)'].\(port.name)"
+                )
             }
             portsString = "[" + portArrayString.joined(separator: ", ") + "]"
         }
 
         let url = URL(string: targetOrigin)?.absoluteString ?? "*"
         let source = """
-        (function() {
-            window.postMessage(\(message.jsData), '\(url)', \(portsString));
-        })();
-        """
+            (function() {
+                window.postMessage(\(message.jsData), '\(url)', \(portsString));
+            })();
+            """
         evaluateJavascript(source: source, completionHandler: completionHandler)
         message.dispose()
     }
 
     public func addWebMessageListener(webMessageListener: WebMessageListener) throws {
-        if webMessageListeners.map({ ($0.jsObjectName) }).contains(webMessageListener.jsObjectName) {
-            throw NSError(domain: "jsObjectName \(webMessageListener.jsObjectName) was already added.", code: 0)
+        if webMessageListeners.map({ ($0.jsObjectName) }).contains(webMessageListener.jsObjectName)
+        {
+            throw NSError(
+                domain: "jsObjectName \(webMessageListener.jsObjectName) was already added.",
+                code: 0)
         }
         try webMessageListener.assertOriginRulesValid()
         webMessageListener.initJsInstance(webView: self)
@@ -3249,6 +3862,9 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
     }
 
     public func dispose() {
+        guard !isDisposed else { return }
+        isDisposed = true
+
         channelDelegate?.dispose()
         channelDelegate = nil
         runWindowBeforeCreatedCallbacks()
@@ -3260,9 +3876,9 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
             removeObserver(self, forKeyPath: #keyPath(WKWebView.microphoneCaptureState))
         }
         // TODO: Still not working on iOS 16.0!
-//        if #available(iOS 16.0, *) {
-//            removeObserver(self, forKeyPath: #keyPath(WKWebView.fullscreenState))
-//        }
+        //        if #available(iOS 16.0, *) {
+        //            removeObserver(self, forKeyPath: #keyPath(WKWebView.fullscreenState))
+        //        }
         scrollView.removeObserver(self, forKeyPath: #keyPath(UIScrollView.contentOffset))
         scrollView.removeObserver(self, forKeyPath: #keyPath(UIScrollView.zoomScale))
         scrollView.removeObserver(self, forKeyPath: #keyPath(UIScrollView.contentSize))
@@ -3276,9 +3892,12 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         interceptOnlyAsyncAjaxRequestsPluginScript = nil
         if windowId == nil {
             configuration.userContentController.removeAllPluginScriptMessageHandlers()
-            configuration.userContentController.removeScriptMessageHandler(forName: "onCallAsyncJavaScriptResultBelowIOS14Received")
-            configuration.userContentController.removeScriptMessageHandler(forName: "onWebMessagePortMessageReceived")
-            configuration.userContentController.removeScriptMessageHandler(forName: "onWebMessageListenerPostMessageReceived")
+            configuration.userContentController.removeScriptMessageHandler(
+                forName: "onCallAsyncJavaScriptResultBelowIOS14Received")
+            configuration.userContentController.removeScriptMessageHandler(
+                forName: "onWebMessagePortMessageReceived")
+            configuration.userContentController.removeScriptMessageHandler(
+                forName: "onWebMessageListenerPostMessageReceived")
             configuration.userContentController.removeAllUserScripts()
             if #available(iOS 11.0, *) {
                 configuration.userContentController.removeAllContentRuleLists()
@@ -3294,7 +3913,8 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
         longPressRecognizer.removeTarget(self, action: #selector(longPressGestureDetected))
         longPressRecognizer.delegate = nil
         scrollView.removeGestureRecognizer(longPressRecognizer)
-        recognizerForDisablingContextMenuOnLinks.removeTarget(self, action: #selector(longPressGestureDetected))
+        recognizerForDisablingContextMenuOnLinks.removeTarget(
+            self, action: #selector(longPressGestureDetected))
         recognizerForDisablingContextMenuOnLinks.delegate = nil
         scrollView.removeGestureRecognizer(recognizerForDisablingContextMenuOnLinks)
         panGestureRecognizer.removeTarget(self, action: #selector(endDraggingDetected))
@@ -3316,5 +3936,6 @@ if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {
 
     deinit {
         debugPrint("InAppWebView - dealloc")
+        dispose()
     }
 }

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -1,4 +1,8 @@
+import AuthenticationServices
 import Flutter
+import SafariServices
+import UIKit
+
 //
 //  WebAuthenticationSession.swift
 //  zikzak_inappwebview
@@ -6,11 +10,9 @@ import Flutter
 //  Created by ARRRRNY on 08/05/22.
 //
 
-import UIKit
-import AuthenticationServices
-import SafariServices
-
-public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentationContextProviding, Disposable {
+public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentationContextProviding,
+    Disposable
+{
     static let METHOD_CHANNEL_NAME_PREFIX = "wtf.zikzak/flutter_webauthenticationsession_"
     var id: String
     var plugin: SwiftFlutterPlugin?
@@ -21,7 +23,10 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
     var channelDelegate: WebAuthenticationSessionChannelDelegate?
     private var _canStart = true
 
-    public init(plugin: SwiftFlutterPlugin, id: String, url: URL, callbackURLScheme: String?, settings: WebAuthenticationSessionSettings) {
+    public init(
+        plugin: SwiftFlutterPlugin, id: String, url: URL, callbackURLScheme: String?,
+        settings: WebAuthenticationSessionSettings
+    ) {
         self.id = id
         self.plugin = plugin
         self.url = url
@@ -29,17 +34,23 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         super.init()
         self.callbackURLScheme = callbackURLScheme
         if #available(iOS 12.0, *) {
-            let session = ASWebAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
+            let session = ASWebAuthenticationSession(
+                url: self.url, callbackURLScheme: self.callbackURLScheme,
+                completionHandler: self.completionHandler)
             if #available(iOS 13.0, *) {
                 session.presentationContextProvider = self
             }
             self.session = session
         } else if #available(iOS 11.0, *) {
-            self.session = SFAuthenticationSession(url: self.url, callbackURLScheme: self.callbackURLScheme, completionHandler: self.completionHandler)
+            self.session = SFAuthenticationSession(
+                url: self.url, callbackURLScheme: self.callbackURLScheme,
+                completionHandler: self.completionHandler)
         }
-        let channel = FlutterMethodChannel(name: WebAuthenticationSession.METHOD_CHANNEL_NAME_PREFIX + id,
-                                           binaryMessenger: plugin.registrar!.messenger())
-        self.channelDelegate = WebAuthenticationSessionChannelDelegate(webAuthenticationSession: self, channel: channel)
+        let channel = FlutterMethodChannel(
+            name: WebAuthenticationSession.METHOD_CHANNEL_NAME_PREFIX + id,
+            binaryMessenger: plugin.registrar!.messenger())
+        self.channelDelegate = WebAuthenticationSessionChannelDelegate(
+            webAuthenticationSession: self, channel: channel)
     }
 
     public func prepare() {
@@ -48,7 +59,7 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         }
     }
 
-    public func completionHandler(url: URL?, error: Error?) -> Void {
+    public func completionHandler(url: URL?, error: Error?) {
         channelDelegate?.onComplete(url: url, errorCode: error?._code)
     }
 
@@ -89,7 +100,9 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         }
     }
 
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+    @available(iOS 12.0, *)
+    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor
+    {
         return UIApplication.shared.windows.first { $0.isKeyWindow } ?? ASPresentationAnchor()
     }
 

--- a/zikzak_inappwebview_ios/pubspec.yaml
+++ b/zikzak_inappwebview_ios/pubspec.yaml
@@ -18,7 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_linux/example/pubspec.lock
+++ b/zikzak_inappwebview_linux/example/pubspec.lock
@@ -274,10 +274,9 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: c0432ea3eee7cb2dfec36eae7afb19bbe04fd82314ec4040e236120d4f7e4152
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_linux:
     dependency: "direct main"
@@ -289,10 +288,9 @@ packages:
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: d7ee03c83bfb767155f66ca1476a115cb31d983aafd7f402da5c9a3ffa79a3ce
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.2.4"
 sdks:
   dart: ">=3.10.8 <4.0.0"

--- a/zikzak_inappwebview_linux/example/pubspec.yaml
+++ b/zikzak_inappwebview_linux/example/pubspec.yaml
@@ -25,7 +25,8 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  zikzak_inappwebview_platform_interface: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../../zikzak_inappwebview_platform_interface
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/zikzak_inappwebview_linux/linux/CMakeLists.txt
+++ b/zikzak_inappwebview_linux/linux/CMakeLists.txt
@@ -42,7 +42,11 @@ target_include_directories(${PLUGIN_NAME} INTERFACE
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
 target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
 
-pkg_check_modules(WEBKIT2GTK REQUIRED webkit2gtk-4.0)
+# Try webkit2gtk-4.1 first (Ubuntu 24.04 Noble, Debian 13+), fall back to 4.0
+pkg_check_modules(WEBKIT2GTK webkit2gtk-4.1)
+if(NOT WEBKIT2GTK_FOUND)
+  pkg_check_modules(WEBKIT2GTK REQUIRED webkit2gtk-4.0)
+endif()
 target_include_directories(${PLUGIN_NAME} PRIVATE ${WEBKIT2GTK_INCLUDE_DIRS})
 target_link_libraries(${PLUGIN_NAME} PRIVATE ${WEBKIT2GTK_LIBRARIES})
 

--- a/zikzak_inappwebview_linux/linux/in_app_webview.cc
+++ b/zikzak_inappwebview_linux/linux/in_app_webview.cc
@@ -1,5 +1,6 @@
 #include "include/zikzak_inappwebview_linux/in_app_webview.h"
 #include <cstring>
+#include <glib/gstdio.h>
 #include <iostream>
 
 struct _InAppWebView {
@@ -9,7 +10,7 @@ struct _InAppWebView {
   FlMethodChannel* channel;
   GtkWidget* web_view;
   int64_t texture_id;
-  
+
   uint8_t* buffer;
   int32_t width;
   int32_t height;
@@ -23,15 +24,15 @@ static gboolean in_app_webview_copy_pixels(FlPixelBufferTexture* texture,
                                            uint32_t* height,
                                            GError** error) {
   InAppWebView* self = IN_APP_WEBVIEW(texture);
-  
+
   if (self->buffer == nullptr) {
       *width = 1;
       *height = 1;
-      static uint8_t dummy[4] = {255, 0, 0, 255}; 
+      static uint8_t dummy[4] = {255, 0, 0, 255};
       *buffer = dummy;
       return TRUE;
   }
-  
+
   *buffer = self->buffer;
   *width = self->width;
   *height = self->height;
@@ -72,7 +73,7 @@ static void in_app_webview_init(InAppWebView* self) {
     self->width = 1280;
     self->height = 720;
     self->buffer = (uint8_t*)g_malloc0(self->width * self->height * 4);
-    
+
     // Fill with blue for initial state
     for (int i = 0; i < self->width * self->height; i++) {
         self->buffer[i * 4] = 0;     // R
@@ -92,40 +93,40 @@ static void on_snapshot_ready(GObject* source_object, GAsyncResult* res, gpointe
     GError* error = nullptr;
     WebKitWebView* web_view = WEBKIT_WEB_VIEW(source_object);
     cairo_surface_t* surface = webkit_web_view_get_snapshot_finish(web_view, res, &error);
-    
+
     if (surface) {
         int width = cairo_image_surface_get_width(surface);
         int height = cairo_image_surface_get_height(surface);
         // int stride = cairo_image_surface_get_stride(surface); // Unused
         unsigned char* data = cairo_image_surface_get_data(surface);
-        
+
         if (width != self->width || height != self->height) {
             g_free(self->buffer);
             self->width = width;
             self->height = height;
             self->buffer = (uint8_t*)g_malloc0(width * height * 4);
         }
-        
+
         // Cairo uses ARGB or RGB24, usually premultiplied. Flutter expects RGBA.
         // WebKit snapshot is usually CAIRO_FORMAT_ARGB32 (premultiplied ARGB, host endian).
-        
+
         // Convert ARGB to RGBA
         for (int i = 0; i < width * height; i++) {
             // uint32_t* pixel = (uint32_t*)(data + i * 4);
-            
+
             uint8_t b = data[i * 4];
             uint8_t g = data[i * 4 + 1];
             uint8_t r = data[i * 4 + 2];
             uint8_t a = data[i * 4 + 3];
-            
+
             self->buffer[i * 4] = r;
             self->buffer[i * 4 + 1] = g;
             self->buffer[i * 4 + 2] = b;
             self->buffer[i * 4 + 3] = a;
         }
-        
+
         cairo_surface_destroy(surface);
-        
+
         // Notify texture updated
         fl_texture_registrar_mark_texture_frame_available(
             fl_plugin_registrar_get_texture_registrar(self->registrar),
@@ -136,7 +137,7 @@ static void on_snapshot_ready(GObject* source_object, GAsyncResult* res, gpointe
             g_error_free(error);
         }
     }
-    
+
     g_object_unref(self);
 }
 
@@ -161,20 +162,20 @@ InAppWebView* in_app_webview_new(FlPluginRegistrar* registrar, const char* id) {
   InAppWebView* self = IN_APP_WEBVIEW(g_object_new(IN_APP_WEBVIEW_TYPE, nullptr));
   self->registrar = registrar;
   self->id = g_strdup(id);
-  
+
   g_autofree gchar* channel_name = g_strdup_printf("dev.zuzu/zikzak_inappwebview_%s", id);
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
   self->channel = fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
                                         channel_name,
                                         FL_METHOD_CODEC(codec));
   fl_method_channel_set_method_call_handler(self->channel, in_app_webview_method_call_handler, g_object_ref(self), g_object_unref);
-  
+
   self->web_view = webkit_web_view_new();
   g_object_ref_sink(self->web_view);
-  
+
   // Connect load-changed signal
   g_signal_connect(self->web_view, "load-changed", G_CALLBACK(on_load_changed), self);
-  
+
   // Register texture
   FlTextureRegistrar* texture_registrar = fl_plugin_registrar_get_texture_registrar(registrar);
   if (fl_texture_registrar_register_texture(texture_registrar, FL_TEXTURE(self))) {
@@ -182,10 +183,10 @@ InAppWebView* in_app_webview_new(FlPluginRegistrar* registrar, const char* id) {
   } else {
       self->texture_id = 0;
   }
-  
+
   // Set initial size
   gtk_widget_set_size_request(self->web_view, 1280, 720);
-  
+
   return self;
 }
 
@@ -238,7 +239,7 @@ static void print_failed_callback(WebKitPrintOperation* operation, GError* error
 void in_app_webview_handle_method_call(InAppWebView* self, FlMethodCall* method_call) {
     const gchar* method = fl_method_call_get_name(method_call);
     FlValue* args = fl_method_call_get_args(method_call);
-    
+
     if (strcmp(method, "getUrl") == 0) {
         const gchar* uri = webkit_web_view_get_uri(WEBKIT_WEB_VIEW(self->web_view));
         g_autoptr(FlValue) result = uri ? fl_value_new_string(uri) : fl_value_new_null();
@@ -251,7 +252,7 @@ void in_app_webview_handle_method_call(InAppWebView* self, FlMethodCall* method_
                 FlMethodCall* method_call = FL_METHOD_CALL(user_data);
                 GError* error = nullptr;
                 WebKitJavascriptResult* js_result = webkit_web_view_run_javascript_finish(WEBKIT_WEB_VIEW(object), result, &error);
-                
+
                 if (!js_result) {
                     fl_method_call_respond(method_call, FL_METHOD_RESPONSE(fl_method_error_response_new("error", error->message, nullptr)), nullptr);
                     g_error_free(error);
@@ -285,27 +286,27 @@ void in_app_webview_handle_method_call(InAppWebView* self, FlMethodCall* method_
         fl_method_call_respond(method_call, FL_METHOD_RESPONSE(fl_method_error_response_new("error", "Invalid arguments", nullptr)), nullptr);
     } else if (strcmp(method, "createPdf") == 0) {
         WebKitPrintOperation* operation = webkit_print_operation_new(WEBKIT_WEB_VIEW(self->web_view));
-        
+
         GtkPrintSettings* settings = gtk_print_settings_new();
-        
+
         gchar* filename = g_strdup_printf("/tmp/flutter_inappwebview_print_%p_%ld.pdf", self, g_get_real_time());
         gchar* uri = g_strdup_printf("file://%s", filename);
-        
+
         gtk_print_settings_set(settings, GTK_PRINT_SETTINGS_OUTPUT_URI, uri);
         gtk_print_settings_set(settings, GTK_PRINT_SETTINGS_OUTPUT_FILE_FORMAT, "pdf");
-        
+
         webkit_print_operation_set_print_settings(operation, settings);
-        
+
         PrintContext* context = g_new(PrintContext, 1);
         context->method_call = method_call;
         g_object_ref(context->method_call);
         context->filename = filename;
-        
+
         g_signal_connect(operation, "finished", G_CALLBACK(print_finished_callback), context);
         g_signal_connect(operation, "failed", G_CALLBACK(print_failed_callback), context);
-        
+
         webkit_print_operation_print(operation);
-        
+
         g_object_unref(settings);
         g_free(uri);
         return;

--- a/zikzak_inappwebview_linux/linux/include/zikzak_inappwebview_linux/in_app_web_view_flutter_plugin.h
+++ b/zikzak_inappwebview_linux/linux/include/zikzak_inappwebview_linux/in_app_web_view_flutter_plugin.h
@@ -1,0 +1,22 @@
+#ifndef FLUTTER_PLUGIN_IN_APP_WEB_VIEW_FLUTTER_PLUGIN_H_
+#define FLUTTER_PLUGIN_IN_APP_WEB_VIEW_FLUTTER_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+#ifndef FLUTTER_PLUGIN_EXPORT
+#define FLUTTER_PLUGIN_EXPORT
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FLUTTER_PLUGIN_EXPORT void
+in_app_web_view_flutter_plugin_register_with_registrar(
+    FlPluginRegistrar *registrar);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // FLUTTER_PLUGIN_IN_APP_WEB_VIEW_FLUTTER_PLUGIN_H_

--- a/zikzak_inappwebview_linux/linux/include/zikzak_inappwebview_linux/zikzak_inappwebview_linux_plugin.h
+++ b/zikzak_inappwebview_linux/linux/include/zikzak_inappwebview_linux/zikzak_inappwebview_linux_plugin.h
@@ -18,9 +18,10 @@ typedef struct {
 
 FLUTTER_PLUGIN_EXPORT GType zikzak_inappwebview_linux_plugin_get_type();
 
-FLUTTER_PLUGIN_EXPORT void zikzak_inappwebview_linux_plugin_register_with_registrar(
-    FlPluginRegistrar* registrar);
+FLUTTER_PLUGIN_EXPORT void
+zikzak_inappwebview_linux_plugin_register_with_registrar(
+    FlPluginRegistrar *registrar);
 
 G_END_DECLS
 
-#endif  // FLUTTER_PLUGIN_ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN_H_
+#endif // FLUTTER_PLUGIN_ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN_H_

--- a/zikzak_inappwebview_linux/linux/zikzak_inappwebview_linux_plugin.cc
+++ b/zikzak_inappwebview_linux/linux/zikzak_inappwebview_linux_plugin.cc
@@ -1,5 +1,7 @@
 #include "include/zikzak_inappwebview_linux/zikzak_inappwebview_linux_plugin.h"
 
+#include <zikzak_inappwebview_linux/in_app_web_view_flutter_plugin.h>
+
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
 #include <sys/utsname.h>
@@ -7,49 +9,52 @@
 #include <cstring>
 #include <iostream>
 
-#include "zikzak_inappwebview_linux_plugin_private.h"
 #include "include/zikzak_inappwebview_linux/in_app_webview.h"
+#include "zikzak_inappwebview_linux_plugin_private.h"
 
-#define ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(obj) \
-  (G_TYPE_CHECK_INSTANCE_CAST((obj), zikzak_inappwebview_linux_plugin_get_type(), \
+#define ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(obj)                                  \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),                                           \
+                              zikzak_inappwebview_linux_plugin_get_type(),     \
                               ZikzakInappwebviewLinuxPlugin))
 
 struct _ZikzakInappwebviewLinuxPlugin {
   GObject parent_instance;
-  FlPluginRegistrar* registrar;
-  GHashTable* web_views;
+  FlPluginRegistrar *registrar;
+  GHashTable *web_views;
 };
 
-G_DEFINE_TYPE(ZikzakInappwebviewLinuxPlugin, zikzak_inappwebview_linux_plugin, g_object_get_type())
+G_DEFINE_TYPE(ZikzakInappwebviewLinuxPlugin, zikzak_inappwebview_linux_plugin,
+              g_object_get_type())
 
 // Called when a method call is received from Flutter.
 static void zikzak_inappwebview_linux_plugin_handle_method_call(
-    ZikzakInappwebviewLinuxPlugin* self,
-    FlMethodCall* method_call) {
+    ZikzakInappwebviewLinuxPlugin *self, FlMethodCall *method_call) {
   g_autoptr(FlMethodResponse) response = nullptr;
 
-  const gchar* method = fl_method_call_get_name(method_call);
-  FlValue* args = fl_method_call_get_args(method_call);
+  const gchar *method = fl_method_call_get_name(method_call);
+  FlValue *args = fl_method_call_get_args(method_call);
 
   if (strcmp(method, "getPlatformVersion") == 0) {
     response = get_platform_version();
   } else if (strcmp(method, "create") == 0) {
-      if (fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
-          FlValue* idVal = fl_value_lookup_string(args, "id");
-          if (idVal && fl_value_get_type(idVal) == FL_VALUE_TYPE_STRING) {
-              const char* id = fl_value_get_string(idVal);
-              
-              InAppWebView* webview = in_app_webview_new(self->registrar, id);
-              
-              g_hash_table_insert(self->web_views, g_strdup(id), webview);
-              
-              int64_t texture_id = in_app_webview_get_texture_id(webview);
-              response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_int(texture_id)));
-          }
+    if (fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
+      FlValue *idVal = fl_value_lookup_string(args, "id");
+      if (idVal && fl_value_get_type(idVal) == FL_VALUE_TYPE_STRING) {
+        const char *id = fl_value_get_string(idVal);
+
+        InAppWebView *webview = in_app_webview_new(self->registrar, id);
+
+        g_hash_table_insert(self->web_views, g_strdup(id), webview);
+
+        int64_t texture_id = in_app_webview_get_texture_id(webview);
+        response = FL_METHOD_RESPONSE(
+            fl_method_success_response_new(fl_value_new_int(texture_id)));
       }
-      if (!response) {
-         response = FL_METHOD_RESPONSE(fl_method_error_response_new("error", "Invalid arguments", nullptr));
-      }
+    }
+    if (!response) {
+      response = FL_METHOD_RESPONSE(
+          fl_method_error_response_new("error", "Invalid arguments", nullptr));
+    }
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }
@@ -57,41 +62,50 @@ static void zikzak_inappwebview_linux_plugin_handle_method_call(
   fl_method_call_respond(method_call, response, nullptr);
 }
 
-static void headless_method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call, gpointer user_data) {
-  ZikzakInappwebviewLinuxPlugin* self = ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(user_data);
+static void headless_method_call_cb(FlMethodChannel *channel,
+                                    FlMethodCall *method_call,
+                                    gpointer user_data) {
+  ZikzakInappwebviewLinuxPlugin *self =
+      ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(user_data);
   g_autoptr(FlMethodResponse) response = nullptr;
-  
-  const gchar* method = fl_method_call_get_name(method_call);
-  FlValue* args = fl_method_call_get_args(method_call);
-  
+
+  const gchar *method = fl_method_call_get_name(method_call);
+  FlValue *args = fl_method_call_get_args(method_call);
+
   if (strcmp(method, "createHeadless") == 0) {
-      if (fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
-          FlValue* idVal = fl_value_lookup_string(args, "id");
-          if (idVal && fl_value_get_type(idVal) == FL_VALUE_TYPE_STRING) {
-              const char* id = fl_value_get_string(idVal);
-              
-              InAppWebView* webview = in_app_webview_new(self->registrar, id);
-              g_hash_table_insert(self->web_views, g_strdup(id), webview);
-              
-              response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(true)));
-          }
+    if (fl_value_get_type(args) == FL_VALUE_TYPE_MAP) {
+      FlValue *idVal = fl_value_lookup_string(args, "id");
+      if (idVal && fl_value_get_type(idVal) == FL_VALUE_TYPE_STRING) {
+        const char *id = fl_value_get_string(idVal);
+
+        InAppWebView *webview = in_app_webview_new(self->registrar, id);
+        g_hash_table_insert(self->web_views, g_strdup(id), webview);
+
+        response = FL_METHOD_RESPONSE(
+            fl_method_success_response_new(fl_value_new_bool(true)));
       }
+    }
   } else {
-      response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+    response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
   }
-  
+
   if (!response) {
-     response = FL_METHOD_RESPONSE(fl_method_error_response_new("error", "Invalid arguments", nullptr));
+    response = FL_METHOD_RESPONSE(
+        fl_method_error_response_new("error", "Invalid arguments", nullptr));
   }
-  
+
   fl_method_call_respond(method_call, response, nullptr);
 }
 
-static void browser_method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call, gpointer user_data) {
-    fl_method_call_respond(method_call, FL_METHOD_RESPONSE(fl_method_not_implemented_response_new()), nullptr);
+static void browser_method_call_cb(FlMethodChannel *channel,
+                                   FlMethodCall *method_call,
+                                   gpointer user_data) {
+  fl_method_call_respond(
+      method_call, FL_METHOD_RESPONSE(fl_method_not_implemented_response_new()),
+      nullptr);
 }
 
-FlMethodResponse* get_platform_version() {
+FlMethodResponse *get_platform_version() {
   struct utsname uname_data = {};
   uname(&uname_data);
   g_autofree gchar *version = g_strdup_printf("Linux %s", uname_data.version);
@@ -99,60 +113,74 @@ FlMethodResponse* get_platform_version() {
   return FL_METHOD_RESPONSE(fl_method_success_response_new(result));
 }
 
-static void zikzak_inappwebview_linux_plugin_dispose(GObject* object) {
-  ZikzakInappwebviewLinuxPlugin* self = ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(object);
+static void zikzak_inappwebview_linux_plugin_dispose(GObject *object) {
+  ZikzakInappwebviewLinuxPlugin *self =
+      ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(object);
   if (self->web_views) {
-      g_hash_table_destroy(self->web_views);
+    g_hash_table_destroy(self->web_views);
   }
-  G_OBJECT_CLASS(zikzak_inappwebview_linux_plugin_parent_class)->dispose(object);
+  G_OBJECT_CLASS(zikzak_inappwebview_linux_plugin_parent_class)
+      ->dispose(object);
 }
 
-static void zikzak_inappwebview_linux_plugin_class_init(ZikzakInappwebviewLinuxPluginClass* klass) {
+static void zikzak_inappwebview_linux_plugin_class_init(
+    ZikzakInappwebviewLinuxPluginClass *klass) {
   G_OBJECT_CLASS(klass)->dispose = zikzak_inappwebview_linux_plugin_dispose;
 }
 
-static void zikzak_inappwebview_linux_plugin_init(ZikzakInappwebviewLinuxPlugin* self) {
-    self->web_views = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_object_unref);
+static void
+zikzak_inappwebview_linux_plugin_init(ZikzakInappwebviewLinuxPlugin *self) {
+  self->web_views =
+      g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_object_unref);
 }
 
-static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+static void method_call_cb(FlMethodChannel *channel, FlMethodCall *method_call,
                            gpointer user_data) {
-  ZikzakInappwebviewLinuxPlugin* plugin = ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(user_data);
+  ZikzakInappwebviewLinuxPlugin *plugin =
+      ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(user_data);
   zikzak_inappwebview_linux_plugin_handle_method_call(plugin, method_call);
 }
 
-void zikzak_inappwebview_linux_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
-  ZikzakInappwebviewLinuxPlugin* plugin = ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(
+void zikzak_inappwebview_linux_plugin_register_with_registrar(
+    FlPluginRegistrar *registrar) {
+  ZikzakInappwebviewLinuxPlugin *plugin = ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(
       g_object_new(zikzak_inappwebview_linux_plugin_get_type(), nullptr));
-  
+
   plugin->registrar = registrar;
 
   g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
-  g_autoptr(FlMethodChannel) channel =
-      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
-                            "zikzak_inappwebview_linux",
-                            FL_METHOD_CODEC(codec));
-  fl_method_channel_set_method_call_handler(channel, method_call_cb,
-                                            g_object_ref(plugin),
-                                            g_object_unref);
+  g_autoptr(FlMethodChannel) channel = fl_method_channel_new(
+      fl_plugin_registrar_get_messenger(registrar), "zikzak_inappwebview_linux",
+      FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(
+      channel, method_call_cb, g_object_ref(plugin), g_object_unref);
 
-  g_autoptr(FlStandardMethodCodec) headless_codec = fl_standard_method_codec_new();
+  g_autoptr(FlStandardMethodCodec) headless_codec =
+      fl_standard_method_codec_new();
   g_autoptr(FlMethodChannel) headless_channel =
       fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
                             "wtf.zikzak/flutter_headless_inappwebview",
                             FL_METHOD_CODEC(headless_codec));
-  fl_method_channel_set_method_call_handler(headless_channel, headless_method_call_cb,
-                                            g_object_ref(plugin),
-                                            g_object_unref);
+  fl_method_channel_set_method_call_handler(
+      headless_channel, headless_method_call_cb, g_object_ref(plugin),
+      g_object_unref);
 
-  g_autoptr(FlStandardMethodCodec) browser_codec = fl_standard_method_codec_new();
-  g_autoptr(FlMethodChannel) browser_channel =
-      fl_method_channel_new(fl_plugin_registrar_get_messenger(registrar),
-                            "dev.zuzu/flutter_inappbrowser",
-                            FL_METHOD_CODEC(browser_codec));
-  fl_method_channel_set_method_call_handler(browser_channel, browser_method_call_cb,
-                                            g_object_ref(plugin),
-                                            g_object_unref);
+  g_autoptr(FlStandardMethodCodec) browser_codec =
+      fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) browser_channel = fl_method_channel_new(
+      fl_plugin_registrar_get_messenger(registrar),
+      "dev.zuzu/flutter_inappbrowser", FL_METHOD_CODEC(browser_codec));
+  fl_method_channel_set_method_call_handler(
+      browser_channel, browser_method_call_cb, g_object_ref(plugin),
+      g_object_unref);
 
   g_object_unref(plugin);
+}
+
+// Compatibility wrapper for the legacy InAppWebViewFlutterPlugin naming
+// used by Flutter's generated_plugin_registrant.cc
+extern "C" FLUTTER_PLUGIN_EXPORT void
+in_app_web_view_flutter_plugin_register_with_registrar(
+    FlPluginRegistrar *registrar) {
+  zikzak_inappwebview_linux_plugin_register_with_registrar(registrar);
 }

--- a/zikzak_inappwebview_linux/pubspec.yaml
+++ b/zikzak_inappwebview_linux/pubspec.yaml
@@ -18,8 +18,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
-  zikzak_inappwebview_internal_annotations: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_internal_annotations:
+    path: ../zikzak_inappwebview_internal_annotations
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -7,76 +7,86 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     private var findInteractionChannel: FlutterMethodChannel!
     private var searchText: String?
     private var isDisposed = false
-    
-    init(registrar: FlutterPluginRegistrar, viewId: Any, arguments: Any?, channelName: String? = nil) {
+
+    init(
+        registrar: FlutterPluginRegistrar, viewId: Any, arguments: Any?, channelName: String? = nil
+    ) {
         let configuration = WKWebViewConfiguration()
         let userContentController = WKUserContentController()
         configuration.userContentController = userContentController
-        
+
         super.init(frame: .zero, configuration: configuration)
         self.navigationDelegate = self
         self.uiDelegate = self
-        
+
         userContentController.add(WeakScriptMessageHandler(delegate: self), name: "consoleHandler")
-        userContentController.add(WeakScriptMessageHandler(delegate: self), name: "onFindResultReceived")
-        
+        userContentController.add(
+            WeakScriptMessageHandler(delegate: self), name: "onFindResultReceived")
+
         let consoleOverrideScript = """
-        (function() {
-            var originalLog = console.log;
-            var originalDebug = console.debug;
-            var originalInfo = console.info;
-            var originalWarn = console.warn;
-            var originalError = console.error;
-            
-            function log(level, message) {
-                window.webkit.messageHandlers.consoleHandler.postMessage({
-                    "message": message,
-                    "messageLevel": level
-                });
-            }
-            console.log = function(message) { log("LOG", message); if (originalLog) originalLog.call(console, message); };
-            console.debug = function(message) { log("DEBUG", message); if (originalDebug) originalDebug.call(console, message); };
-            console.info = function(message) { log("INFO", message); if (originalInfo) originalInfo.call(console, message); };
-            console.warn = function(message) { log("WARNING", message); if (originalWarn) originalWarn.call(console, message); };
-            console.error = function(message) { log("ERROR", message); if (originalError) originalError.call(console, message); };
-        })();
-        """
-        let userScript = WKUserScript(source: consoleOverrideScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
+            (function() {
+                var originalLog = console.log;
+                var originalDebug = console.debug;
+                var originalInfo = console.info;
+                var originalWarn = console.warn;
+                var originalError = console.error;
+
+                function log(level, message) {
+                    window.webkit.messageHandlers.consoleHandler.postMessage({
+                        "message": message,
+                        "messageLevel": level
+                    });
+                }
+                console.log = function(message) { log("LOG", message); if (originalLog) originalLog.call(console, message); };
+                console.debug = function(message) { log("DEBUG", message); if (originalDebug) originalDebug.call(console, message); };
+                console.info = function(message) { log("INFO", message); if (originalInfo) originalInfo.call(console, message); };
+                console.warn = function(message) { log("WARNING", message); if (originalWarn) originalWarn.call(console, message); };
+                console.error = function(message) { log("ERROR", message); if (originalError) originalError.call(console, message); };
+            })();
+            """
+        let userScript = WKUserScript(
+            source: consoleOverrideScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         userContentController.addUserScript(userScript)
-        
-        let findInteractionUserScript = WKUserScript(source: FIND_TEXT_HIGHLIGHT_JS_SOURCE, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+
+        let findInteractionUserScript = WKUserScript(
+            source: FIND_TEXT_HIGHLIGHT_JS_SOURCE, injectionTime: .atDocumentStart,
+            forMainFrameOnly: true)
         userContentController.addUserScript(findInteractionUserScript)
-        
+
         let finalChannelName = channelName ?? "dev.zuzu/zikzak_inappwebview_\(viewId)"
         channel = FlutterMethodChannel(name: finalChannelName, binaryMessenger: registrar.messenger)
         channel.setMethodCallHandler(self.handle)
-        
+
         let findInteractionChannelName = "wtf.zikzak/zikzak_inappwebview_find_interaction_\(viewId)"
-        findInteractionChannel = FlutterMethodChannel(name: findInteractionChannelName, binaryMessenger: registrar.messenger)
+        findInteractionChannel = FlutterMethodChannel(
+            name: findInteractionChannelName, binaryMessenger: registrar.messenger)
         findInteractionChannel.setMethodCallHandler(self.handleFindInteraction)
-        
+
         if let args = arguments as? [String: Any] {
             if let initialUrlRequest = args["initialUrlRequest"] as? [String: Any],
-               let urlString = initialUrlRequest["url"] as? String,
-               let url = URL(string: urlString) {
+                let urlString = initialUrlRequest["url"] as? String,
+                let url = URL(string: urlString)
+            {
                 let request = URLRequest(url: url)
                 self.load(request)
             }
         }
-        
+
         self.addObserver(self, forKeyPath: "estimatedProgress", options: .new, context: nil)
         self.addObserver(self, forKeyPath: "url", options: .new, context: nil)
         self.addObserver(self, forKeyPath: "title", options: .new, context: nil)
     }
-    
+
     deinit {
         dispose()
     }
-    
+
     public func dispose() {
         if !isDisposed {
-            self.configuration.userContentController.removeScriptMessageHandler(forName: "consoleHandler")
-            self.configuration.userContentController.removeScriptMessageHandler(forName: "onFindResultReceived")
+            self.configuration.userContentController.removeScriptMessageHandler(
+                forName: "consoleHandler")
+            self.configuration.userContentController.removeScriptMessageHandler(
+                forName: "onFindResultReceived")
             self.removeObserver(self, forKeyPath: "estimatedProgress")
             self.removeObserver(self, forKeyPath: "url")
             self.removeObserver(self, forKeyPath: "title")
@@ -85,32 +95,37 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             isDisposed = true
         }
     }
-    
+
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
-    
-    public override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+
+    public override func observeValue(
+        forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?,
+        context: UnsafeMutableRawPointer?
+    ) {
+        guard !isDisposed else { return }
+
         if keyPath == "estimatedProgress" {
             let progress = Int(self.estimatedProgress * 100)
-            channel.invokeMethod("onProgressChanged", arguments: ["progress": progress])
+            channel?.invokeMethod("onProgressChanged", arguments: ["progress": progress])
         } else if keyPath == "url" {
             var arguments: [String: Any] = ["isReload": false]
             if let url = self.url?.absoluteString {
                 arguments["url"] = url
             }
-            channel.invokeMethod("onUpdateVisitedHistory", arguments: arguments)
+            channel?.invokeMethod("onUpdateVisitedHistory", arguments: arguments)
         } else if keyPath == "title" {
             var arguments: [String: Any] = [:]
             if let title = self.title {
                 arguments["title"] = title
             }
-            channel.invokeMethod("onTitleChanged", arguments: arguments)
+            channel?.invokeMethod("onTitleChanged", arguments: arguments)
         } else {
             super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
         }
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "getUrl":
@@ -121,23 +136,27 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             result(Int(self.estimatedProgress * 100))
         case "loadUrl":
             if let args = call.arguments as? [String: Any],
-               let urlRequest = args["urlRequest"] as? [String: Any],
-               let urlString = urlRequest["url"] as? String,
-               let url = URL(string: urlString) {
+                let urlRequest = args["urlRequest"] as? [String: Any],
+                let urlString = urlRequest["url"] as? String,
+                let url = URL(string: urlString)
+            {
                 let request = URLRequest(url: url)
                 self.load(request)
                 result(true)
             } else {
-                result(FlutterError(code: "InAppWebView", message: "Invalid arguments", details: nil))
+                result(
+                    FlutterError(code: "InAppWebView", message: "Invalid arguments", details: nil))
             }
         case "loadData":
             if let args = call.arguments as? [String: Any],
-               let data = args["data"] as? String,
-               let baseUrl = args["baseUrl"] as? String {
+                let data = args["data"] as? String,
+                let baseUrl = args["baseUrl"] as? String
+            {
                 self.loadHTMLString(data, baseURL: URL(string: baseUrl))
                 result(true)
             } else {
-                result(FlutterError(code: "InAppWebView", message: "Invalid arguments", details: nil))
+                result(
+                    FlutterError(code: "InAppWebView", message: "Invalid arguments", details: nil))
             }
         case "reload":
             self.reload()
@@ -164,7 +183,10 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         case "getHtml":
             self.evaluateJavaScript("document.documentElement.outerHTML") { (value, error) in
                 if let error = error {
-                    result(FlutterError(code: "InAppWebView", message: error.localizedDescription, details: nil))
+                    result(
+                        FlutterError(
+                            code: "InAppWebView", message: error.localizedDescription, details: nil)
+                    )
                 } else {
                     result(value)
                 }
@@ -173,7 +195,8 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             if #available(macOS 11.0, *) {
                 let pdfConfiguration = WKPDFConfiguration()
                 if let args = call.arguments as? [String: Any],
-                   let configMap = args["pdfConfiguration"] as? [String: Any] {
+                    let configMap = args["pdfConfiguration"] as? [String: Any]
+                {
                     if let rectMap = configMap["rect"] as? [String: Double] {
                         let x = rectMap["x"] ?? 0
                         let y = rectMap["y"] ?? 0
@@ -182,13 +205,13 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                         pdfConfiguration.rect = CGRect(x: x, y: y, width: width, height: height)
                     }
                 }
-                
+
                 self.createPDF(configuration: pdfConfiguration) { res in
                     switch res {
                     case .success(let data):
                         result(data)
                     case .failure(_):
-                result(nil)
+                        result(nil)
                     }
                 }
             } else {
@@ -198,7 +221,8 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             if #available(macOS 10.13, *) {
                 var snapshotConfiguration: WKSnapshotConfiguration? = nil
                 if let args = call.arguments as? [String: Any],
-                   let configMap = args["screenshotConfiguration"] as? [String: Any?] {
+                    let configMap = args["screenshotConfiguration"] as? [String: Any?]
+                {
                     snapshotConfiguration = WKSnapshotConfiguration()
                     if let rectMap = configMap["rect"] as? [String: Double] {
                         snapshotConfiguration!.rect = CGRect(
@@ -215,34 +239,41 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                         snapshotConfiguration!.afterScreenUpdates = afterScreenUpdates
                     }
                 }
-                
+
                 self.takeSnapshot(with: snapshotConfiguration) { (image, error) -> Void in
                     var imageData: Data? = nil
                     if let screenshot = image {
-                        if let configMap = (call.arguments as? [String: Any])?["screenshotConfiguration"] as? [String: Any?] {
+                        if let configMap = (call.arguments as? [String: Any])?[
+                            "screenshotConfiguration"] as? [String: Any?]
+                        {
                             let compressFormat = configMap["compressFormat"] as? String ?? "PNG"
                             switch compressFormat {
                             case "JPEG":
                                 let quality = Float((configMap["quality"] as? Int) ?? 100) / 100.0
                                 if let tiffData = screenshot.tiffRepresentation,
-                                   let bitmapRep = NSBitmapImageRep(data: tiffData) {
+                                    let bitmapRep = NSBitmapImageRep(data: tiffData)
+                                {
                                     let properties: [NSBitmapImageRep.PropertyKey: Any] = [
                                         .compressionFactor: quality
                                     ]
-                                    imageData = bitmapRep.representation(using: .jpeg, properties: properties)
+                                    imageData = bitmapRep.representation(
+                                        using: .jpeg, properties: properties)
                                 }
                                 break
                             case "PNG":
                                 fallthrough
                             default:
                                 if let tiffData = screenshot.tiffRepresentation,
-                                   let bitmapRep = NSBitmapImageRep(data: tiffData) {
-                                    imageData = bitmapRep.representation(using: .png, properties: [:])
+                                    let bitmapRep = NSBitmapImageRep(data: tiffData)
+                                {
+                                    imageData = bitmapRep.representation(
+                                        using: .png, properties: [:])
                                 }
                             }
                         } else {
                             if let tiffData = screenshot.tiffRepresentation,
-                               let bitmapRep = NSBitmapImageRep(data: tiffData) {
+                                let bitmapRep = NSBitmapImageRep(data: tiffData)
+                            {
                                 imageData = bitmapRep.representation(using: .png, properties: [:])
                             }
                         }
@@ -254,35 +285,47 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             }
         case "evaluateJavascript":
             if let args = call.arguments as? [String: Any],
-               let source = args["source"] as? String {
+                let source = args["source"] as? String
+            {
                 self.evaluateJavaScript(source) { (value, error) in
                     if let error = error {
-                        result(FlutterError(code: "InAppWebView", message: error.localizedDescription, details: nil))
+                        result(
+                            FlutterError(
+                                code: "InAppWebView", message: error.localizedDescription,
+                                details: nil))
                     } else {
                         result(value)
                     }
                 }
             } else {
-                 result(FlutterError(code: "InAppWebView", message: "Invalid arguments", details: nil))
+                result(
+                    FlutterError(code: "InAppWebView", message: "Invalid arguments", details: nil))
             }
         default:
             result(FlutterMethodNotImplemented)
         }
     }
 
-    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-        channel.invokeMethod("onLoadStart", arguments: ["url": webView.url?.absoluteString])
+    public func webView(
+        _ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!
+    ) {
+        channel?.invokeMethod("onLoadStart", arguments: ["url": webView.url?.absoluteString])
     }
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        channel.invokeMethod("onLoadStop", arguments: ["url": webView.url?.absoluteString])
+        channel?.invokeMethod("onLoadStop", arguments: ["url": webView.url?.absoluteString])
     }
 
-    public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+    public func webView(
+        _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error
+    ) {
         onReceivedError(error: error)
     }
 
-    public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+    public func webView(
+        _ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
         onReceivedError(error: error)
     }
 
@@ -291,15 +334,17 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         arguments["url"] = self.url?.absoluteString
         arguments["code"] = (error as NSError).code
         arguments["message"] = error.localizedDescription
-        channel.invokeMethod("onReceivedError", arguments: arguments)
+        channel?.invokeMethod("onReceivedError", arguments: arguments)
     }
-    
-    public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+
+    public func userContentController(
+        _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
+    ) {
         if message.name == "consoleHandler", let body = message.body as? [String: Any] {
             var arguments: [String: Any] = [:]
             arguments["message"] = body["message"] as? String
-            
-            var level = 1 // LOG
+
+            var level = 1  // LOG
             if let messageLevel = body["messageLevel"] as? String {
                 switch messageLevel {
                 case "LOG":
@@ -317,12 +362,13 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                 }
             }
             arguments["messageLevel"] = level
-            channel.invokeMethod("onConsoleMessage", arguments: arguments)
-        } else if message.name == "onFindResultReceived", let body = message.body as? [String: Any] {
-            findInteractionChannel.invokeMethod("onFindResultReceived", arguments: body)
+            channel?.invokeMethod("onConsoleMessage", arguments: arguments)
+        } else if message.name == "onFindResultReceived", let body = message.body as? [String: Any]
+        {
+            findInteractionChannel?.invokeMethod("onFindResultReceived", arguments: body)
         }
     }
-    
+
     public func handleFindInteraction(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "findAll":
@@ -332,36 +378,41 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             }
             result(true)
         case "findNext":
-             if let args = call.arguments as? [String: Any], let forward = args["forward"] as? Bool {
+            if let args = call.arguments as? [String: Any], let forward = args["forward"] as? Bool {
                 let js = "window.\(JAVASCRIPT_BRIDGE_NAME)._findNext(\(forward));"
                 self.evaluateJavaScript(js, completionHandler: nil)
-             }
-             result(true)
+            }
+            result(true)
         case "clearMatches":
-             let js = "window.\(JAVASCRIPT_BRIDGE_NAME)._clearMatches();"
-             self.evaluateJavaScript(js, completionHandler: nil)
-             result(true)
+            let js = "window.\(JAVASCRIPT_BRIDGE_NAME)._clearMatches();"
+            self.evaluateJavaScript(js, completionHandler: nil)
+            result(true)
         case "setSearchText":
-             if let args = call.arguments as? [String: Any], let searchText = args["searchText"] as? String {
+            if let args = call.arguments as? [String: Any],
+                let searchText = args["searchText"] as? String
+            {
                 self.searchText = searchText
-             }
-             result(true)
+            }
+            result(true)
         case "getSearchText":
-             result(self.searchText)
+            result(self.searchText)
         default:
-             result(FlutterMethodNotImplemented)
+            result(FlutterMethodNotImplemented)
         }
     }
-    
-    public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+
+    public func webView(
+        _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
         var arguments: [String: Any] = [:]
         let request: [String: Any] = [
             "url": navigationAction.request.url?.absoluteString ?? "",
             "method": navigationAction.request.httpMethod ?? "GET",
-            "headers": navigationAction.request.allHTTPHeaderFields ?? [:]
+            "headers": navigationAction.request.allHTTPHeaderFields ?? [:],
         ]
         // body is skipped for now
-        
+
         let sourceFrame: [String: Any] = [
             "isMainFrame": navigationAction.sourceFrame.isMainFrame,
             "request": [
@@ -370,10 +421,10 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             "securityOrigin": [
                 "host": navigationAction.sourceFrame.securityOrigin.host,
                 "port": navigationAction.sourceFrame.securityOrigin.port,
-                "protocol": navigationAction.sourceFrame.securityOrigin.protocol
-            ]
+                "protocol": navigationAction.sourceFrame.securityOrigin.protocol,
+            ],
         ]
-        
+
         var targetFrame: [String: Any] = [:]
         if let target = navigationAction.targetFrame {
             targetFrame["isMainFrame"] = target.isMainFrame
@@ -381,43 +432,32 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             targetFrame["securityOrigin"] = [
                 "host": target.securityOrigin.host,
                 "port": target.securityOrigin.port,
-                "protocol": target.securityOrigin.protocol
+                "protocol": target.securityOrigin.protocol,
             ]
         }
-        
+
         arguments["navigationAction"] = [
             "request": request,
             "isForMainFrame": navigationAction.targetFrame?.isMainFrame ?? false,
-            "hasGesture": navigationAction.navigationType == .linkActivated || navigationAction.navigationType == .formSubmitted,
+            "hasGesture": navigationAction.navigationType == .linkActivated
+                || navigationAction.navigationType == .formSubmitted,
             "isRedirect": false,
             "navigationType": navigationAction.navigationType.rawValue,
             "sourceFrame": sourceFrame,
-            "targetFrame": targetFrame
+            "targetFrame": targetFrame,
         ]
-        
-        channel.invokeMethod("shouldOverrideUrlLoading", arguments: arguments) { result in
-                    if let result = result as? Int {
-                        if result == 0 {
-                            decisionHandler(.cancel)
-                            return
-                        } else if result == 1 {
-                            decisionHandler(.allow)
-                            return
-                        } else if result == 2 {
-                            if #available(macOS 11.3, *) {
-                                decisionHandler(.download)
-                            } else {
-                                decisionHandler(.cancel)
-                            }
-                            return
-                        }
-                    }
-                    decisionHandler(.allow)
-                }
+
+        channel?.invokeMethod("shouldOverrideUrlLoading", arguments: arguments)
+        decisionHandler(.allow)
     }
 
-    public func webView(_ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse, decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void) {
-        if let response = navigationResponse.response as? HTTPURLResponse, response.statusCode >= 400 {
+    public func webView(
+        _ webView: WKWebView, decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        if let response = navigationResponse.response as? HTTPURLResponse,
+            response.statusCode >= 400
+        {
             var arguments: [String: Any] = [:]
             arguments["request"] = [
                 "url": response.url?.absoluteString ?? ""
@@ -425,20 +465,23 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             arguments["errorResponse"] = [
                 "statusCode": response.statusCode,
                 "reasonPhrase": HTTPURLResponse.localizedString(forStatusCode: response.statusCode),
-                "headers": response.allHeaderFields
+                "headers": response.allHeaderFields,
             ]
-            channel.invokeMethod("onReceivedHttpError", arguments: arguments)
+            channel?.invokeMethod("onReceivedHttpError", arguments: arguments)
         }
         decisionHandler(.allow)
     }
-    
-    public func webView(_ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void) {
+
+    public func webView(
+        _ webView: WKWebView, runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping () -> Void
+    ) {
         var arguments: [String: Any] = [:]
         arguments["message"] = message
         arguments["url"] = frame.request.url?.absoluteString ?? ""
         arguments["isMainFrame"] = frame.isMainFrame
         arguments["iosIsMainFrame"] = frame.isMainFrame
-        
+
         channel.invokeMethod("onJsAlert", arguments: arguments) { result in
             if let result = result as? [String: Any] {
                 let handledByClient = result["handledByClient"] as? Bool ?? false
@@ -449,16 +492,19 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                     alert.runModal()
                 }
             } else {
-                 let alert = NSAlert()
-                 alert.messageText = message
-                 alert.addButton(withTitle: "OK")
-                 alert.runModal()
+                let alert = NSAlert()
+                alert.messageText = message
+                alert.addButton(withTitle: "OK")
+                alert.runModal()
             }
             completionHandler()
         }
     }
-    
-    public func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
+
+    public func webView(
+        _ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void
+    ) {
         var arguments: [String: Any] = [:]
         arguments["message"] = message
         arguments["url"] = frame.request.url?.absoluteString ?? ""
@@ -489,8 +535,12 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             }
         }
     }
-    
-    public func webView(_ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String, defaultText: String?, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (String?) -> Void) {
+
+    public func webView(
+        _ webView: WKWebView, runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?, initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping (String?) -> Void
+    ) {
         var arguments: [String: Any] = [:]
         arguments["message"] = prompt
         arguments["defaultValue"] = defaultText
@@ -506,11 +556,11 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                     alert.messageText = prompt
                     alert.addButton(withTitle: "OK")
                     alert.addButton(withTitle: "Cancel")
-                    
+
                     let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
                     input.stringValue = defaultText ?? ""
                     alert.accessoryView = input
-                    
+
                     let res = alert.runModal()
                     if res == .alertFirstButtonReturn {
                         completionHandler(input.stringValue)
@@ -531,11 +581,11 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                 alert.messageText = prompt
                 alert.addButton(withTitle: "OK")
                 alert.addButton(withTitle: "Cancel")
-                
+
                 let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
                 input.stringValue = defaultText ?? ""
                 alert.accessoryView = input
-                
+
                 let res = alert.runModal()
                 if res == .alertFirstButtonReturn {
                     completionHandler(input.stringValue)

--- a/zikzak_inappwebview_macos/pubspec.lock
+++ b/zikzak_inappwebview_macos/pubspec.lock
@@ -211,18 +211,16 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: c0432ea3eee7cb2dfec36eae7afb19bbe04fd82314ec4040e236120d4f7e4152
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: d7ee03c83bfb767155f66ca1476a115cb31d983aafd7f402da5c9a3ffa79a3ce
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.2.4"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview_macos/pubspec.yaml
+++ b/zikzak_inappwebview_macos/pubspec.yaml
@@ -18,7 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_platform_interface/pubspec.yaml
+++ b/zikzak_inappwebview_platform_interface/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  zikzak_inappwebview_internal_annotations: ^4.2.4
+  zikzak_inappwebview_internal_annotations:
+    path: ../zikzak_inappwebview_internal_annotations
   meta: ^1.15.0
 
 dev_dependencies:

--- a/zikzak_inappwebview_web/pubspec.lock
+++ b/zikzak_inappwebview_web/pubspec.lock
@@ -224,18 +224,16 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: c0432ea3eee7cb2dfec36eae7afb19bbe04fd82314ec4040e236120d4f7e4152
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: d7ee03c83bfb767155f66ca1476a115cb31d983aafd7f402da5c9a3ffa79a3ce
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.2.4"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview_web/pubspec.yaml
+++ b/zikzak_inappwebview_web/pubspec.yaml
@@ -20,7 +20,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
   web: ^1.1.1
 
 dev_dependencies:

--- a/zikzak_inappwebview_windows/pubspec.lock
+++ b/zikzak_inappwebview_windows/pubspec.lock
@@ -219,18 +219,16 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: c0432ea3eee7cb2dfec36eae7afb19bbe04fd82314ec4040e236120d4f7e4152
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.2.4"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: d7ee03c83bfb767155f66ca1476a115cb31d983aafd7f402da5c9a3ffa79a3ce
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.2.4"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview_windows/pubspec.yaml
+++ b/zikzak_inappwebview_windows/pubspec.yaml
@@ -19,7 +19,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.2.4
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
   webview_windows: ^0.4.0
   path: ^1.9.0
 


### PR DESCRIPTION
## 4.3.0 Release

### iOS/macOS Fixes

- **Fixed: iOS `onCreateWindow` not respecting client return value (#107)** — `createWebViewWith` now returns `nil` when the Flutter callback indicates the client handles window creation (`handledByClient = true`). Uses semaphore + run loop pumping to wait for the async callback.
- **Fixed: iOS crash on `InAppWebView.dispose()` when KVO observers fire after disposal (#120, #129)** — added `isDisposed` guard to `observeValue`, made `dispose()` idempotent with `isDisposed = true`, added `dispose()` call in `deinit`.
- **Fixed: macOS SIGSEGV crash (#126)** — added `isDisposed` guard to `observeValue`, added optional chaining on `channel?.invokeMethod` calls.

### Other Changes

- Updated CHANGELOG.md with 4.3.0 entry
- Android: various fixes and updates
- Linux: build fixes, CMakeLists, header cleanup
- Platform interface: dependency updates
- Web/Windows: dependency updates
- Example apps: synced Podfile and pubspec.lock
- Bumped minimum iOS build version to 16.0
- Reorganized imports in WebAuthenticationSession.swift
- Updated to local path dependencies for development

Closes #107, Closes #120, Closes #126, Closes #129