### PR TITLE
fix(linux): pre-existing C++ issues — texture ID + screenshot ref leak

### DIFF
--- a/zikzak_inappwebview_linux/linux/in_app_webview.cc
+++ b/zikzak_inappwebview_linux/linux/in_app_webview.cc
@@ -195,7 +195,7 @@ InAppWebView *in_app_webview_new(FlPluginRegistrar *registrar, const char *id) {
       fl_plugin_registrar_get_texture_registrar(registrar);
   if (fl_texture_registrar_register_texture(texture_registrar,
                                             FL_TEXTURE(self))) {
-    self->texture_id = (int64_t)self;
+    self->texture_id = fl_texture_get_id(FL_TEXTURE(self));
   } else {
     self->texture_id = 0;
   }
@@ -388,7 +388,6 @@ void in_app_webview_handle_method_call(InAppWebView *self,
     g_free(uri);
     return;
   } else if (strcmp(method, "takeScreenshot") == 0) {
-    g_object_ref(method_call);
     webkit_web_view_get_snapshot(
         WEBKIT_WEB_VIEW(self->web_view), WEBKIT_SNAPSHOT_REGION_VISIBLE,
         WEBKIT_SNAPSHOT_OPTIONS_NONE, nullptr,


### PR DESCRIPTION
Fixes two pre-existing issues in `in_app_webview.cc` identified during review of #171.

### Changes

1. **Texture ID from object pointer** (`L198`): `self->texture_id = (int64_t)self` → `fl_texture_get_id(FL_TEXTURE(self))`. Casting the object pointer to int64_t only works if the Flutter embedder assigns texture IDs from object addresses. The proper API is `fl_texture_get_id()`.

2. **Redundant `g_object_ref` in takeScreenshot** (`L391`): Removed the first `g_object_ref(method_call)`. The call at L458 already passes a ref'd copy as `user_data`, and the callback lambdas properly unref it. The standalone ref at L391 was never released — leaking an `FlMethodCall` on every screenshot.

### Files
- `zikzak_inappwebview_linux/linux/in_app_webview.cc` (1 insertion, 2 deletions)