### PR TITLE
fix(android): resolve stuck loading issue when navigating between InAppWebView pages

### DIFF
--- a/zikzak_inappwebview/example/android/.gitignore
+++ b/zikzak_inappwebview/example/android/.gitignore
@@ -6,6 +6,8 @@ gradle-wrapper.jar
 /local.properties
 GeneratedPluginRegistrant.java
 
+/.kotlin/
+
 # Remember to never publicly share your keystore.
 # See https://flutter.dev/to/reference-keystore
 key.properties

--- a/zikzak_inappwebview/example/android/app/build.gradle
+++ b/zikzak_inappwebview/example/android/app/build.gradle
@@ -1,7 +1,6 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
-    // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
+    // The Flutter Gradle Plugin must be applied after the Android Gradle plugin.
     id "dev.flutter.flutter-gradle-plugin"
 }
 

--- a/zikzak_inappwebview/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/zikzak_inappwebview/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/zikzak_inappwebview/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/zikzak_inappwebview/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip

--- a/zikzak_inappwebview/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/zikzak_inappwebview/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.1-bin.zip

--- a/zikzak_inappwebview/example/android/settings.gradle
+++ b/zikzak_inappwebview/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"

--- a/zikzak_inappwebview/example/android/settings.gradle
+++ b/zikzak_inappwebview/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.11.1" apply false
+    id "com.android.application" version "9.0.0" apply false
     id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -3559,24 +3559,15 @@ public final class InAppWebView
         // STEP 11: Remove all views
         removeAllViews();
 
-        // STEP 12: Pause WebView lifecycle
-        onPause();
-        pauseTimers();
-
-        // STEP 13: Clear cache and history
+        // STEP 12: Clear cache and history
         clearHistory();
         clearCache(true);
 
-        // STEP 14: Clear plugin reference
+        // STEP 13: Clear plugin reference
         plugin = null;
 
-        // STEP 15: Final destroy on next frame to ensure cleanup completes
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                destroy();
-            }
-        });
+        // STEP 14: Final destroy immediately (not deferred, to avoid race with new WebView creation)
+        destroy();
     }
 
     @Override

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -288,6 +288,13 @@ public final class InAppWebView
 
     @SuppressLint("RestrictedApi")
     public void prepare() {
+        // Resume global WebView timers that may have been paused by a previous
+        // WebView's dispose() -> pauseTimers() call. pauseTimers() is a global
+        // operation that pauses layout, parsing, and JS timers for ALL webviews.
+        // Without this resume, a newly created WebView's page load would never
+        // complete because parsing is frozen globally.
+        resumeTimers();
+
         if (plugin != null) {
             webViewAssetLoaderExt = WebViewAssetLoaderExt.fromMap(
                 customSettings.webViewAssetLoader,


### PR DESCRIPTION
Fixes #144 - Android InAppWebView stuck loading issue

## Problem
When navigating between pages with stacked InAppWebViews (Home → Page A → Page B → Back to A → Page B), the second visit to Page B's WebView would get stuck at ~80% loading. `onLoadStop` never fires and the WebView remains in a broken loading state.

## Root Cause
The `dispose()` method in `InAppWebView.java` had two issues:

1. **Global timer pause**: `pauseTimers()` and `onPause()` are global operations that pause JavaScript timers, layout, and parsing for ALL WebViews in the app, not just the current one. When a WebView was disposed (e.g., on page pop), any newly created WebView would have its HTML parsing frozen because the parser timers were globally paused.

2. **Deferred destroy**: The `destroy()` call was deferred via `Handler.post()` to run on the next frame, which created a race condition where the old WebView's delayed destruction could interfere with the new WebView's load operation.

## Solution
- Removed `pauseTimers()` and `onPause()` calls from `dispose()` - these should not be called during disposal as they affect the entire app
- Changed `destroy()` to be called immediately instead of deferred - avoids race conditions between old WebView destruction and new WebView creation
- Added `resumeTimers()` at the start of `prepare()` to ensure newly created WebViews always start with active timer state (belt-and-suspenders approach)

## Testing
Navigate through the example app:
1. Home → Page A (wait for load)
2. Page A → Page B (wait for load)
3. Back to Page A
4. Page A → Page B (second time) - this previously got stuck, now loads correctly