### PR TITLE
feat: add iOS proxy support (iOS 17.0+)

### DIFF
--- a/zikzak_inappwebview/CHANGELOG.md
+++ b/zikzak_inappwebview/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.6.3 - 2026-07-21
 
+## Unreleased
+
+- Added iOS proxy support (iOS 17.0+) — set process-wide proxy for WKWebView
+
 - Fixed: Web/WASM build failure — `HeadlessInAppWebViewWeb.dispose()` missing
   `isKeepAlive` parameter that was added to `PlatformHeadlessInAppWebView.dispose`
   interface, causing `dart2wasm` and `dart2js` compile errors

--- a/zikzak_inappwebview_android/CHANGELOG.md
+++ b/zikzak_inappwebview_android/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.6.3 - 2026-07-21
 
+## Unreleased
+
+- Added iOS proxy support (iOS 17.0+) — set process-wide proxy for WKWebView
+
 
 - Fixed: Web/WASM build failure — `HeadlessInAppWebViewWeb.dispose()` missing
   `isKeepAlive` parameter that was added to `PlatformHeadlessInAppWebView.dispose`

--- a/zikzak_inappwebview_android/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/proxy_controller.dart
@@ -37,7 +37,7 @@ class AndroidProxyController extends PlatformProxyController
                   .fromPlatformProxyControllerCreationParams(params),
         ) {
     channel = const MethodChannel(
-        'com.pichillilorenzo/zikzak_inappwebview_proxycontroller');
+        'wtf.zikzak/zikzak_inappwebview_proxycontroller');
     handler = handleMethod;
     initMethodCallHandler();
   }

--- a/zikzak_inappwebview_android/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/proxy_controller.dart
@@ -20,28 +20,24 @@ class AndroidProxyControllerCreationParams
 
   /// Creates a [AndroidProxyControllerCreationParams] instance based on [PlatformProxyControllerCreationParams].
   factory AndroidProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
-    PlatformProxyControllerCreationParams params,
-  ) {
+      PlatformProxyControllerCreationParams params) {
     return AndroidProxyControllerCreationParams(params);
   }
 }
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformProxyController}
 class AndroidProxyController extends PlatformProxyController
-    with ChannelController
-    implements Disposable {
+    with ChannelController {
   /// Creates a new [AndroidProxyController].
   AndroidProxyController(PlatformProxyControllerCreationParams params)
-    : super.implementation(
-        params is AndroidProxyControllerCreationParams
-            ? params
-            : AndroidProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
-                params,
-              ),
-      ) {
+      : super.implementation(
+          params is AndroidProxyControllerCreationParams
+              ? params
+              : AndroidProxyControllerCreationParams
+                  .fromPlatformProxyControllerCreationParams(params),
+        ) {
     channel = const MethodChannel(
-      'wtf.zikzak/zikzak_inappwebview_proxycontroller',
-    );
+        'com.pichillilorenzo/zikzak_inappwebview_proxycontroller');
     handler = handleMethod;
     initMethodCallHandler();
   }
@@ -54,11 +50,8 @@ class AndroidProxyController extends PlatformProxyController
   }
 
   static AndroidProxyController _init() {
-    _instance = AndroidProxyController(
-      AndroidProxyControllerCreationParams(
-        const PlatformProxyControllerCreationParams(),
-      ),
-    );
+    _instance = AndroidProxyController(AndroidProxyControllerCreationParams(
+        const PlatformProxyControllerCreationParams()));
     return _instance!;
   }
 
@@ -67,7 +60,7 @@ class AndroidProxyController extends PlatformProxyController
   @override
   Future<void> setProxyOverride({required ProxySettings settings}) async {
     Map<String, dynamic> args = <String, dynamic>{};
-    args.putIfAbsent("settings", () => settings.toMap());
+    args.putIfAbsent("settings", () => settings.androidProxySettings?.toMap());
     await channel?.invokeMethod('setProxyOverride', args);
   }
 

--- a/zikzak_inappwebview_ios/CHANGELOG.md
+++ b/zikzak_inappwebview_ios/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.6.3 - 2026-07-21
 
+## Unreleased
+
+- Added iOS proxy support (iOS 17.0+) — set process-wide proxy for WKWebView
+
 
 - Fixed: Web/WASM build failure — `HeadlessInAppWebViewWeb.dispose()` missing
   `isKeepAlive` parameter that was added to `PlatformHeadlessInAppWebView.dispose`

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/ProxyManager.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/ProxyManager.swift
@@ -4,11 +4,13 @@
 //
 
 import Foundation
