### PR TITLE
4.3.1: additional iOS/macOS fixes — WebAuthn, toolbar crash, frame drift, deadlock, and more

### DIFF
--- a/dev_packages/generators/pubspec.yaml
+++ b/dev_packages/generators/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: none
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:

--- a/zikzak_inappwebview/CHANGELOG.md
+++ b/zikzak_inappwebview/CHANGELOG.md
@@ -8,6 +8,21 @@
   `isDisposed = true`, added `dispose()` call in `deinit` (#120, #129)
 - Fixed: macOS SIGSEGV crash in `callAsyncJavaScript` — added `isDisposed` guard to
   `observeValue`, added optional chaining on `channel?.invokeMethod` calls (#126)
+- Fixed: iOS Passkey/WebAuthn support — wired `webAuthenticationSupport` setting into
+  native `WKWebViewWebAuthenticationSupport.boundKeychainForPasskeys` on iOS 16.4+ (#131)
+- Fixed: macOS 26 crash in AppKit NSToolbar when InAppBrowser window closes — added
+  `isClosing` guard and `window?.delegate = nil` before teardown (#87)
+- Fixed: macOS WebView native frame drift with fractional platform view widths —
+  overrode `layout()` to explicitly sync frame from superview bounds (#93)
+- Fixed: iOS `shouldOverrideUrlLoading` deadlock when adding custom headers — added
+  `isNavigatingWithCustomAction` flag to prevent re-entrant navigation callbacks (#132)
+- Fixed: `InAppLocalhostServer` fails after app resumes from background — added
+  `AppLifecycleListener` to close and reset server state on resume (#113)
+- Fixed: `build_runner` fails due to missing `generators` package — added as dev_dependency
+  in platform_interface pubspec (#139)
+- Feature: `WebAuthenticationSession` now supports `additionalHeaderFields` for custom
+  HTTP headers — available on iOS 17.4+ (#100)
+- Chore: Raised minimum Flutter version from 3.29.0 to 3.38.6 for iOS touch fix (#128)
 - Chore: Updated minimum iOS build version to 16.0
 
 ## 4.2.4 - 2026-06-03

--- a/zikzak_inappwebview/CHANGELOG.md
+++ b/zikzak_inappwebview/CHANGELOG.md
@@ -1,13 +1,5 @@
-## 4.3.0 - 2026-06-03
+## 4.3.1 - 2026-06-03
 
-- Fixed: iOS `onCreateWindow` not respecting client return value — now returns `nil` when
-  the client handles the window creation, preventing WebKit from creating an unused
-  window WebView (#107)
-- Fixed: iOS crash on `InAppWebView.dispose()` when KVO observers fire after disposal —
-  added `isDisposed` guard to `observeValue`, made `dispose()` idempotent with
-  `isDisposed = true`, added `dispose()` call in `deinit` (#120, #129)
-- Fixed: macOS SIGSEGV crash in `callAsyncJavaScript` — added `isDisposed` guard to
-  `observeValue`, added optional chaining on `channel?.invokeMethod` calls (#126)
 - Fixed: iOS Passkey/WebAuthn support — wired `webAuthenticationSupport` setting into
   native `WKWebViewWebAuthenticationSupport.boundKeychainForPasskeys` on iOS 16.4+ (#131)
 - Fixed: macOS 26 crash in AppKit NSToolbar when InAppBrowser window closes — added
@@ -23,6 +15,17 @@
 - Feature: `WebAuthenticationSession` now supports `additionalHeaderFields` for custom
   HTTP headers — available on iOS 17.4+ (#100)
 - Chore: Raised minimum Flutter version from 3.29.0 to 3.38.6 for iOS touch fix (#128)
+
+## 4.3.0 - 2026-06-03
+
+- Fixed: iOS `onCreateWindow` not respecting client return value — now returns `nil` when
+  the client handles the window creation, preventing WebKit from creating an unused
+  window WebView (#107)
+- Fixed: iOS crash on `InAppWebView.dispose()` when KVO observers fire after disposal —
+  added `isDisposed` guard to `observeValue`, made `dispose()` idempotent with
+  `isDisposed = true`, added `dispose()` call in `deinit` (#120, #129)
+- Fixed: macOS SIGSEGV crash in `callAsyncJavaScript` — added `isDisposed` guard to
+  `observeValue`, added optional chaining on `channel?.invokeMethod` calls (#126)
 - Chore: Updated minimum iOS build version to 16.0
 
 ## 4.2.4 - 2026-06-03

--- a/zikzak_inappwebview/example/pubspec.lock
+++ b/zikzak_inappwebview/example/pubspec.lock
@@ -486,66 +486,58 @@ packages:
   zikzak_inappwebview_android:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_android
-      sha256: "459348fd6081c0943e40eaa585dc3abdd4d75220ae6b9fd3c660d66e8ebf1ebf"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_android"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: "922bd14f5bbcb81820021fae7612b64692fff9b8d70ff4b75224cd83b13b76f6"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_ios:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_ios
-      sha256: "437e77d736e86bc7d7e930170986fa1b74309ee5f0361423186991585a3ed0b6"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_ios"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_linux:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_linux
-      sha256: "0cd54894c74b2cc6d36241aa6fddcf1d63685c666aecb0968d9691ec8aa35c77"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_linux"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_macos:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_macos
-      sha256: "7335b7caaac97268ce745dc391a8a784e7f0962a20c374f88f06cfdaa6d0761b"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_macos"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_platform_interface:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: "126dc9a7f6a746820e06c678d6e0c5f08dc6393212ea5901c2d89c19ed6f41bc"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_web:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_web
-      sha256: bcf05ce40bbb27b50665925fc7ced42d61b69dd596af6a0d86e930470d9e6b24
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_web"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_windows:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_windows
-      sha256: eaa1d4e2f86b96c9e65af1be97a87e96f1d6621d17af20f183d9527e742361d7
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_windows"
+      relative: true
+    source: path
     version: "4.3.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview/pubspec.yaml
+++ b/zikzak_inappwebview/pubspec.yaml
@@ -13,18 +13,25 @@ topics:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
-  zikzak_inappwebview_android: ^4.3.0
-  zikzak_inappwebview_ios: ^4.3.0
-  zikzak_inappwebview_macos: ^4.3.0
-  zikzak_inappwebview_web: ^4.3.0
-  zikzak_inappwebview_windows: ^4.3.0
-  zikzak_inappwebview_linux: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_android:
+    path: ../zikzak_inappwebview_android
+  zikzak_inappwebview_ios:
+    path: ../zikzak_inappwebview_ios
+  zikzak_inappwebview_macos:
+    path: ../zikzak_inappwebview_macos
+  zikzak_inappwebview_web:
+    path: ../zikzak_inappwebview_web
+  zikzak_inappwebview_windows:
+    path: ../zikzak_inappwebview_windows
+  zikzak_inappwebview_linux:
+    path: ../zikzak_inappwebview_linux
 
 dev_dependencies:
   flutter_test:
@@ -92,4 +99,3 @@ flutter:
 false_secrets:
   - /test_node_server/*.pem
   - /test_node_server/*.pfx
-

--- a/zikzak_inappwebview_android/pubspec.yaml
+++ b/zikzak_inappwebview_android/pubspec.yaml
@@ -13,12 +13,13 @@ topics:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -71,6 +71,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
 
     fileprivate var interceptOnlyAsyncAjaxRequestsPluginScript: PluginScript?
 
+    var isNavigatingWithCustomAction = false
+
     init(
         id: Any?, plugin: SwiftFlutterPlugin?, frame: CGRect, configuration: WKWebViewConfiguration,
         contextMenu: [String: Any]?, userScripts: [UserScript] = []
@@ -1051,6 +1053,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     }
 
     public func loadUrl(urlRequest: URLRequest, allowingReadAccessTo: URL?) {
+        isNavigatingWithCustomAction = true
         let url = urlRequest.url!
 
         if #available(iOS 9.0, *), let allowingReadAccessTo = allowingReadAccessTo,
@@ -2191,6 +2194,11 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
+        if isNavigatingWithCustomAction {
+            isNavigatingWithCustomAction = false
+            decisionHandler(.allow)
+            return
+        }
         var decisionHandlerCalled = false
         let callback = WebViewChannelDelegate.ShouldOverrideUrlLoadingCallback()
         callback.nonNullSuccess = { (response: WKNavigationActionPolicy) in

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -57,6 +57,9 @@ public class WebAuthenticationSession: NSObject, ASWebAuthenticationPresentation
         if #available(iOS 13.0, *), let session = session as? ASWebAuthenticationSession {
             session.prefersEphemeralWebBrowserSession = settings.prefersEphemeralWebBrowserSession
         }
+        if #available(iOS 17.4, *), let session = session as? ASWebAuthenticationSession {
+            session.additionalHeaderFields = settings.additionalHeaderFields
+        }
     }
 
     public func completionHandler(url: URL?, error: Error?) {

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSessionSettings.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/WebAuthenticationSession/WebAuthenticationSessionSettings.swift
@@ -11,18 +11,22 @@ import SafariServices
 
 @objcMembers
 public class WebAuthenticationSessionSettings: ISettings<WebAuthenticationSession> {
-    
+
     var prefersEphemeralWebBrowserSession = false
-    
+    var additionalHeaderFields: [String: String]?
+
     override init(){
         super.init()
     }
-    
+
     override func getRealSettings(obj: WebAuthenticationSession?) -> [String: Any?] {
         var realOptions: [String: Any?] = toMap()
         if #available(iOS 12.0, *), let session = obj?.session as? ASWebAuthenticationSession {
             if #available(iOS 13.0, *) {
                 realOptions["prefersEphemeralWebBrowserSession"] = session.prefersEphemeralWebBrowserSession
+            }
+            if #available(iOS 17.4, *) {
+                realOptions["additionalHeaderFields"] = session.additionalHeaderFields
             }
         }
         return realOptions

--- a/zikzak_inappwebview_ios/pubspec.yaml
+++ b/zikzak_inappwebview_ios/pubspec.yaml
@@ -13,12 +13,13 @@ topics:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_linux/example/pubspec.lock
+++ b/zikzak_inappwebview_linux/example/pubspec.lock
@@ -274,10 +274,9 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: "922bd14f5bbcb81820021fae7612b64692fff9b8d70ff4b75224cd83b13b76f6"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_linux:
     dependency: "direct main"
@@ -289,10 +288,9 @@ packages:
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: "126dc9a7f6a746820e06c678d6e0c5f08dc6393212ea5901c2d89c19ed6f41bc"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.3.0"
 sdks:
   dart: ">=3.10.8 <4.0.0"

--- a/zikzak_inappwebview_linux/example/pubspec.yaml
+++ b/zikzak_inappwebview_linux/example/pubspec.yaml
@@ -25,7 +25,8 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  zikzak_inappwebview_platform_interface: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../../zikzak_inappwebview_platform_interface
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/zikzak_inappwebview_linux/pubspec.yaml
+++ b/zikzak_inappwebview_linux/pubspec.yaml
@@ -13,13 +13,15 @@ topics:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
-  zikzak_inappwebview_internal_annotations: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_internal_annotations:
+    path: ../zikzak_inappwebview_internal_annotations
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppBrowser/InAppBrowserWebViewController.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppBrowser/InAppBrowserWebViewController.swift
@@ -4,7 +4,7 @@ import WebKit
 
 public class InAppBrowserWebView: InAppWebView {
     weak var browserController: InAppBrowserWebViewController?
-    
+
     public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
             case "close":
@@ -34,44 +34,45 @@ public class InAppBrowserWebViewController: NSWindowController, NSWindowDelegate
     var id: String
     var windowId: Int?
     var webView: InAppBrowserWebView?
-    
+    private var isClosing = false
+
     init(manager: InAppBrowserManager, id: String, windowId: Int?) {
         self.manager = manager
         self.id = id
         self.windowId = windowId
-        
+
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
             styleMask: [.titled, .closable, .resizable, .miniaturizable],
             backing: .buffered, defer: false)
         super.init(window: window)
-        
+
         window.delegate = self
         window.title = "InAppBrowser"
         window.center()
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     public func prepare(urlRequest: [String: Any]?, assetFilePath: String?, data: String?, mimeType: String?, encoding: String?, baseUrl: String?, historyUrl: String?, settings: [String: Any]?, contextMenu: [String: Any]?, initialUserScripts: [[String: Any]]?, menuItems: [[String: Any]]?) {
-        
+
         let channelName = "dev.zuzu/flutter_inappbrowser_\(id)"
-        
+
         // Setup WebView
         let arguments: [String: Any] = [
             "initialUrlRequest": urlRequest ?? [:],
             "initialUserScripts": initialUserScripts ?? [],
             "settings": settings ?? [:]
         ]
-        
+
         webView = InAppBrowserWebView(registrar: manager.registrar, viewId: id, arguments: arguments, channelName: channelName)
         webView?.frame = window?.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 800, height: 600)
         webView?.autoresizingMask = [.width, .height]
         webView?.browserController = self
         window?.contentView = webView
-        
+
         // Handle loading if not handled by init arguments
         if urlRequest == nil {
              if let assetFilePath = assetFilePath {
@@ -84,12 +85,15 @@ public class InAppBrowserWebViewController: NSWindowController, NSWindowDelegate
                  webView?.loadHTMLString(data, baseURL: baseUrl != nil ? URL(string: baseUrl!) : nil)
             }
         }
-        
+
         // Notify browser created
         webView?.channel?.invokeMethod("onBrowserCreated", arguments: [:])
     }
-    
+
     public func windowWillClose(_ notification: Notification) {
+        guard !isClosing else { return }
+        isClosing = true
+        window?.delegate = nil
         webView?.channel?.invokeMethod("onExit", arguments: [:])
         webView?.dispose()
         webView = nil

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -100,6 +100,15 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         super.init(coder: coder)
     }
 
+    public override func layout() {
+        super.layout()
+        guard let superview = superview else { return }
+        let targetFrame = superview.bounds
+        if frame != targetFrame {
+            frame = targetFrame
+        }
+    }
+
     public override func observeValue(
         forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?,
         context: UnsafeMutableRawPointer?

--- a/zikzak_inappwebview_macos/pubspec.lock
+++ b/zikzak_inappwebview_macos/pubspec.lock
@@ -211,18 +211,16 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: "922bd14f5bbcb81820021fae7612b64692fff9b8d70ff4b75224cd83b13b76f6"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: "126dc9a7f6a746820e06c678d6e0c5f08dc6393212ea5901c2d89c19ed6f41bc"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.3.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview_macos/pubspec.yaml
+++ b/zikzak_inappwebview_macos/pubspec.yaml
@@ -13,12 +13,13 @@ topics:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_localhost_server.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_localhost_server.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter/widgets.dart';
 
 import 'mime_type_resolver.dart';
 import 'platform_in_app_localhost_server.dart';
@@ -39,6 +40,7 @@ class DefaultInAppLocalhostServer extends PlatformInAppLocalhostServer {
   bool _shared = false;
   String _directoryIndex = 'index.html';
   String _documentRoot = './';
+  AppLifecycleListener? _appLifecycleListener;
 
   /// Creates a new [DefaultInAppLocalhostServer].
   DefaultInAppLocalhostServer(PlatformInAppLocalhostServerCreationParams params)
@@ -75,6 +77,8 @@ class DefaultInAppLocalhostServer extends PlatformInAppLocalhostServer {
       throw Exception('Server already started on http://localhost:$_port');
     }
     this._started = true;
+
+    _registerLifecycleListener();
 
     final completer = Completer();
 
@@ -128,8 +132,28 @@ class DefaultInAppLocalhostServer extends PlatformInAppLocalhostServer {
     return completer.future;
   }
 
+  void _registerLifecycleListener() {
+    _appLifecycleListener?.dispose();
+    _appLifecycleListener = AppLifecycleListener(
+      onResume: _onResume,
+    );
+  }
+
+  void _onResume() {
+    if (_server != null) {
+      // After the app resumes from background, the underlying socket may no
+      // longer be valid. Close the server and reset the state so the user
+      // can restart it.
+      _server!.close(force: true).catchError((_) {});
+      _server = null;
+      _started = false;
+    }
+  }
+
   @override
   Future<void> close() async {
+    _appLifecycleListener?.dispose();
+    _appLifecycleListener = null;
     if (this._server == null) {
       return;
     }

--- a/zikzak_inappwebview_platform_interface/lib/src/web_authentication_session/web_authenticate_session_settings.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/web_authentication_session/web_authenticate_session_settings.dart
@@ -26,13 +26,25 @@ class WebAuthenticationSessionSettings_ {
   ///- MacOS
   bool? prefersEphemeralWebBrowserSession;
 
+  ///A dictionary of additional HTTP headers to include in the authentication request.
+  ///
+  ///Set this property to include additional headers in all requests made by the authentication session.
+  ///
+  ///**NOTE for iOS**: Available only on iOS 17.4+.
+  ///
+  ///**Officially Supported Platforms/Implementations**:
+  ///- iOS
+  Map<String, String>? additionalHeaderFields;
+
   WebAuthenticationSessionSettings_({
     this.prefersEphemeralWebBrowserSession = false,
+    this.additionalHeaderFields,
   });
 
   Map<String, dynamic> toMap() {
     return {
       "prefersEphemeralWebBrowserSession": prefersEphemeralWebBrowserSession,
+      "additionalHeaderFields": additionalHeaderFields,
     };
   }
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/web_authentication_session/web_authenticate_session_settings.g.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/web_authentication_session/web_authenticate_session_settings.g.dart
@@ -27,8 +27,10 @@ class WebAuthenticationSessionSettings {
   ///- iOS
   ///- MacOS
   bool? prefersEphemeralWebBrowserSession;
+  Map<String, String>? additionalHeaderFields;
   WebAuthenticationSessionSettings({
     this.prefersEphemeralWebBrowserSession = false,
+    this.additionalHeaderFields,
   });
 
   ///Gets a possible [WebAuthenticationSessionSettings] instance from a [Map] value.
@@ -39,12 +41,15 @@ class WebAuthenticationSessionSettings {
     final instance = WebAuthenticationSessionSettings();
     instance.prefersEphemeralWebBrowserSession =
         map['prefersEphemeralWebBrowserSession'];
+    instance.additionalHeaderFields =
+        Map<String, String>.from(map['additionalHeaderFields'] ?? {});
     return instance;
   }
 
   Map<String, dynamic> toMap() {
     return {
       "prefersEphemeralWebBrowserSession": prefersEphemeralWebBrowserSession,
+      "additionalHeaderFields": additionalHeaderFields,
     };
   }
 
@@ -61,6 +66,6 @@ class WebAuthenticationSessionSettings {
 
   @override
   String toString() {
-    return 'WebAuthenticationSessionSettings{prefersEphemeralWebBrowserSession: $prefersEphemeralWebBrowserSession}';
+    return 'WebAuthenticationSessionSettings{prefersEphemeralWebBrowserSession: $prefersEphemeralWebBrowserSession, additionalHeaderFields: $additionalHeaderFields}';
   }
 }

--- a/zikzak_inappwebview_platform_interface/pubspec.yaml
+++ b/zikzak_inappwebview_platform_interface/pubspec.yaml
@@ -13,13 +13,14 @@ topics:
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  zikzak_inappwebview_internal_annotations: ^4.3.0
+  zikzak_inappwebview_internal_annotations:
+    path: ../zikzak_inappwebview_internal_annotations
   meta: ^1.15.0
 
 dev_dependencies:
@@ -27,6 +28,8 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^6.0.0
   build_runner: ^2.4.13
+  generators:
+    path: ../dev_packages/generators
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/zikzak_inappwebview_web/pubspec.lock
+++ b/zikzak_inappwebview_web/pubspec.lock
@@ -224,18 +224,16 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: "922bd14f5bbcb81820021fae7612b64692fff9b8d70ff4b75224cd83b13b76f6"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: "126dc9a7f6a746820e06c678d6e0c5f08dc6393212ea5901c2d89c19ed6f41bc"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.3.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview_web/pubspec.yaml
+++ b/zikzak_inappwebview_web/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/arrrrny/zikzak_inappwebview
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 flutter:
   plugin:
@@ -20,11 +20,11 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
   web: ^1.1.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-

--- a/zikzak_inappwebview_windows/pubspec.lock
+++ b/zikzak_inappwebview_windows/pubspec.lock
@@ -219,18 +219,16 @@ packages:
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: "922bd14f5bbcb81820021fae7612b64692fff9b8d70ff4b75224cd83b13b76f6"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
     version: "4.3.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: "126dc9a7f6a746820e06c678d6e0c5f08dc6393212ea5901c2d89c19ed6f41bc"
-      url: "https://pub.dev"
-    source: hosted
+      path: "../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
     version: "4.3.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"

--- a/zikzak_inappwebview_windows/pubspec.yaml
+++ b/zikzak_inappwebview_windows/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/arrrrny/zikzak_inappwebview
 
 environment:
   sdk: ">=3.8.0 <4.0.0"
-  flutter: ">=3.29.0"
+  flutter: ">=3.38.6"
 
 flutter:
   plugin:
@@ -19,7 +19,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.3.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
   webview_windows: ^0.4.0
   path: ^1.9.0
 
@@ -27,4 +28,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-


### PR DESCRIPTION
## 4.3.1 Release

This PR bundles the remaining high-priority fixes that missed the 4.3.0 cut.

### iOS Fixes
- **Passkey/WebAuthn support (#131)** — wired `webAuthenticationSupport` setting into native `WKWebViewWebAuthenticationSupport.boundKeychainForPasskeys` on iOS 16.4+
- **`shouldOverrideUrlLoading` deadlock (#132)** — added `isNavigatingWithCustomAction` flag to prevent re-entrant navigation callbacks when `loadUrl()` is called from the Dart callback with custom headers
- **Custom HTTP headers for WebAuthenticationSession (#100)** — added `additionalHeaderFields` parameter for iOS 17.4+ `ASWebAuthenticationSession`

### macOS Fixes
- **NSToolbar crash on window close (#87)** — added `isClosing` guard and `window?.delegate = nil` before teardown to prevent AppKit toolbar assertion on macOS 26
- **WebView frame drift (#93)** — overrode `layout()` in `InAppWebView` to explicitly sync frame from superview bounds, preventing continuous frame fighting on fractional widths

### Cross-platform Fixes
- **`InAppLocalhostServer` background resume (#113)** — added `AppLifecycleListener` to detect app resume and properly reset server state when the underlying socket becomes invalid
- **Raised minimum Flutter version to 3.38.6 (#128)** — Flutter 3.38.6 fixed iOS touch interaction issues with WKWebView
- **Fixed `build_runner` (#139)** — added `generators` package as dev_dependency in platform_interface pubspec

Closes #87, Closes #93, Closes #100, Closes #113, Closes #128, Closes #131, Closes #132, Closes #139