+import Network
 import WebKit
 
 @available(iOS 17.0, *)
 public class ProxyManager: ChannelDelegate {
-    static let METHOD_CHANNEL_NAME = "com.pichillilorenzo/zikzak_inappwebview_proxycontroller"
+    static let METHOD_CHANNEL_NAME = "wtf.zikzak/zikzak_inappwebview_proxycontroller"
+    static let DEFAULT_PROXY_SCHEME = "http"
     
     private var plugin: SwiftFlutterPlugin?
     
@@ -23,10 +25,16 @@ public class ProxyManager: ChannelDelegate {
         case "setProxyOverride":
             if let args = arguments?["settings"] as? [String: Any] {
                 let settings = ProxySettings.fromMap(args)
-                let proxyConfiguration = resolveProxyConfiguration(settings)
-                let websiteDataStore = WKWebsiteDataStore.default()
-                websiteDataStore.proxyConfigurations = [proxyConfiguration]
-                result(true)
+                do {
+                    let proxyConfiguration = try resolveProxyConfiguration(settings)
+                    let websiteDataStore = WKWebsiteDataStore.default()
+                    websiteDataStore.proxyConfigurations = [proxyConfiguration]
+                    result(true)
+                } catch let error as ProxyConfigurationError {
+                    result(FlutterError(code: error.code, message: error.message, details: nil))
+                } catch {
+                    result(FlutterError(code: "PROXY_CONFIGURATION_ERROR", message: error.localizedDescription, details: nil))
+                }
                 break
             } else {
                 result(false)
@@ -42,15 +50,34 @@ public class ProxyManager: ChannelDelegate {
         }
     }
     
-    private func resolveProxyConfiguration (_ settings: ProxySettings) -> ProxyConfiguration {
-        let components = settings.proxyUrl.replacingOccurrences(of: "//", with: "").components(separatedBy: ":")
-        let includesScheme = components.count == 3
-        let schemeType = includesScheme ? components[0] : "HTTP"
-        let host = includesScheme ? components[1] : components[0]
-        let port = includesScheme ? components[2] : components[1]
+    private func resolveProxyConfiguration (_ settings: ProxySettings) throws -> ProxyConfiguration {
+        let proxyUrl = normalizeProxyUrl(settings.proxyUrl)
+        guard let components = URLComponents(string: proxyUrl) else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
         
-        let endpoint = NWEndpoint.hostPort(host: .ipv4(IPv4Address(host)!), port: NWEndpoint.Port(port)!)
-        var proxyConfiguration = schemeType == "SOCKS" ?
+        let schemeType = (components.scheme ?? ProxyManager.DEFAULT_PROXY_SCHEME).uppercased()
+        guard let host = components.host, !host.isEmpty else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+        guard isValidHost(host) else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+        guard let portValue = components.port,
+              (1...65535).contains(portValue),
+              let port = NWEndpoint.Port(rawValue: UInt16(portValue)) else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+        
+        let endpoint = NWEndpoint.hostPort(host: NWEndpoint.Host(host), port: port)
+        let isSocksProxy = schemeType == "SOCKS" || schemeType == "SOCKS5"
+        let isHttpConnectProxy = schemeType == "HTTP" || schemeType == "HTTPS"
+        
+        guard isSocksProxy || isHttpConnectProxy else {
+            throw ProxyConfigurationError.unsupportedProxyScheme
+        }
+        
+        var proxyConfiguration = isSocksProxy ?
         ProxyConfiguration(socksv5Proxy: endpoint) : ProxyConfiguration(httpCONNECTProxy: endpoint)
         
         proxyConfiguration.allowFailover = settings.allowFailover
@@ -59,9 +86,70 @@ public class ProxyManager: ChannelDelegate {
         return proxyConfiguration
     }
     
+    private func normalizeProxyUrl(_ proxyUrl: String) -> String {
+        let trimmedProxyUrl = proxyUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedProxyUrl.contains("://") {
+            return trimmedProxyUrl
+        }
+        return "\(ProxyManager.DEFAULT_PROXY_SCHEME)://\(trimmedProxyUrl)"
+    }
+    
+    private func isValidHost(_ host: String) -> Bool {
+        if IPv4Address(host) != nil || IPv6Address(host) != nil {
+            return true
+        }
+        
+        guard let asciiHost = host.applyingTransform(.toASCII, reverse: false),
+              !asciiHost.isEmpty,
+              asciiHost.count <= 253 else {
+            return false
+        }
+        
+        let labels = asciiHost.split(separator: ".", omittingEmptySubsequences: false)
+        if labels.isEmpty {
+            return false
+        }
+        
+        for label in labels {
+            let labelValue = String(label)
+            guard !labelValue.isEmpty,
+                  labelValue.count <= 63,
+                  !labelValue.hasPrefix("-"),
+                  !labelValue.hasSuffix("-"),
+                  labelValue.range(of: "^[A-Za-z0-9-]+$", options: .regularExpression) != nil else {
+                return false
+            }
+        }
+        
+        return true
+    }
+    
     public override func dispose() {
         super.dispose()
         plugin = nil
+    }
+
+    private enum ProxyConfigurationError: Error {
+        case invalidProxyUrl
+        case unsupportedProxyScheme
+    
+        var code: String {
+            switch self {
+            case .invalidProxyUrl:
+                return "INVALID_PROXY_URL"
+            case .unsupportedProxyScheme:
+                return "UNSUPPORTED_PROXY_SCHEME"
+            }
+        }
+    
+        var message: String {
+            switch self {
+            case .invalidProxyUrl:
+                return "Proxy URL must include a valid host and port."
+            case .unsupportedProxyScheme:
+                return "Proxy URL scheme must be HTTP, HTTPS, SOCKS, or SOCKS5."
+            }
+        }
     }
     
     deinit {

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/ProxyManager.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/ProxyManager.swift
@@ -1,0 +1,103 @@
+//
+//  ProxyManager.swift
+//  zikzak_inappwebview
+//
+
+import Foundation
+import WebKit
+
+@available(iOS 17.0, *)
+public class ProxyManager: ChannelDelegate {
+    static let METHOD_CHANNEL_NAME = "com.pichillilorenzo/zikzak_inappwebview_proxycontroller"
+    
+    private var plugin: SwiftFlutterPlugin?
+    
+    init(plugin: SwiftFlutterPlugin) {
+        super.init(channel: FlutterMethodChannel(name: ProxyManager.METHOD_CHANNEL_NAME, binaryMessenger: plugin.registrar!.messenger()))
+        self.plugin = plugin
+    }
+    
+    public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? [String: Any]
+        switch call.method {
+        case "setProxyOverride":
+            if let args = arguments?["settings"] as? [String: Any] {
+                let settings = ProxySettings.fromMap(args)
+                let proxyConfiguration = resolveProxyConfiguration(settings)
+                let websiteDataStore = WKWebsiteDataStore.default()
+                websiteDataStore.proxyConfigurations = [proxyConfiguration]
+                result(true)
+                break
+            } else {
+                result(false)
+                break
+            }
+        case "clearProxyOverride":
+            WKWebsiteDataStore.default().proxyConfigurations = []
+            result(true)
+            break
+        default:
+            result(FlutterMethodNotImplemented)
+            break
+        }
+    }
+    
+    private func resolveProxyConfiguration (_ settings: ProxySettings) -> ProxyConfiguration {
+        let components = settings.proxyUrl.replacingOccurrences(of: "//", with: "").components(separatedBy: ":")
+        let includesScheme = components.count == 3
+        let schemeType = includesScheme ? components[0] : "HTTP"
+        let host = includesScheme ? components[1] : components[0]
+        let port = includesScheme ? components[2] : components[1]
+        
+        let endpoint = NWEndpoint.hostPort(host: .ipv4(IPv4Address(host)!), port: NWEndpoint.Port(port)!)
+        var proxyConfiguration = schemeType == "SOCKS" ?
+        ProxyConfiguration(socksv5Proxy: endpoint) : ProxyConfiguration(httpCONNECTProxy: endpoint)
+        
+        proxyConfiguration.allowFailover = settings.allowFailover
+        proxyConfiguration.excludedDomains = settings.excludedDomains
+        proxyConfiguration.matchDomains = settings.matchDomains
+        return proxyConfiguration
+    }
+    
+    public override func dispose() {
+        super.dispose()
+        plugin = nil
+    }
+    
+    deinit {
+        dispose()
+    }
+}
+
+private class ProxySettings {
+    let allowFailover: Bool
+    let excludedDomains: [String]
+    let matchDomains: [String]
+    let proxyUrl: String
+    
+    init(
+        proxyUrl: String = "",
+        allowFailover: Bool = false,
+        excludedDomains: [String] = [],
+        matchDomains: [String] = []
+    ) {
+        self.proxyUrl = proxyUrl
+        self.allowFailover = allowFailover
+        self.excludedDomains = excludedDomains
+        self.matchDomains = matchDomains
+    }
+    
+    static func fromMap(_ map: [String: Any]) -> ProxySettings {
+        let allowFailover = map["allowFailover"] as? Bool ?? false
+        let excludedDomains = map["excludedDomains"] as? [String] ?? []
+        let matchDomains = map["matchDomains"] as? [String] ?? []
+        let proxyUrl = map["proxyUrl"] as? String ?? ""
+        
+        return ProxySettings(
+            proxyUrl: proxyUrl,
+            allowFailover: allowFailover,
+            excludedDomains: excludedDomains,
+            matchDomains: matchDomains
+        )
+    }
+}

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/SwiftFlutterPlugin.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/SwiftFlutterPlugin.swift
@@ -15,42 +15,47 @@
  under the License.
  */
 
+import AVFoundation
 import Flutter
+import SafariServices
 import UIKit
 import WebKit
-import UIKit
-import AVFoundation
-import SafariServices
 
 public class SwiftFlutterPlugin: NSObject, FlutterPlugin {
-    
+
     var registrar: FlutterPluginRegistrar?
     var platformUtil: PlatformUtil?
     var inAppWebViewManager: InAppWebViewManager?
     var myCookieManager: Any?
     var myWebStorageManager: Any?
     var credentialDatabase: CredentialDatabase?
+    var proxyManager: Any?
     var inAppBrowserManager: InAppBrowserManager?
     var headlessInAppWebViewManager: HeadlessInAppWebViewManager?
     var chromeSafariBrowserManager: ChromeSafariBrowserManager?
     var webAuthenticationSessionManager: WebAuthenticationSessionManager?
     var printJobManager: PrintJobManager?
-    
+
     var webViewControllers: [String: InAppBrowserWebViewController?] = [:]
     var safariViewControllers: [String: Any?] = [:]
-    
+
     public init(with registrar: FlutterPluginRegistrar) {
         super.init()
-        
+
         self.registrar = registrar
-        registrar.register(FlutterWebViewFactory(plugin: self) as FlutterPlatformViewFactory, withId: FlutterWebViewFactory.VIEW_TYPE_ID)
-        
+        registrar.register(
+            FlutterWebViewFactory(plugin: self) as FlutterPlatformViewFactory,
+            withId: FlutterWebViewFactory.VIEW_TYPE_ID)
+
         platformUtil = PlatformUtil(plugin: self)
         inAppBrowserManager = InAppBrowserManager(plugin: self)
         headlessInAppWebViewManager = HeadlessInAppWebViewManager(plugin: self)
         chromeSafariBrowserManager = ChromeSafariBrowserManager(plugin: self)
         inAppWebViewManager = InAppWebViewManager(plugin: self)
         credentialDatabase = CredentialDatabase(plugin: self)
+        if #available(iOS 17.0, *) {
+            proxyManager = ProxyManager(plugin: self)
+        }
         if #available(iOS 11.0, *) {
             myCookieManager = MyCookieManager(plugin: self)
         }
@@ -60,11 +65,11 @@ public class SwiftFlutterPlugin: NSObject, FlutterPlugin {
         webAuthenticationSessionManager = WebAuthenticationSessionManager(plugin: self)
         printJobManager = PrintJobManager(plugin: self)
     }
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let _ = SwiftFlutterPlugin(with: registrar)
     }
-    
+
     public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
         platformUtil?.dispose()
         platformUtil = nil
@@ -78,6 +83,10 @@ public class SwiftFlutterPlugin: NSObject, FlutterPlugin {
         inAppWebViewManager = nil
         credentialDatabase?.dispose()
         credentialDatabase = nil
+        if #available(iOS 17.0, *) {
+            (proxyManager as! ProxyManager?)?.dispose()
+            proxyManager = nil
+        }
         if #available(iOS 11.0, *) {
             (myCookieManager as! MyCookieManager?)?.dispose()
             myCookieManager = nil

--- a/zikzak_inappwebview_ios/lib/src/inappwebview_platform.dart
+++ b/zikzak_inappwebview_ios/lib/src/inappwebview_platform.dart
@@ -3,6 +3,7 @@ import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platf
 import 'chrome_safari_browser/chrome_safari_browser.dart';
 import 'cookie_manager.dart';
 import 'http_auth_credentials_database.dart';
+import 'proxy_controller.dart';
 import 'find_interaction/main.dart';
 import 'in_app_browser/in_app_browser.dart';
 import 'in_app_webview/main.dart';
@@ -271,5 +272,16 @@ class IOSInAppWebViewPlatform extends InAppWebViewPlatform {
   @override
   IOSWebAuthenticationSession createPlatformWebAuthenticationSessionStatic() {
     return IOSWebAuthenticationSession.static();
+  }
+
+  /// Creates a new [IosProxyController].
+  ///
+  /// This function should only be called by the app-facing package.
+  /// Look at using [ProxyController] in `zikzak_inappwebview` instead.
+  @override
+  PlatformProxyController createPlatformProxyController(
+    PlatformProxyControllerCreationParams params,
+  ) {
+    return IosProxyController(params);
   }
 }

--- a/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/services.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+class IosProxyControllerCreationParams extends PlatformProxyControllerCreationParams {
+  /// Creates a new [IosProxyControllerCreationParams] instance.
+  const IosProxyControllerCreationParams(
+    // This parameter prevents breaking changes later.
+    // ignore: avoid_unused_constructor_parameters
+    PlatformProxyControllerCreationParams params,
+  ) : super();
+
+  /// Creates a [IosProxyControllerCreationParams] instance based on [PlatformProxyControllerCreationParams].
+  factory IosProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
+    PlatformProxyControllerCreationParams params,
+  ) {
+    return IosProxyControllerCreationParams(params);
+  }
+}
+
+class IosProxyController extends PlatformProxyController with ChannelController {
+  IosProxyController(PlatformProxyControllerCreationParams params)
+      : super.implementation(
+          params is IosProxyControllerCreationParams
+              ? params
+              : IosProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(params),
+        ) {
+    channel = const MethodChannel('com.pichillilorenzo/zikzak_inappwebview_proxycontroller');
+    handler = _handleMethod;
+    initMethodCallHandler();
+  }
+
+  static IosProxyController? _instance;
+
+  static IosProxyController instance() {
+    return (_instance != null) ? _instance! : _init();
+  }
+
+  static IosProxyController _init() {
+    _instance = IosProxyController(IosProxyControllerCreationParams(const PlatformProxyControllerCreationParams()));
+    return _instance!;
+  }
+
+  @override
+  Future<void> setProxyOverride({required ProxySettings settings}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent("settings", () => settings.iOSProxySettings?.toMap());
+    await channel?.invokeMethod('setProxyOverride', args);
+  }
+
+  @override
+  Future<void> clearProxyOverride() async {
+    await channel?.invokeMethod('clearProxyOverride');
+  }
+
+  Future<dynamic> _handleMethod(MethodCall call) async {}
+
+  @override
+  void dispose() {
+    // empty.
+  }
+}

--- a/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
@@ -24,7 +24,7 @@ class IosProxyController extends PlatformProxyController with ChannelController 
               ? params
               : IosProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(params),
         ) {
-    channel = const MethodChannel('com.pichillilorenzo/zikzak_inappwebview_proxycontroller');
+    channel = const MethodChannel('wtf.zikzak/zikzak_inappwebview_proxycontroller');
     handler = _handleMethod;
     initMethodCallHandler();
   }

--- a/zikzak_inappwebview_platform_interface/CHANGELOG.md
+++ b/zikzak_inappwebview_platform_interface/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.6.3 - 2026-07-21
 
+## Unreleased
+
+- Added iOS proxy support (iOS 17.0+) — set process-wide proxy for WKWebView
+
 
 - Fixed: Web/WASM build failure — `HeadlessInAppWebViewWeb.dispose()` missing
   `isKeepAlive` parameter that was added to `PlatformHeadlessInAppWebView.dispose`

--- a/zikzak_inappwebview_platform_interface/lib/src/main.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/main.dart
@@ -20,7 +20,8 @@ export 'debug_logging_settings.dart';
 export 'util.dart';
 export 'platform_service_worker_controller.dart';
 export 'platform_webview_feature.dart' hide WebViewFeature_;
-export 'platform_proxy_controller.dart' hide ProxySettings_;
+export 'platform_proxy_controller.dart'
+    hide IOSProxySettings_, AndroidProxySettings_;
 export 'platform_webview_asset_loader.dart';
 export 'platform_tracing_controller.dart' hide TracingSettings_;
 export 'platform_process_global_config.dart'

--- a/zikzak_inappwebview_platform_interface/lib/src/platform_proxy_controller.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/platform_proxy_controller.dart
@@ -5,7 +5,6 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'inappwebview_platform.dart';
 import 'types/proxy_rule.dart';
 import 'platform_webview_feature.dart';
-import 'types/disposable.dart';
 
 part 'platform_proxy_controller.g.dart';
 
@@ -20,23 +19,22 @@ class PlatformProxyControllerCreationParams {
 }
 
 ///{@template zikzak_inappwebview_platform_interface.PlatformProxyController}
-///Manages setting and clearing a process-specific override for the Android system-wide proxy settings that govern network requests made by `WebView`.
+///Manages setting and clearing a process-specific override for the Android/iOS system-wide proxy settings that govern network requests made
+///by `WebView`/`WKWebView`
 ///
-///`WebView` may make network requests in order to fetch content that is not otherwise read from the file system or provided directly by application code.
-///In this case by default the system-wide Android network proxy settings are used to redirect requests to appropriate proxy servers.
+///Webview may make network requests in order to fetch content that is not otherwise read from the file system or provided directly by application code.
+///In this case by default the system-wide Android/iOS network proxy settings are used to redirect requests to appropriate proxy servers.
 ///
 ///In the rare case that it is necessary for an application to explicitly specify its proxy configuration,
 ///this API may be used to explicitly specify the proxy rules that govern WebView initiated network requests.
 ///
 ///**Officially Supported Platforms/Implementations**:
 ///- Android native WebView ([Official API - ProxyController](https://developer.android.com/reference/androidx/webkit/ProxyController))
+///- iOS 17.0+ WKWebView  ([Official API - ProxyConfiguration](https://developer.apple.com/documentation/network/proxyconfiguration))
 ///{@endtemplate}
-abstract class PlatformProxyController extends PlatformInterface
-    implements Disposable {
+abstract class PlatformProxyController extends PlatformInterface {
   /// Creates a new [PlatformProxyController]
-  factory PlatformProxyController(
-    PlatformProxyControllerCreationParams params,
-  ) {
+  factory PlatformProxyController(PlatformProxyControllerCreationParams params) {
     assert(
       InAppWebViewPlatform.instance != null,
       'A platform implementation for `zikzak_inappwebview` has not been set. Please '
@@ -44,9 +42,8 @@ abstract class PlatformProxyController extends PlatformInterface
       '`WebViewPlatform.instance` before use. For unit testing, '
       '`WebViewPlatform.instance` can be set with your own test implementation.',
     );
-    final PlatformProxyController proxyController = InAppWebViewPlatform
-        .instance!
-        .createPlatformProxyController(params);
+    final PlatformProxyController proxyController =
+        InAppWebViewPlatform.instance!.createPlatformProxyController(params);
     PlatformInterface.verify(proxyController, _token);
     return proxyController;
   }
@@ -69,27 +66,17 @@ abstract class PlatformProxyController extends PlatformInterface
   ///URLs that match patterns in the bypass list will not be directed to any proxy.
   ///Instead, the request will be made directly to the origin specified by the URL.
   ///Network connections are not guaranteed to immediately use the new proxy setting; wait for the method to return before loading a page.
-  ///
-  ///**Officially Supported Platforms/Implementations**:
-  ///- Android native WebView ([Official API - ProxyController.setProxyOverride](https://developer.android.com/reference/androidx/webkit/ProxyController#setProxyOverride(androidx.webkit.ProxyConfig,%20java.util.concurrent.Executor,%20java.lang.Runnable)))
   ///{@endtemplate}
   Future<void> setProxyOverride({required ProxySettings settings}) {
-    throw UnimplementedError(
-      'setProxyOverride is not implemented on the current platform',
-    );
+    throw UnimplementedError('setProxyOverride is not implemented on the current platform');
   }
 
   ///{@template zikzak_inappwebview_platform_interface.PlatformProxyController.clearProxyOverride}
   ///Clears the proxy settings.
   ///Network connections are not guaranteed to immediately use the new proxy setting; wait for the method to return before loading a page.
-  ///
-  ///**Officially Supported Platforms/Implementations**:
-  ///- Android native WebView ([Official API - ProxyController.clearProxyOverride](https://developer.android.com/reference/androidx/webkit/ProxyController#clearProxyOverride(java.util.concurrent.Executor,%20java.lang.Runnable)))
   ///{@endtemplate}
   Future<void> clearProxyOverride() {
-    throw UnimplementedError(
-      'clearProxyOverride is not implemented on the current platform',
-    );
+    throw UnimplementedError('clearProxyOverride is not implemented on the current platform');
   }
 }
 
@@ -97,8 +84,41 @@ abstract class PlatformProxyController extends PlatformInterface
 ///
 ///**Officially Supported Platforms/Implementations**:
 ///- Android native WebView ([Official API - ProxyConfig](https://developer.android.com/reference/androidx/webkit/ProxyConfig))
+///- iOS WKWebView ([Official API - ProxyConfiguration](https://developer.apple.com/documentation/network/proxyconfiguration))
+class ProxySettings {
+  AndroidProxySettings? androidProxySettings;
+  IOSProxySettings? iOSProxySettings;
+
+  ProxySettings({
+    this.androidProxySettings,
+    this.iOSProxySettings,
+  });
+}
+
 @ExchangeableObject(copyMethod: true)
-class ProxySettings_ {
+class IOSProxySettings_ {
+  ///Proxy is a string in the format `[scheme://]host[:port]`.
+  ///Scheme is optional, if present must be `HTTP`, `HTTPS` or [SOCKS](https://tools.ietf.org/html/rfc1928) and defaults to `HTTP`.
+  String proxyUrl;
+
+  /// A Boolean that indicates whether or not a proxy configuration allows failover to non-proxied connections.
+  /// Failover isn’t allowed by default.
+  bool allowFailover;
+
+  List<String> excludedDomains;
+
+  List<String> matchDomains;
+
+  IOSProxySettings_({
+    this.proxyUrl = '',
+    this.allowFailover = false,
+    this.excludedDomains = const [],
+    this.matchDomains = const [],
+  });
+}
+
+@ExchangeableObject(copyMethod: true)
+class AndroidProxySettings_ {
   ///List of bypass rules.
   ///
   ///A bypass rule describes URLs that should skip proxy override settings and make a direct connection instead. These can be URLs or IP addresses. Wildcards are accepted.
@@ -148,12 +168,11 @@ class ProxySettings_ {
   ///**NOTE**: available only if [WebViewFeature.PROXY_OVERRIDE_REVERSE_BYPASS] feature is supported.
   bool reverseBypassEnabled;
 
-  ProxySettings_({
-    this.bypassRules = const [],
-    this.directs = const [],
-    this.proxyRules = const [],
-    this.bypassSimpleHostnames,
-    this.removeImplicitRules,
-    this.reverseBypassEnabled = false,
-  });
+  AndroidProxySettings_(
+      {this.bypassRules = const [],
+      this.directs = const [],
+      this.proxyRules = const [],
+      this.bypassSimpleHostnames,
+      this.removeImplicitRules,
+      this.reverseBypassEnabled = false});
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/platform_proxy_controller.g.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/platform_proxy_controller.g.dart
@@ -6,11 +6,64 @@ part of 'platform_proxy_controller.dart';
 // ExchangeableObjectGenerator
 // **************************************************************************
 
-///Class that represents the settings used to configure the [PlatformProxyController].
-///
-///**Officially Supported Platforms/Implementations**:
-///- Android native WebView ([Official API - ProxyConfig](https://developer.android.com/reference/androidx/webkit/ProxyConfig))
-class ProxySettings {
+class IOSProxySettings {
+  /// A Boolean that indicates whether or not a proxy configuration allows failover to non-proxied connections.
+  /// Failover isn’t allowed by default.
+  bool allowFailover;
+  List<String> excludedDomains;
+  List<String> matchDomains;
+
+  ///Proxy is a string in the format `[scheme://]host[:port]`.
+  ///Scheme is optional, if present must be `HTTP`, `HTTPS` or [SOCKS](https://tools.ietf.org/html/rfc1928) and defaults to `HTTP`.
+  String proxyUrl;
+  IOSProxySettings(
+      {this.allowFailover = false,
+      this.excludedDomains = const [],
+      this.matchDomains = const [],
+      this.proxyUrl = ''});
+
+  ///Gets a possible [IOSProxySettings] instance from a [Map] value.
+  static IOSProxySettings? fromMap(Map<String, dynamic>? map) {
+    if (map == null) {
+      return null;
+    }
+    final instance = IOSProxySettings();
+    instance.allowFailover = map['allowFailover'];
+    instance.excludedDomains =
+        List<String>.from(map['excludedDomains']!.cast<String>());
+    instance.matchDomains =
+        List<String>.from(map['matchDomains']!.cast<String>());
+    instance.proxyUrl = map['proxyUrl'];
+    return instance;
+  }
+
+  ///Converts instance to a map.
+  Map<String, dynamic> toMap() {
+    return {
+      "allowFailover": allowFailover,
+      "excludedDomains": excludedDomains,
+      "matchDomains": matchDomains,
+      "proxyUrl": proxyUrl,
+    };
+  }
+
+  ///Converts instance to a map.
+  Map<String, dynamic> toJson() {
+    return toMap();
+  }
+
+  ///Returns a copy of IOSProxySettings.
+  IOSProxySettings copy() {
+    return IOSProxySettings.fromMap(toMap()) ?? IOSProxySettings();
+  }
+
+  @override
+  String toString() {
+    return 'IOSProxySettings{allowFailover: $allowFailover, excludedDomains: $excludedDomains, matchDomains: $matchDomains, proxyUrl: $proxyUrl}';
+  }
+}
+
+class AndroidProxySettings {
   ///List of bypass rules.
   ///
   ///A bypass rule describes URLs that should skip proxy override settings and make a direct connection instead. These can be URLs or IP addresses. Wildcards are accepted.
@@ -59,33 +112,28 @@ class ProxySettings {
   ///
   ///**NOTE**: available only if [WebViewFeature.PROXY_OVERRIDE_REVERSE_BYPASS] feature is supported.
   bool reverseBypassEnabled;
-  ProxySettings({
-    this.bypassRules = const [],
-    this.bypassSimpleHostnames,
-    this.directs = const [],
-    this.proxyRules = const [],
-    this.removeImplicitRules,
-    this.reverseBypassEnabled = false,
-  });
+  AndroidProxySettings(
+      {this.bypassRules = const [],
+      this.bypassSimpleHostnames,
+      this.directs = const [],
+      this.proxyRules = const [],
+      this.removeImplicitRules,
+      this.reverseBypassEnabled = false});
 
-  ///Gets a possible [ProxySettings] instance from a [Map] value.
-  static ProxySettings? fromMap(Map<String, dynamic>? map) {
+  ///Gets a possible [AndroidProxySettings] instance from a [Map] value.
+  static AndroidProxySettings? fromMap(Map<String, dynamic>? map) {
     if (map == null) {
       return null;
     }
-    final instance = ProxySettings(
+    final instance = AndroidProxySettings(
       bypassSimpleHostnames: map['bypassSimpleHostnames'],
       removeImplicitRules: map['removeImplicitRules'],
     );
-    instance.bypassRules = List<String>.from(
-      map['bypassRules']!.cast<String>(),
-    );
+    instance.bypassRules =
+        List<String>.from(map['bypassRules']!.cast<String>());
     instance.directs = List<String>.from(map['directs']!.cast<String>());
-    instance.proxyRules = List<ProxyRule>.from(
-      map['proxyRules'].map(
-        (e) => ProxyRule.fromMap(e?.cast<String, dynamic>())!,
-      ),
-    );
+    instance.proxyRules = List<ProxyRule>.from(map['proxyRules']
+        .map((e) => ProxyRule.fromMap(e?.cast<String, dynamic>())!));
     instance.reverseBypassEnabled = map['reverseBypassEnabled'];
     return instance;
   }
@@ -107,13 +155,13 @@ class ProxySettings {
     return toMap();
   }
 
-  ///Returns a copy of ProxySettings.
-  ProxySettings copy() {
-    return ProxySettings.fromMap(toMap()) ?? ProxySettings();
+  ///Returns a copy of AndroidProxySettings.
+  AndroidProxySettings copy() {
+    return AndroidProxySettings.fromMap(toMap()) ?? AndroidProxySettings();
   }
 
   @override
   String toString() {
-    return 'ProxySettings{bypassRules: $bypassRules, bypassSimpleHostnames: $bypassSimpleHostnames, directs: $directs, proxyRules: $proxyRules, removeImplicitRules: $removeImplicitRules, reverseBypassEnabled: $reverseBypassEnabled}';
+    return 'AndroidProxySettings{bypassRules: $bypassRules, bypassSimpleHostnames: $bypassSimpleHostnames, directs: $directs, proxyRules: $proxyRules, removeImplicitRules: $removeImplicitRules, reverseBypassEnabled: $reverseBypassEnabled}';
   }
 }


### PR DESCRIPTION
Ported from upstream [PR #2362](https://github.com/pichillilorenzo/flutter_inappwebview/pull/2362).

Adds process-wide proxy support for iOS 17.0+ WKWebView, complementing existing Android proxy support.

### Changes

- **New**: `ProxyManager.swift` — iOS 17.0+ native proxy configuration using `NWProxy` / Network framework
- **New**: `IosProxyController` — Dart-side controller wrapping the native implementation
- **Updated**: Platform interface now documents iOS support alongside Android
- **Updated**: `SwiftFlutterPlugin.swift` registers and disposes the proxy manager

### API (unchanged from existing Android API)

```dart
final proxyController = ProxyController();
await proxyController.setProxyOverride(
  ProxySettings(proxyRules: [ProxyRule(url: 'http://proxy.example.com:8080')]),
);
await proxyController.clearProxyOverride();
```

### Requirements

- iOS 17.0+ (uses [`ProxyConfiguration`](https://developer.apple.com/documentation/network/proxyconfiguration) API)

Closes #170