### PR TITLE
fix: standardize dispose patterns across all wrapper classes

### DIFF
--- a/zikzak_inappwebview/example/integration_test/lifecycle_test.dart
+++ b/zikzak_inappwebview/example/integration_test/lifecycle_test.dart
@@ -46,10 +46,9 @@ void main() {
     await controller.loadData(
       data: '<html><body><h1>lifecycle</h1></body></html>',
     );
-    await pageLoaded.future.timeout(
-      const Duration(seconds: 15),
-      onTimeout: () {},
-    );
+    // No onTimeout fallback: a page that never finishes loading must fail
+    // the test instead of being silently swallowed.
+    await pageLoaded.future.timeout(const Duration(seconds: 15));
     await tester.pumpAndSettle();
     return controller;
   }
@@ -122,10 +121,22 @@ void main() {
       ),
     );
 
-    // P1 regression: dispose() before run() completes must not leak and
-    // must not hang; a second dispose() must be a no-op.
+    // P1 regression: dispose() before run() must be safe and idempotent.
     await headless.dispose();
     await headless.dispose();
+
+    // dispose() while run() is still in flight must coordinate with the
+    // pending startup: it waits for the native side to come up, tears it
+    // down, and must not hang; a second dispose() remains a no-op.
+    final headlessInFlight = HeadlessInAppWebView(
+      initialData: InAppWebViewInitialData(
+        data: '<html><body>headless-in-flight</body></html>',
+      ),
+    );
+    final runFuture = headlessInFlight.run();
+    await headlessInFlight.dispose();
+    await runFuture;
+    await headlessInFlight.dispose();
 
     // A fresh instance still runs and disposes cleanly.
     final Completer<void> loaded = Completer();

--- a/zikzak_inappwebview/example/integration_test/lifecycle_test.dart
+++ b/zikzak_inappwebview/example/integration_test/lifecycle_test.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+
+/// Lifecycle integration tests (P2 of the dispose-pattern epic).
+///
+/// Covers:
+///  - hot restart: the WebView keeps working after a reassemble
+///  - activity recreation: background -> foreground without
+///    MissingPluginException
+///  - plugin registration without an Activity (FlutterFragment scenario)
+///  - HeadlessInAppWebView dispose-before-run and double-dispose (P1 bug)
+///  - InAppLocalhostServer.dispose stops the server (P1)
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  Future<InAppWebViewController> pumpWebView(
+    WidgetTester tester, {
+    required Completer<void> pageLoaded,
+  }) async {
+    final Completer<InAppWebViewController> created = Completer();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InAppWebView(
+            onWebViewCreated: (c) {
+              if (!created.isCompleted) {
+                created.complete(c);
+              }
+            },
+            onLoadStop: (controller, url) {
+              if (!pageLoaded.isCompleted) {
+                pageLoaded.complete();
+              }
+            },
+          ),
+        ),
+      ),
+    );
+    final controller = await created.future.timeout(
+      const Duration(seconds: 15),
+    );
+    await controller.loadData(
+      data: '<html><body><h1>lifecycle</h1></body></html>',
+    );
+    await pageLoaded.future.timeout(
+      const Duration(seconds: 15),
+      onTimeout: () {},
+    );
+    await tester.pumpAndSettle();
+    return controller;
+  }
+
+  testWidgets('WebView survives hot restart (reassemble)', (
+    WidgetTester tester,
+  ) async {
+    var controller = await pumpWebView(tester, pageLoaded: Completer());
+    expect(
+      await controller.evaluateJavascript(source: '1 + 1'),
+      anyOf(equals(2), equals('2')),
+    );
+
+    // Simulate hot restart: reassembles the whole widget tree, recreating
+    // platform views the same way a real hot restart does.
+    final binding = IntegrationTestWidgetsFlutterBinding.instance;
+    await binding.reassembleApplication();
+    await tester.pumpAndSettle();
+
+    controller = await pumpWebView(tester, pageLoaded: Completer());
+    expect(
+      await controller.evaluateJavascript(source: '2 + 2'),
+      anyOf(equals(4), equals('4')),
+    );
+  });
+
+  testWidgets(
+    'background -> foreground does not throw MissingPluginException',
+    (WidgetTester tester) async {
+      final controller = await pumpWebView(tester, pageLoaded: Completer());
+
+      // Simulate activity going to background and coming back.
+      WidgetsBinding.instance.handleAppLifecycleStateChanged(
+        AppLifecycleState.paused,
+      );
+      await tester.pump();
+      WidgetsBinding.instance.handleAppLifecycleStateChanged(
+        AppLifecycleState.resumed,
+      );
+      await tester.pumpAndSettle();
+
+      // Channel must still be alive.
+      expect(
+        await controller.evaluateJavascript(source: '3 + 3'),
+        anyOf(equals(6), equals('6')),
+      );
+      expect(await controller.getUrl(), isNotNull);
+    },
+  );
+
+  testWidgets('plugin registration works without an Activity', (
+    WidgetTester tester,
+  ) async {
+    // FlutterFragment scenario: the plugin must be registered and usable
+    // even when no Android Activity is attached. On desktop/mobile test
+    // runners the equivalent statement is that the platform instance is
+    // registered and controller methods round-trip.
+    expect(InAppWebViewPlatform.instance, isNotNull);
+
+    final controller = await pumpWebView(tester, pageLoaded: Completer());
+    expect(await controller.getTitle(), isA<String?>());
+  });
+
+  testWidgets('HeadlessInAppWebView: dispose before run + double dispose', (
+    WidgetTester tester,
+  ) async {
+    final headless = HeadlessInAppWebView(
+      initialData: InAppWebViewInitialData(
+        data: '<html><body>headless</body></html>',
+      ),
+    );
+
+    // P1 regression: dispose() before run() completes must not leak and
+    // must not hang; a second dispose() must be a no-op.
+    await headless.dispose();
+    await headless.dispose();
+
+    // A fresh instance still runs and disposes cleanly.
+    final Completer<void> loaded = Completer();
+    final headless2 = HeadlessInAppWebView(
+      initialData: InAppWebViewInitialData(
+        data: '<html><body>headless2</body></html>',
+      ),
+      onLoadStop: (controller, url) {
+        if (!loaded.isCompleted) {
+          loaded.complete();
+        }
+      },
+    );
+    await headless2.run();
+    await headless2.dispose();
+    await headless2.dispose();
+  });
+
+  testWidgets('InAppLocalhostServer.dispose stops the server', (
+    WidgetTester tester,
+  ) async {
+    final server = InAppLocalhostServer(port: 18099, shared: true);
+    await server.start();
+    expect(server.isRunning(), isTrue);
+    expect(server.disposed, isFalse);
+
+    server.dispose();
+    expect(server.disposed, isTrue);
+
+    // close() is asynchronous inside dispose(); give it a moment.
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (server.isRunning() && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+    }
+    expect(server.isRunning(), isFalse);
+
+    // Double dispose is a no-op.
+    server.dispose();
+  });
+
+  testWidgets('wrapper classes implement Disposable at runtime', (
+    WidgetTester tester,
+  ) async {
+    final controller = await pumpWebView(tester, pageLoaded: Completer());
+    expect(controller, isA<Disposable>());
+    expect(InAppWebView(onWebViewCreated: (_) {}), isA<Disposable>());
+    expect(InAppLocalhostServer(port: 18098), isA<Disposable>());
+  });
+
+  testWidgets(
+    'Windows: WebView2 read-only install directory (Program Files)',
+    (WidgetTester tester) async {},
+    // Requires a Windows host with WebView2; covered by Windows CI.
+    skip: true,
+  );
+}

--- a/zikzak_inappwebview/lib/src/chrome_safari_browser/chrome_safari_browser.dart
+++ b/zikzak_inappwebview/lib/src/chrome_safari_browser/chrome_safari_browser.dart
@@ -158,7 +158,8 @@ class ChromeSafariBrowser implements PlatformChromeSafariBrowserEvents {
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformChromeSafariBrowser.dispose}
   @mustCallSuper
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 
   @override
   void onClosed() {}

--- a/zikzak_inappwebview/lib/src/in_app_browser/in_app_browser.dart
+++ b/zikzak_inappwebview/lib/src/in_app_browser/in_app_browser.dart
@@ -187,7 +187,8 @@ class InAppBrowser implements PlatformInAppBrowserEvents {
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppBrowser.dispose}
   @mustCallSuper
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 
   @Deprecated('Use onFormResubmission instead')
   Future<FormResubmissionAction?>? androidOnFormResubmission(WebUri? url) {

--- a/zikzak_inappwebview/lib/src/in_app_localhost_server.dart
+++ b/zikzak_inappwebview/lib/src/in_app_localhost_server.dart
@@ -68,7 +68,9 @@ class InAppLocalhostServer implements Disposable {
     }
     _disposed = true;
     if (isRunning()) {
-      unawaited(close());
+      // Fire-and-forget (dispose is synchronous): swallow a rejected
+      // close() future so it cannot surface as an unhandled async error.
+      unawaited(close().catchError((_) {}));
     }
   }
 }

--- a/zikzak_inappwebview/lib/src/in_app_localhost_server.dart
+++ b/zikzak_inappwebview/lib/src/in_app_localhost_server.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppLocalhostServer}
-class InAppLocalhostServer {
+class InAppLocalhostServer implements Disposable {
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppLocalhostServer}
   InAppLocalhostServer({
     int port = 8080,
@@ -51,4 +51,24 @@ class InAppLocalhostServer {
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppLocalhostServer.isRunning}
   bool isRunning() => platform.isRunning();
+
+  bool _disposed = false;
+
+  /// Indicates if the server has been disposed.
+  bool get disposed => _disposed;
+
+  /// Disposes the server, stopping it if it is still running,
+  /// and releasing its resources.
+  ///
+  /// After disposal, this instance cannot be used anymore.
+  @override
+  void dispose({bool isKeepAlive = false}) {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    if (isRunning()) {
+      unawaited(close());
+    }
+  }
 }

--- a/zikzak_inappwebview/lib/src/in_app_webview/android/in_app_webview_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/android/in_app_webview_controller.dart
@@ -115,7 +115,7 @@ class AndroidInAppWebViewController {
     return await _controller?.getOriginalUrl();
   }
 
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     _controller = null;
   }
 }

--- a/zikzak_inappwebview/lib/src/in_app_webview/apple/in_app_webview_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/apple/in_app_webview_controller.dart
@@ -57,7 +57,7 @@ class IOSInAppWebViewController {
     return await InAppWebViewController.handlesURLScheme(urlScheme);
   }
 
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     _controller = null;
   }
 }

--- a/zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -11,7 +11,7 @@ import '../pull_to_refresh/pull_to_refresh_controller.dart';
 import 'network_capture/network_capture_manager.dart';
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView}
-class HeadlessInAppWebView {
+class HeadlessInAppWebView implements Disposable {
   /// Constructs a [HeadlessInAppWebView].
   ///
   ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView}
@@ -350,40 +350,39 @@ class HeadlessInAppWebView {
     );
     return HeadlessInAppWebView.fromPlatformCreationParams(
       params: PlatformHeadlessInAppWebViewCreationParams(
-           controllerFromPlatform:
-               (PlatformInAppWebViewController controller) =>
-                   InAppWebViewController.fromPlatform(platform: controller),
-           initialSize: initialSize,
-           windowId: windowId,
-           initialUrlRequest: initialUrlRequest,
-           initialFile: initialFile,
-           initialData: initialData,
-           initialSettings: initialSettings,
-           initialUserScripts: NetworkCaptureManager.mergeUserScripts(
-             initialUserScripts,
-             networkCaptureManager,
-           ),
-           pullToRefreshController: pullToRefreshController?.platform,
-           findInteractionController: findInteractionController?.platform,
-           contextMenu: contextMenu,
-           webViewEnvironment: webViewEnvironment?.platform,
-           onWebViewCreated: (controller) {
-             networkCaptureManager?.attach(controller);
-             onWebViewCreated?.call(controller);
-           },
-           onLoadStart: (controller, url) {
-             networkCaptureManager?.onPageLoad(controller);
-             onLoadStart?.call(controller, url);
-           },
-           onLoadStop: (controller, url) {
-             networkCaptureManager?.onPageLoad(controller);
-             onLoadStop?.call(controller, url);
-             if (initialSettings?.dismissDialogues ?? false) {
-               () async {
-                 try {
-                   for (var i = 0; i < 3; i++) {
-                     await controller.evaluateJavascript(
-                       source: '''
+        controllerFromPlatform: (PlatformInAppWebViewController controller) =>
+            InAppWebViewController.fromPlatform(platform: controller),
+        initialSize: initialSize,
+        windowId: windowId,
+        initialUrlRequest: initialUrlRequest,
+        initialFile: initialFile,
+        initialData: initialData,
+        initialSettings: initialSettings,
+        initialUserScripts: NetworkCaptureManager.mergeUserScripts(
+          initialUserScripts,
+          networkCaptureManager,
+        ),
+        pullToRefreshController: pullToRefreshController?.platform,
+        findInteractionController: findInteractionController?.platform,
+        contextMenu: contextMenu,
+        webViewEnvironment: webViewEnvironment?.platform,
+        onWebViewCreated: (controller) {
+          networkCaptureManager?.attach(controller);
+          onWebViewCreated?.call(controller);
+        },
+        onLoadStart: (controller, url) {
+          networkCaptureManager?.onPageLoad(controller);
+          onLoadStart?.call(controller, url);
+        },
+        onLoadStop: (controller, url) {
+          networkCaptureManager?.onPageLoad(controller);
+          onLoadStop?.call(controller, url);
+          if (initialSettings?.dismissDialogues ?? false) {
+            () async {
+              try {
+                for (var i = 0; i < 3; i++) {
+                  await controller.evaluateJavascript(
+                    source: '''
                           (function() {
                             var removed = 0;
                             var all = document.querySelectorAll('*');
@@ -403,250 +402,242 @@ class HeadlessInAppWebView {
                             return removed;
                           })();
                         ''',
-                     );
-                     if (i < 2) {
-                       await Future.delayed(const Duration(milliseconds: 800));
-                     }
-                   }
-                 } catch (_) {}
-               }();
-             }
-           },
-           onReceivedError: onReceivedError != null
-               ? (controller, request, error) =>
-                     onReceivedError.call(controller, request, error)
-               : null,
-           onReceivedHttpError: onReceivedHttpError != null
-               ? (controller, request, errorResponse) => onReceivedHttpError
-                     .call(controller, request, errorResponse)
-               : null,
-           onConsoleMessage: onConsoleMessage != null
-               ? (controller, consoleMessage) =>
-                     onConsoleMessage.call(controller, consoleMessage)
-               : null,
-           onProgressChanged: onProgressChanged != null
-               ? (controller, progress) =>
-                     onProgressChanged.call(controller, progress)
-               : null,
-           shouldOverrideUrlLoading: shouldOverrideUrlLoading != null
-               ? (controller, navigationAction) =>
-                     shouldOverrideUrlLoading(controller, navigationAction)
-               : null,
-           onLoadResource: onLoadResource != null
-               ? (controller, resource) =>
-                     onLoadResource.call(controller, resource)
-               : null,
-           onScrollChanged: onScrollChanged != null
-               ? (controller, x, y) => onScrollChanged.call(controller, x, y)
-               : null,
-           onDownloadStartRequest: onDownloadStartRequest != null
-               ? (controller, downloadStartRequest) => onDownloadStartRequest
-                     .call(controller, downloadStartRequest)
-               : null,
-           onLoadResourceWithCustomScheme:
-               onLoadResourceWithCustomScheme != null
-               ? (controller, request) =>
-                     onLoadResourceWithCustomScheme.call(controller, request)
-               : null,
-           onCreateWindow: onCreateWindow != null
-               ? (controller, createWindowAction) =>
-                     onCreateWindow.call(controller, createWindowAction)
-               : null,
-           onCloseWindow: onCloseWindow != null
-               ? (controller) => onCloseWindow.call(controller)
-               : null,
-           onJsAlert: onJsAlert != null
-               ? (controller, jsAlertRequest) =>
-                     onJsAlert.call(controller, jsAlertRequest)
-               : null,
-           onJsConfirm: onJsConfirm != null
-               ? (controller, jsConfirmRequest) =>
-                     onJsConfirm.call(controller, jsConfirmRequest)
-               : null,
-           onJsPrompt: onJsPrompt != null
-               ? (controller, jsPromptRequest) =>
-                     onJsPrompt.call(controller, jsPromptRequest)
-               : null,
-           onReceivedHttpAuthRequest: onReceivedHttpAuthRequest != null
-               ? (controller, challenge) =>
-                     onReceivedHttpAuthRequest.call(controller, challenge)
-               : null,
-           onReceivedServerTrustAuthRequest:
-               onReceivedServerTrustAuthRequest != null
-               ? (controller, challenge) => onReceivedServerTrustAuthRequest
-                     .call(controller, challenge)
-               : null,
-           onReceivedClientCertRequest: onReceivedClientCertRequest != null
-               ? (controller, challenge) =>
-                     onReceivedClientCertRequest.call(controller, challenge)
-               : null,
-           shouldInterceptAjaxRequest: shouldInterceptAjaxRequest != null
-               ? (controller, ajaxRequest) =>
-                     shouldInterceptAjaxRequest.call(controller, ajaxRequest)
-               : null,
-           onAjaxReadyStateChange: onAjaxReadyStateChange != null
-               ? (controller, ajaxRequest) =>
-                     onAjaxReadyStateChange.call(controller, ajaxRequest)
-               : null,
-           onAjaxProgress: onAjaxProgress != null
-               ? (controller, ajaxRequest) =>
-                     onAjaxProgress.call(controller, ajaxRequest)
-               : null,
-           shouldInterceptFetchRequest: shouldInterceptFetchRequest != null
-               ? (controller, fetchRequest) =>
-                     shouldInterceptFetchRequest.call(controller, fetchRequest)
-               : null,
-           onUpdateVisitedHistory: onUpdateVisitedHistory != null
-               ? (controller, url, isReload) =>
-                     onUpdateVisitedHistory.call(controller, url, isReload)
-               : null,
-           onPrintRequest: onPrintRequest != null
-               ? (controller, url, printJobController) =>
-                     onPrintRequest.call(controller, url, printJobController)
-               : null,
-           onLongPressHitTestResult: onLongPressHitTestResult != null
-               ? (controller, hitTestResult) =>
-                     onLongPressHitTestResult.call(controller, hitTestResult)
-               : null,
-           onEnterFullscreen: onEnterFullscreen != null
-               ? (controller) => onEnterFullscreen.call(controller)
-               : null,
-           onExitFullscreen: onExitFullscreen != null
-               ? (controller) => onExitFullscreen.call(controller)
-               : null,
-           onPageCommitVisible: onPageCommitVisible != null
-               ? (controller, url) => onPageCommitVisible.call(controller, url)
-               : null,
-           onTitleChanged: onTitleChanged != null
-               ? (controller, title) => onTitleChanged.call(controller, title)
-               : null,
-           onWindowFocus: onWindowFocus != null
-               ? (controller) => onWindowFocus.call(controller)
-               : null,
-           onWindowBlur: onWindowBlur != null
-               ? (controller) => onWindowBlur.call(controller)
-               : null,
-           onOverScrolled: onOverScrolled != null
-               ? (controller, x, y, clampedX, clampedY) =>
-                     onOverScrolled.call(controller, x, y, clampedX, clampedY)
-               : null,
-           onZoomScaleChanged: onZoomScaleChanged != null
-               ? (controller, oldScale, newScale) =>
-                     onZoomScaleChanged.call(controller, oldScale, newScale)
-               : null,
-           onSafeBrowsingHit: onSafeBrowsingHit != null
-               ? (controller, url, threatType) =>
-                     onSafeBrowsingHit.call(controller, url, threatType)
-               : null,
-           onPermissionRequest: onPermissionRequest != null
-               ? (controller, permissionRequest) =>
-                     onPermissionRequest.call(controller, permissionRequest)
-               : null,
-           onGeolocationPermissionsShowPrompt:
-               onGeolocationPermissionsShowPrompt != null
-               ? (controller, origin) =>
-                     onGeolocationPermissionsShowPrompt.call(controller, origin)
-               : null,
-           onGeolocationPermissionsHidePrompt:
-               onGeolocationPermissionsHidePrompt != null
-               ? (controller) =>
-                     onGeolocationPermissionsHidePrompt.call(controller)
-               : null,
-           shouldInterceptRequest: shouldInterceptRequest != null
-               ? (controller, request) =>
-                     shouldInterceptRequest.call(controller, request)
-               : null,
-           onRenderProcessGone: onRenderProcessGone != null
-               ? (controller, detail) =>
-                     onRenderProcessGone.call(controller, detail)
-               : null,
-           onRenderProcessResponsive: onRenderProcessResponsive != null
-               ? (controller) =>
-                     onRenderProcessResponsive.call(controller, null)
-               : null,
-           onRenderProcessUnresponsive: onRenderProcessUnresponsive != null
-               ? (controller) =>
-                     onRenderProcessUnresponsive.call(controller, null)
-               : null,
-           onFormResubmission: onFormResubmission != null
-               ? (controller, url) => onFormResubmission.call(controller, url)
-               : null,
-           onReceivedIcon: onReceivedIcon != null
-               ? (controller, icon) => onReceivedIcon.call(controller, icon)
-               : null,
-           onReceivedTouchIconUrl: onReceivedTouchIconUrl != null
-               ? (controller, url, precomposed) =>
-                     onReceivedTouchIconUrl.call(controller, url, precomposed)
-               : null,
-           onJsBeforeUnload: onJsBeforeUnload != null
-               ? (controller, jsBeforeUnloadRequest) =>
-                     onJsBeforeUnload.call(controller, jsBeforeUnloadRequest)
-               : null,
-           onReceivedLoginRequest: onReceivedLoginRequest != null
-               ? (controller, loginRequest) =>
-                     onReceivedLoginRequest.call(controller, loginRequest)
-               : null,
-           onPermissionRequestCanceled: onPermissionRequestCanceled != null
-               ? (controller, permissionRequest) => onPermissionRequestCanceled
-                     .call(controller, permissionRequest)
-               : null,
-           onRequestFocus: onRequestFocus != null
-               ? (controller) => onRequestFocus.call(controller)
-               : null,
-           onWebContentProcessDidTerminate:
-               onWebContentProcessDidTerminate != null
-               ? (controller) =>
-                     onWebContentProcessDidTerminate.call(controller)
-               : null,
-           onDidReceiveServerRedirectForProvisionalNavigation:
-               onDidReceiveServerRedirectForProvisionalNavigation != null
-               ? (controller) =>
-                     onDidReceiveServerRedirectForProvisionalNavigation.call(
-                       controller,
-                     )
-               : null,
-           onNavigationResponse: onNavigationResponse != null
-               ? (controller, navigationResponse) =>
-                     onNavigationResponse.call(controller, navigationResponse)
-               : null,
-           shouldAllowDeprecatedTLS: shouldAllowDeprecatedTLS != null
-               ? (controller, challenge) =>
-                     shouldAllowDeprecatedTLS.call(controller, challenge)
-               : null,
-           onCameraCaptureStateChanged: onCameraCaptureStateChanged != null
-               ? (controller, oldState, newState) => onCameraCaptureStateChanged
-                     .call(controller, oldState, newState)
-               : null,
-           onMicrophoneCaptureStateChanged:
-               onMicrophoneCaptureStateChanged != null
-               ? (controller, oldState, newState) =>
-                     onMicrophoneCaptureStateChanged.call(
-                       controller,
-                       oldState,
-                       newState,
-                     )
-               : null,
-           onContentSizeChanged: onContentSizeChanged != null
-               ? (controller, oldContentSize, newContentSize) =>
-                     onContentSizeChanged.call(
-                       controller,
-                       oldContentSize,
-                       newContentSize,
-                     )
-               : null,
-           onNetworkRequest: onNetworkRequest != null
-               ? (controller, request) =>
-                     onNetworkRequest.call(controller, request)
-               : null,
-           onNetworkResponse: onNetworkResponse != null
-               ? (controller, response) =>
-                     onNetworkResponse.call(controller, response)
-               : null,
-           onNetworkLoadingFinished: onNetworkLoadingFinished != null
-               ? (controller, responseBody) =>
-                     onNetworkLoadingFinished.call(controller, responseBody)
-               : null,
-         ),
+                  );
+                  if (i < 2) {
+                    await Future.delayed(const Duration(milliseconds: 800));
+                  }
+                }
+              } catch (_) {}
+            }();
+          }
+        },
+        onReceivedError: onReceivedError != null
+            ? (controller, request, error) =>
+                  onReceivedError.call(controller, request, error)
+            : null,
+        onReceivedHttpError: onReceivedHttpError != null
+            ? (controller, request, errorResponse) =>
+                  onReceivedHttpError.call(controller, request, errorResponse)
+            : null,
+        onConsoleMessage: onConsoleMessage != null
+            ? (controller, consoleMessage) =>
+                  onConsoleMessage.call(controller, consoleMessage)
+            : null,
+        onProgressChanged: onProgressChanged != null
+            ? (controller, progress) =>
+                  onProgressChanged.call(controller, progress)
+            : null,
+        shouldOverrideUrlLoading: shouldOverrideUrlLoading != null
+            ? (controller, navigationAction) =>
+                  shouldOverrideUrlLoading(controller, navigationAction)
+            : null,
+        onLoadResource: onLoadResource != null
+            ? (controller, resource) =>
+                  onLoadResource.call(controller, resource)
+            : null,
+        onScrollChanged: onScrollChanged != null
+            ? (controller, x, y) => onScrollChanged.call(controller, x, y)
+            : null,
+        onDownloadStartRequest: onDownloadStartRequest != null
+            ? (controller, downloadStartRequest) =>
+                  onDownloadStartRequest.call(controller, downloadStartRequest)
+            : null,
+        onLoadResourceWithCustomScheme: onLoadResourceWithCustomScheme != null
+            ? (controller, request) =>
+                  onLoadResourceWithCustomScheme.call(controller, request)
+            : null,
+        onCreateWindow: onCreateWindow != null
+            ? (controller, createWindowAction) =>
+                  onCreateWindow.call(controller, createWindowAction)
+            : null,
+        onCloseWindow: onCloseWindow != null
+            ? (controller) => onCloseWindow.call(controller)
+            : null,
+        onJsAlert: onJsAlert != null
+            ? (controller, jsAlertRequest) =>
+                  onJsAlert.call(controller, jsAlertRequest)
+            : null,
+        onJsConfirm: onJsConfirm != null
+            ? (controller, jsConfirmRequest) =>
+                  onJsConfirm.call(controller, jsConfirmRequest)
+            : null,
+        onJsPrompt: onJsPrompt != null
+            ? (controller, jsPromptRequest) =>
+                  onJsPrompt.call(controller, jsPromptRequest)
+            : null,
+        onReceivedHttpAuthRequest: onReceivedHttpAuthRequest != null
+            ? (controller, challenge) =>
+                  onReceivedHttpAuthRequest.call(controller, challenge)
+            : null,
+        onReceivedServerTrustAuthRequest:
+            onReceivedServerTrustAuthRequest != null
+            ? (controller, challenge) =>
+                  onReceivedServerTrustAuthRequest.call(controller, challenge)
+            : null,
+        onReceivedClientCertRequest: onReceivedClientCertRequest != null
+            ? (controller, challenge) =>
+                  onReceivedClientCertRequest.call(controller, challenge)
+            : null,
+        shouldInterceptAjaxRequest: shouldInterceptAjaxRequest != null
+            ? (controller, ajaxRequest) =>
+                  shouldInterceptAjaxRequest.call(controller, ajaxRequest)
+            : null,
+        onAjaxReadyStateChange: onAjaxReadyStateChange != null
+            ? (controller, ajaxRequest) =>
+                  onAjaxReadyStateChange.call(controller, ajaxRequest)
+            : null,
+        onAjaxProgress: onAjaxProgress != null
+            ? (controller, ajaxRequest) =>
+                  onAjaxProgress.call(controller, ajaxRequest)
+            : null,
+        shouldInterceptFetchRequest: shouldInterceptFetchRequest != null
+            ? (controller, fetchRequest) =>
+                  shouldInterceptFetchRequest.call(controller, fetchRequest)
+            : null,
+        onUpdateVisitedHistory: onUpdateVisitedHistory != null
+            ? (controller, url, isReload) =>
+                  onUpdateVisitedHistory.call(controller, url, isReload)
+            : null,
+        onPrintRequest: onPrintRequest != null
+            ? (controller, url, printJobController) =>
+                  onPrintRequest.call(controller, url, printJobController)
+            : null,
+        onLongPressHitTestResult: onLongPressHitTestResult != null
+            ? (controller, hitTestResult) =>
+                  onLongPressHitTestResult.call(controller, hitTestResult)
+            : null,
+        onEnterFullscreen: onEnterFullscreen != null
+            ? (controller) => onEnterFullscreen.call(controller)
+            : null,
+        onExitFullscreen: onExitFullscreen != null
+            ? (controller) => onExitFullscreen.call(controller)
+            : null,
+        onPageCommitVisible: onPageCommitVisible != null
+            ? (controller, url) => onPageCommitVisible.call(controller, url)
+            : null,
+        onTitleChanged: onTitleChanged != null
+            ? (controller, title) => onTitleChanged.call(controller, title)
+            : null,
+        onWindowFocus: onWindowFocus != null
+            ? (controller) => onWindowFocus.call(controller)
+            : null,
+        onWindowBlur: onWindowBlur != null
+            ? (controller) => onWindowBlur.call(controller)
+            : null,
+        onOverScrolled: onOverScrolled != null
+            ? (controller, x, y, clampedX, clampedY) =>
+                  onOverScrolled.call(controller, x, y, clampedX, clampedY)
+            : null,
+        onZoomScaleChanged: onZoomScaleChanged != null
+            ? (controller, oldScale, newScale) =>
+                  onZoomScaleChanged.call(controller, oldScale, newScale)
+            : null,
+        onSafeBrowsingHit: onSafeBrowsingHit != null
+            ? (controller, url, threatType) =>
+                  onSafeBrowsingHit.call(controller, url, threatType)
+            : null,
+        onPermissionRequest: onPermissionRequest != null
+            ? (controller, permissionRequest) =>
+                  onPermissionRequest.call(controller, permissionRequest)
+            : null,
+        onGeolocationPermissionsShowPrompt:
+            onGeolocationPermissionsShowPrompt != null
+            ? (controller, origin) =>
+                  onGeolocationPermissionsShowPrompt.call(controller, origin)
+            : null,
+        onGeolocationPermissionsHidePrompt:
+            onGeolocationPermissionsHidePrompt != null
+            ? (controller) =>
+                  onGeolocationPermissionsHidePrompt.call(controller)
+            : null,
+        shouldInterceptRequest: shouldInterceptRequest != null
+            ? (controller, request) =>
+                  shouldInterceptRequest.call(controller, request)
+            : null,
+        onRenderProcessGone: onRenderProcessGone != null
+            ? (controller, detail) =>
+                  onRenderProcessGone.call(controller, detail)
+            : null,
+        onRenderProcessResponsive: onRenderProcessResponsive != null
+            ? (controller) => onRenderProcessResponsive.call(controller, null)
+            : null,
+        onRenderProcessUnresponsive: onRenderProcessUnresponsive != null
+            ? (controller) => onRenderProcessUnresponsive.call(controller, null)
+            : null,
+        onFormResubmission: onFormResubmission != null
+            ? (controller, url) => onFormResubmission.call(controller, url)
+            : null,
+        onReceivedIcon: onReceivedIcon != null
+            ? (controller, icon) => onReceivedIcon.call(controller, icon)
+            : null,
+        onReceivedTouchIconUrl: onReceivedTouchIconUrl != null
+            ? (controller, url, precomposed) =>
+                  onReceivedTouchIconUrl.call(controller, url, precomposed)
+            : null,
+        onJsBeforeUnload: onJsBeforeUnload != null
+            ? (controller, jsBeforeUnloadRequest) =>
+                  onJsBeforeUnload.call(controller, jsBeforeUnloadRequest)
+            : null,
+        onReceivedLoginRequest: onReceivedLoginRequest != null
+            ? (controller, loginRequest) =>
+                  onReceivedLoginRequest.call(controller, loginRequest)
+            : null,
+        onPermissionRequestCanceled: onPermissionRequestCanceled != null
+            ? (controller, permissionRequest) => onPermissionRequestCanceled
+                  .call(controller, permissionRequest)
+            : null,
+        onRequestFocus: onRequestFocus != null
+            ? (controller) => onRequestFocus.call(controller)
+            : null,
+        onWebContentProcessDidTerminate: onWebContentProcessDidTerminate != null
+            ? (controller) => onWebContentProcessDidTerminate.call(controller)
+            : null,
+        onDidReceiveServerRedirectForProvisionalNavigation:
+            onDidReceiveServerRedirectForProvisionalNavigation != null
+            ? (controller) => onDidReceiveServerRedirectForProvisionalNavigation
+                  .call(controller)
+            : null,
+        onNavigationResponse: onNavigationResponse != null
+            ? (controller, navigationResponse) =>
+                  onNavigationResponse.call(controller, navigationResponse)
+            : null,
+        shouldAllowDeprecatedTLS: shouldAllowDeprecatedTLS != null
+            ? (controller, challenge) =>
+                  shouldAllowDeprecatedTLS.call(controller, challenge)
+            : null,
+        onCameraCaptureStateChanged: onCameraCaptureStateChanged != null
+            ? (controller, oldState, newState) => onCameraCaptureStateChanged
+                  .call(controller, oldState, newState)
+            : null,
+        onMicrophoneCaptureStateChanged: onMicrophoneCaptureStateChanged != null
+            ? (controller, oldState, newState) =>
+                  onMicrophoneCaptureStateChanged.call(
+                    controller,
+                    oldState,
+                    newState,
+                  )
+            : null,
+        onContentSizeChanged: onContentSizeChanged != null
+            ? (controller, oldContentSize, newContentSize) =>
+                  onContentSizeChanged.call(
+                    controller,
+                    oldContentSize,
+                    newContentSize,
+                  )
+            : null,
+        onNetworkRequest: onNetworkRequest != null
+            ? (controller, request) =>
+                  onNetworkRequest.call(controller, request)
+            : null,
+        onNetworkResponse: onNetworkResponse != null
+            ? (controller, response) =>
+                  onNetworkResponse.call(controller, response)
+            : null,
+        onNetworkLoadingFinished: onNetworkLoadingFinished != null
+            ? (controller, responseBody) =>
+                  onNetworkLoadingFinished.call(controller, responseBody)
+            : null,
+      ),
     );
   }
 

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
@@ -18,7 +18,7 @@ import '../pull_to_refresh/pull_to_refresh_controller.dart';
 import 'network_capture/network_capture_manager.dart';
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewWidget}
-class InAppWebView extends StatefulWidget {
+class InAppWebView extends StatefulWidget implements Disposable {
   /// Constructs a [InAppWebView].
   ///
   /// See [InAppWebView.fromPlatformCreationParams] for setting parameters for
@@ -306,41 +306,40 @@ class InAppWebView extends StatefulWidget {
     return InAppWebView.fromPlatformCreationParams(
       key: key,
       params: PlatformInAppWebViewWidgetCreationParams(
-           controllerFromPlatform:
-               (PlatformInAppWebViewController controller) =>
-                   InAppWebViewController.fromPlatform(platform: controller),
-           windowId: windowId,
-           keepAlive: keepAlive,
-           initialUrlRequest: initialUrlRequest,
-           initialFile: initialFile,
-           initialData: initialData,
-           initialSettings: initialSettings,
-           initialUserScripts: NetworkCaptureManager.mergeUserScripts(
-             initialUserScripts,
-             networkCaptureManager,
-           ),
-           pullToRefreshController: pullToRefreshController?.platform,
-           findInteractionController: findInteractionController?.platform,
-           contextMenu: contextMenu,
-           layoutDirection: layoutDirection,
-           webViewEnvironment: webViewEnvironment?.platform,
-           onWebViewCreated: (controller) {
-             networkCaptureManager?.attach(controller);
-             onWebViewCreated?.call(controller);
-           },
-           onLoadStart: (controller, url) {
-             networkCaptureManager?.onPageLoad(controller);
-             onLoadStart?.call(controller, url);
-           },
-           onLoadStop: (controller, url) {
-             networkCaptureManager?.onPageLoad(controller);
-             onLoadStop?.call(controller, url);
-             if (initialSettings?.dismissDialogues ?? false) {
-               () async {
-                 try {
-                   for (var i = 0; i < 3; i++) {
-                     await controller.evaluateJavascript(
-                       source: '''
+        controllerFromPlatform: (PlatformInAppWebViewController controller) =>
+            InAppWebViewController.fromPlatform(platform: controller),
+        windowId: windowId,
+        keepAlive: keepAlive,
+        initialUrlRequest: initialUrlRequest,
+        initialFile: initialFile,
+        initialData: initialData,
+        initialSettings: initialSettings,
+        initialUserScripts: NetworkCaptureManager.mergeUserScripts(
+          initialUserScripts,
+          networkCaptureManager,
+        ),
+        pullToRefreshController: pullToRefreshController?.platform,
+        findInteractionController: findInteractionController?.platform,
+        contextMenu: contextMenu,
+        layoutDirection: layoutDirection,
+        webViewEnvironment: webViewEnvironment?.platform,
+        onWebViewCreated: (controller) {
+          networkCaptureManager?.attach(controller);
+          onWebViewCreated?.call(controller);
+        },
+        onLoadStart: (controller, url) {
+          networkCaptureManager?.onPageLoad(controller);
+          onLoadStart?.call(controller, url);
+        },
+        onLoadStop: (controller, url) {
+          networkCaptureManager?.onPageLoad(controller);
+          onLoadStop?.call(controller, url);
+          if (initialSettings?.dismissDialogues ?? false) {
+            () async {
+              try {
+                for (var i = 0; i < 3; i++) {
+                  await controller.evaluateJavascript(
+                    source: '''
                           (function() {
                             var removed = 0;
                             var all = document.querySelectorAll('*');
@@ -360,258 +359,257 @@ class InAppWebView extends StatefulWidget {
                             return removed;
                           })();
                         ''',
-                     );
-                     if (i < 2) {
-                       await Future.delayed(const Duration(milliseconds: 800));
-                     }
-                   }
-                 } catch (_) {}
-               }();
-             }
-           },
-           onReceivedError: onReceivedError != null
-               ? (controller, request, error) =>
-                     onReceivedError.call(controller, request, error)
-               : null,
-           onReceivedHttpError: onReceivedHttpError != null
-               ? (controller, request, errorResponse) => onReceivedHttpError
-                     .call(controller, request, errorResponse)
-               : null,
-           onConsoleMessage: onConsoleMessage != null
-               ? (controller, consoleMessage) =>
-                     onConsoleMessage.call(controller, consoleMessage)
-               : null,
-           onProgressChanged: onProgressChanged != null
-               ? (controller, progress) =>
-                     onProgressChanged.call(controller, progress)
-               : null,
-           shouldOverrideUrlLoading: shouldOverrideUrlLoading != null
-               ? (controller, navigationAction) =>
-                     shouldOverrideUrlLoading(controller, navigationAction)
-               : null,
-           onLoadResource: onLoadResource != null
-               ? (controller, resource) =>
-                     onLoadResource.call(controller, resource)
-               : null,
-           onScrollChanged: onScrollChanged != null
-               ? (controller, x, y) => onScrollChanged.call(controller, x, y)
-               : null,
-           onDownloadStartRequest: onDownloadStartRequest != null
-               ? (controller, downloadStartRequest) => onDownloadStartRequest
-                     .call(controller, downloadStartRequest)
-               : null,
-           onLoadResourceWithCustomScheme:
-               onLoadResourceWithCustomScheme != null
-               ? (controller, request) =>
-                     onLoadResourceWithCustomScheme.call(controller, request)
-               : null,
-           onCreateWindow: onCreateWindow != null
-               ? (controller, createWindowAction) =>
-                     onCreateWindow.call(controller, createWindowAction)
-               : null,
-           onCloseWindow: onCloseWindow != null
-               ? (controller) => onCloseWindow.call(controller)
-               : null,
-           onJsAlert: onJsAlert != null
-               ? (controller, jsAlertRequest) =>
-                     onJsAlert.call(controller, jsAlertRequest)
-               : null,
-           onJsConfirm: onJsConfirm != null
-               ? (controller, jsConfirmRequest) =>
-                     onJsConfirm.call(controller, jsConfirmRequest)
-               : null,
-           onJsPrompt: onJsPrompt != null
-               ? (controller, jsPromptRequest) =>
-                     onJsPrompt.call(controller, jsPromptRequest)
-               : null,
-           onReceivedHttpAuthRequest: onReceivedHttpAuthRequest != null
-               ? (controller, challenge) =>
-                     onReceivedHttpAuthRequest.call(controller, challenge)
-               : null,
-           onReceivedServerTrustAuthRequest:
-               onReceivedServerTrustAuthRequest != null
-               ? (controller, challenge) => onReceivedServerTrustAuthRequest
-                     .call(controller, challenge)
-               : null,
-           onReceivedClientCertRequest: onReceivedClientCertRequest != null
-               ? (controller, challenge) =>
-                     onReceivedClientCertRequest.call(controller, challenge)
-               : null,
-           shouldInterceptAjaxRequest: shouldInterceptAjaxRequest != null
-               ? (controller, ajaxRequest) =>
-                     shouldInterceptAjaxRequest.call(controller, ajaxRequest)
-               : null,
-           onAjaxReadyStateChange: onAjaxReadyStateChange != null
-               ? (controller, ajaxRequest) =>
-                     onAjaxReadyStateChange.call(controller, ajaxRequest)
-               : null,
-           onAjaxProgress: onAjaxProgress != null
-               ? (controller, ajaxRequest) =>
-                     onAjaxProgress.call(controller, ajaxRequest)
-               : null,
-           shouldInterceptFetchRequest: shouldInterceptFetchRequest != null
-               ? (controller, fetchRequest) =>
-                     shouldInterceptFetchRequest.call(controller, fetchRequest)
-               : null,
-           onUpdateVisitedHistory: onUpdateVisitedHistory != null
-               ? (controller, url, isReload) =>
-                     onUpdateVisitedHistory.call(controller, url, isReload)
-               : null,
-           onPrintRequest: onPrintRequest != null
-               ? (controller, url, printJobController) =>
-                     onPrintRequest.call(controller, url, printJobController)
-               : null,
-           onLongPressHitTestResult: onLongPressHitTestResult != null
-               ? (controller, hitTestResult) =>
-                     onLongPressHitTestResult.call(controller, hitTestResult)
-               : null,
-           onEnterFullscreen: onEnterFullscreen != null
-               ? (controller) => onEnterFullscreen.call(controller)
-               : null,
-           onExitFullscreen: onExitFullscreen != null
-               ? (controller) => onExitFullscreen.call(controller)
-               : null,
-           onPageCommitVisible: onPageCommitVisible != null
-               ? (controller, url) => onPageCommitVisible.call(controller, url)
-               : null,
-           onTitleChanged: onTitleChanged != null
-               ? (controller, title) => onTitleChanged.call(controller, title)
-               : null,
-           onWindowFocus: onWindowFocus != null
-               ? (controller) => onWindowFocus.call(controller)
-               : null,
-           onWindowBlur: onWindowBlur != null
-               ? (controller) => onWindowBlur.call(controller)
-               : null,
-           onOverScrolled: onOverScrolled != null
-               ? (controller, x, y, clampedX, clampedY) =>
-                     onOverScrolled.call(controller, x, y, clampedX, clampedY)
-               : null,
-           onZoomScaleChanged: onZoomScaleChanged != null
-               ? (controller, oldScale, newScale) =>
-                     onZoomScaleChanged.call(controller, oldScale, newScale)
-               : null,
-           onSafeBrowsingHit: onSafeBrowsingHit != null
-               ? (controller, url, threatType) =>
-                     onSafeBrowsingHit.call(controller, url, threatType)
-               : null,
-           onPermissionRequest: onPermissionRequest != null
-               ? (controller, permissionRequest) =>
-                     onPermissionRequest.call(controller, permissionRequest)
-               : null,
-           onGeolocationPermissionsShowPrompt:
-               onGeolocationPermissionsShowPrompt != null
-               ? (controller, origin) =>
-                     onGeolocationPermissionsShowPrompt.call(controller, origin)
-               : null,
-           onGeolocationPermissionsHidePrompt:
-               onGeolocationPermissionsHidePrompt != null
-               ? (controller) =>
-                     onGeolocationPermissionsHidePrompt.call(controller)
-               : null,
-           shouldInterceptRequest: shouldInterceptRequest != null
-               ? (controller, request) =>
-                     shouldInterceptRequest.call(controller, request)
-               : null,
-           onRenderProcessGone: onRenderProcessGone != null
-               ? (controller, detail) =>
-                     onRenderProcessGone.call(controller, detail)
-               : null,
-           onRenderProcessResponsive: onRenderProcessResponsive != null
-               ? (controller) =>
-                     onRenderProcessResponsive.call(controller, null)
-               : null,
-           onRenderProcessUnresponsive: onRenderProcessUnresponsive != null
-               ? (controller) =>
-                     onRenderProcessUnresponsive.call(controller, null)
-               : null,
-           onFormResubmission: onFormResubmission != null
-               ? (controller, url) => onFormResubmission.call(controller, url)
-               : null,
-           onReceivedIcon: onReceivedIcon != null
-               ? (controller, icon) => onReceivedIcon.call(controller, icon)
-               : null,
-           onReceivedTouchIconUrl: onReceivedTouchIconUrl != null
-               ? (controller, url, precomposed) =>
-                     onReceivedTouchIconUrl.call(controller, url, precomposed)
-               : null,
-           onJsBeforeUnload: onJsBeforeUnload != null
-               ? (controller, jsBeforeUnloadRequest) =>
-                     onJsBeforeUnload.call(controller, jsBeforeUnloadRequest)
-               : null,
-           onReceivedLoginRequest: onReceivedLoginRequest != null
-               ? (controller, loginRequest) =>
-                     onReceivedLoginRequest.call(controller, loginRequest)
-               : null,
-           onPermissionRequestCanceled: onPermissionRequestCanceled != null
-               ? (controller, permissionRequest) => onPermissionRequestCanceled
-                     .call(controller, permissionRequest)
-               : null,
-           onRequestFocus: onRequestFocus != null
-               ? (controller) => onRequestFocus.call(controller)
-               : null,
-           onWebContentProcessDidTerminate:
-               onWebContentProcessDidTerminate != null
-               ? (controller) =>
-                     onWebContentProcessDidTerminate.call(controller)
-               : null,
-           onDidReceiveServerRedirectForProvisionalNavigation:
-               onDidReceiveServerRedirectForProvisionalNavigation != null
-               ? (controller) =>
-                     onDidReceiveServerRedirectForProvisionalNavigation.call(
-                       controller,
-                     )
-               : null,
-           onNavigationResponse: onNavigationResponse != null
-               ? (controller, navigationResponse) =>
-                     onNavigationResponse.call(controller, navigationResponse)
-               : null,
-           shouldAllowDeprecatedTLS: shouldAllowDeprecatedTLS != null
-               ? (controller, challenge) =>
-                     shouldAllowDeprecatedTLS.call(controller, challenge)
-               : null,
-           onCameraCaptureStateChanged: onCameraCaptureStateChanged != null
-               ? (controller, oldState, newState) => onCameraCaptureStateChanged
-                     .call(controller, oldState, newState)
-               : null,
-           onMicrophoneCaptureStateChanged:
-               onMicrophoneCaptureStateChanged != null
-               ? (controller, oldState, newState) =>
-                     onMicrophoneCaptureStateChanged.call(
-                       controller,
-                       oldState,
-                       newState,
-                     )
-               : null,
-           onContentSizeChanged: onContentSizeChanged != null
-               ? (controller, oldContentSize, newContentSize) =>
-                     onContentSizeChanged.call(
-                       controller,
-                       oldContentSize,
-                       newContentSize,
-                     )
-               : null,
-           onNetworkRequest: onNetworkRequest != null
-               ? (controller, request) =>
-                     onNetworkRequest.call(controller, request)
-               : null,
-           onNetworkResponse: onNetworkResponse != null
-               ? (controller, response) =>
-                     onNetworkResponse.call(controller, response)
-               : null,
-           onNetworkLoadingFinished: onNetworkLoadingFinished != null
-               ? (controller, responseBody) =>
-                     onNetworkLoadingFinished.call(controller, responseBody)
-               : null,
-           gestureRecognizers: gestureRecognizers,
-           headlessWebView: headlessWebView?.platform,
-           preventGestureDelay: preventGestureDelay,
-         ),
+                  );
+                  if (i < 2) {
+                    await Future.delayed(const Duration(milliseconds: 800));
+                  }
+                }
+              } catch (_) {}
+            }();
+          }
+        },
+        onReceivedError: onReceivedError != null
+            ? (controller, request, error) =>
+                  onReceivedError.call(controller, request, error)
+            : null,
+        onReceivedHttpError: onReceivedHttpError != null
+            ? (controller, request, errorResponse) =>
+                  onReceivedHttpError.call(controller, request, errorResponse)
+            : null,
+        onConsoleMessage: onConsoleMessage != null
+            ? (controller, consoleMessage) =>
+                  onConsoleMessage.call(controller, consoleMessage)
+            : null,
+        onProgressChanged: onProgressChanged != null
+            ? (controller, progress) =>
+                  onProgressChanged.call(controller, progress)
+            : null,
+        shouldOverrideUrlLoading: shouldOverrideUrlLoading != null
+            ? (controller, navigationAction) =>
+                  shouldOverrideUrlLoading(controller, navigationAction)
+            : null,
+        onLoadResource: onLoadResource != null
+            ? (controller, resource) =>
+                  onLoadResource.call(controller, resource)
+            : null,
+        onScrollChanged: onScrollChanged != null
+            ? (controller, x, y) => onScrollChanged.call(controller, x, y)
+            : null,
+        onDownloadStartRequest: onDownloadStartRequest != null
+            ? (controller, downloadStartRequest) =>
+                  onDownloadStartRequest.call(controller, downloadStartRequest)
+            : null,
+        onLoadResourceWithCustomScheme: onLoadResourceWithCustomScheme != null
+            ? (controller, request) =>
+                  onLoadResourceWithCustomScheme.call(controller, request)
+            : null,
+        onCreateWindow: onCreateWindow != null
+            ? (controller, createWindowAction) =>
+                  onCreateWindow.call(controller, createWindowAction)
+            : null,
+        onCloseWindow: onCloseWindow != null
+            ? (controller) => onCloseWindow.call(controller)
+            : null,
+        onJsAlert: onJsAlert != null
+            ? (controller, jsAlertRequest) =>
+                  onJsAlert.call(controller, jsAlertRequest)
+            : null,
+        onJsConfirm: onJsConfirm != null
+            ? (controller, jsConfirmRequest) =>
+                  onJsConfirm.call(controller, jsConfirmRequest)
+            : null,
+        onJsPrompt: onJsPrompt != null
+            ? (controller, jsPromptRequest) =>
+                  onJsPrompt.call(controller, jsPromptRequest)
+            : null,
+        onReceivedHttpAuthRequest: onReceivedHttpAuthRequest != null
+            ? (controller, challenge) =>
+                  onReceivedHttpAuthRequest.call(controller, challenge)
+            : null,
+        onReceivedServerTrustAuthRequest:
+            onReceivedServerTrustAuthRequest != null
+            ? (controller, challenge) =>
+                  onReceivedServerTrustAuthRequest.call(controller, challenge)
+            : null,
+        onReceivedClientCertRequest: onReceivedClientCertRequest != null
+            ? (controller, challenge) =>
+                  onReceivedClientCertRequest.call(controller, challenge)
+            : null,
+        shouldInterceptAjaxRequest: shouldInterceptAjaxRequest != null
+            ? (controller, ajaxRequest) =>
+                  shouldInterceptAjaxRequest.call(controller, ajaxRequest)
+            : null,
+        onAjaxReadyStateChange: onAjaxReadyStateChange != null
+            ? (controller, ajaxRequest) =>
+                  onAjaxReadyStateChange.call(controller, ajaxRequest)
+            : null,
+        onAjaxProgress: onAjaxProgress != null
+            ? (controller, ajaxRequest) =>
+                  onAjaxProgress.call(controller, ajaxRequest)
+            : null,
+        shouldInterceptFetchRequest: shouldInterceptFetchRequest != null
+            ? (controller, fetchRequest) =>
+                  shouldInterceptFetchRequest.call(controller, fetchRequest)
+            : null,
+        onUpdateVisitedHistory: onUpdateVisitedHistory != null
+            ? (controller, url, isReload) =>
+                  onUpdateVisitedHistory.call(controller, url, isReload)
+            : null,
+        onPrintRequest: onPrintRequest != null
+            ? (controller, url, printJobController) =>
+                  onPrintRequest.call(controller, url, printJobController)
+            : null,
+        onLongPressHitTestResult: onLongPressHitTestResult != null
+            ? (controller, hitTestResult) =>
+                  onLongPressHitTestResult.call(controller, hitTestResult)
+            : null,
+        onEnterFullscreen: onEnterFullscreen != null
+            ? (controller) => onEnterFullscreen.call(controller)
+            : null,
+        onExitFullscreen: onExitFullscreen != null
+            ? (controller) => onExitFullscreen.call(controller)
+            : null,
+        onPageCommitVisible: onPageCommitVisible != null
+            ? (controller, url) => onPageCommitVisible.call(controller, url)
+            : null,
+        onTitleChanged: onTitleChanged != null
+            ? (controller, title) => onTitleChanged.call(controller, title)
+            : null,
+        onWindowFocus: onWindowFocus != null
+            ? (controller) => onWindowFocus.call(controller)
+            : null,
+        onWindowBlur: onWindowBlur != null
+            ? (controller) => onWindowBlur.call(controller)
+            : null,
+        onOverScrolled: onOverScrolled != null
+            ? (controller, x, y, clampedX, clampedY) =>
+                  onOverScrolled.call(controller, x, y, clampedX, clampedY)
+            : null,
+        onZoomScaleChanged: onZoomScaleChanged != null
+            ? (controller, oldScale, newScale) =>
+                  onZoomScaleChanged.call(controller, oldScale, newScale)
+            : null,
+        onSafeBrowsingHit: onSafeBrowsingHit != null
+            ? (controller, url, threatType) =>
+                  onSafeBrowsingHit.call(controller, url, threatType)
+            : null,
+        onPermissionRequest: onPermissionRequest != null
+            ? (controller, permissionRequest) =>
+                  onPermissionRequest.call(controller, permissionRequest)
+            : null,
+        onGeolocationPermissionsShowPrompt:
+            onGeolocationPermissionsShowPrompt != null
+            ? (controller, origin) =>
+                  onGeolocationPermissionsShowPrompt.call(controller, origin)
+            : null,
+        onGeolocationPermissionsHidePrompt:
+            onGeolocationPermissionsHidePrompt != null
+            ? (controller) =>
+                  onGeolocationPermissionsHidePrompt.call(controller)
+            : null,
+        shouldInterceptRequest: shouldInterceptRequest != null
+            ? (controller, request) =>
+                  shouldInterceptRequest.call(controller, request)
+            : null,
+        onRenderProcessGone: onRenderProcessGone != null
+            ? (controller, detail) =>
+                  onRenderProcessGone.call(controller, detail)
+            : null,
+        onRenderProcessResponsive: onRenderProcessResponsive != null
+            ? (controller) => onRenderProcessResponsive.call(controller, null)
+            : null,
+        onRenderProcessUnresponsive: onRenderProcessUnresponsive != null
+            ? (controller) => onRenderProcessUnresponsive.call(controller, null)
+            : null,
+        onFormResubmission: onFormResubmission != null
+            ? (controller, url) => onFormResubmission.call(controller, url)
+            : null,
+        onReceivedIcon: onReceivedIcon != null
+            ? (controller, icon) => onReceivedIcon.call(controller, icon)
+            : null,
+        onReceivedTouchIconUrl: onReceivedTouchIconUrl != null
+            ? (controller, url, precomposed) =>
+                  onReceivedTouchIconUrl.call(controller, url, precomposed)
+            : null,
+        onJsBeforeUnload: onJsBeforeUnload != null
+            ? (controller, jsBeforeUnloadRequest) =>
+                  onJsBeforeUnload.call(controller, jsBeforeUnloadRequest)
+            : null,
+        onReceivedLoginRequest: onReceivedLoginRequest != null
+            ? (controller, loginRequest) =>
+                  onReceivedLoginRequest.call(controller, loginRequest)
+            : null,
+        onPermissionRequestCanceled: onPermissionRequestCanceled != null
+            ? (controller, permissionRequest) => onPermissionRequestCanceled
+                  .call(controller, permissionRequest)
+            : null,
+        onRequestFocus: onRequestFocus != null
+            ? (controller) => onRequestFocus.call(controller)
+            : null,
+        onWebContentProcessDidTerminate: onWebContentProcessDidTerminate != null
+            ? (controller) => onWebContentProcessDidTerminate.call(controller)
+            : null,
+        onDidReceiveServerRedirectForProvisionalNavigation:
+            onDidReceiveServerRedirectForProvisionalNavigation != null
+            ? (controller) => onDidReceiveServerRedirectForProvisionalNavigation
+                  .call(controller)
+            : null,
+        onNavigationResponse: onNavigationResponse != null
+            ? (controller, navigationResponse) =>
+                  onNavigationResponse.call(controller, navigationResponse)
+            : null,
+        shouldAllowDeprecatedTLS: shouldAllowDeprecatedTLS != null
+            ? (controller, challenge) =>
+                  shouldAllowDeprecatedTLS.call(controller, challenge)
+            : null,
+        onCameraCaptureStateChanged: onCameraCaptureStateChanged != null
+            ? (controller, oldState, newState) => onCameraCaptureStateChanged
+                  .call(controller, oldState, newState)
+            : null,
+        onMicrophoneCaptureStateChanged: onMicrophoneCaptureStateChanged != null
+            ? (controller, oldState, newState) =>
+                  onMicrophoneCaptureStateChanged.call(
+                    controller,
+                    oldState,
+                    newState,
+                  )
+            : null,
+        onContentSizeChanged: onContentSizeChanged != null
+            ? (controller, oldContentSize, newContentSize) =>
+                  onContentSizeChanged.call(
+                    controller,
+                    oldContentSize,
+                    newContentSize,
+                  )
+            : null,
+        onNetworkRequest: onNetworkRequest != null
+            ? (controller, request) =>
+                  onNetworkRequest.call(controller, request)
+            : null,
+        onNetworkResponse: onNetworkResponse != null
+            ? (controller, response) =>
+                  onNetworkResponse.call(controller, response)
+            : null,
+        onNetworkLoadingFinished: onNetworkLoadingFinished != null
+            ? (controller, responseBody) =>
+                  onNetworkLoadingFinished.call(controller, responseBody)
+            : null,
+        gestureRecognizers: gestureRecognizers,
+        headlessWebView: headlessWebView?.platform,
+        preventGestureDelay: preventGestureDelay,
+      ),
     );
   }
 
   @override
   _InAppWebViewState createState() => _InAppWebViewState();
+
+  /// Disposes the WebView and releases its resources.
+  ///
+  /// If [isKeepAlive] is `true`, the WebView is kept alive.
+  @override
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 }
 
 class _InAppWebViewState extends State<InAppWebView> {

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -13,7 +13,7 @@ import '../print_job/print_job_controller.dart';
 import 'network_capture/network_capture_manager.dart';
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController}
-class InAppWebViewController {
+class InAppWebViewController implements Disposable {
   /// Constructs a [InAppWebViewController].
   ///
   /// See [InAppWebViewController.fromPlatformCreationParams] for setting parameters for

--- a/zikzak_inappwebview/lib/src/print_job/print_job_controller.dart
+++ b/zikzak_inappwebview/lib/src/print_job/print_job_controller.dart
@@ -49,5 +49,6 @@ class PrintJobController {
   Future<PrintJobInfo?> getInfo() => platform.getInfo();
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformPrintJobController.dispose}
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 }

--- a/zikzak_inappwebview/lib/src/web_authentication_session/web_authenticate_session.dart
+++ b/zikzak_inappwebview/lib/src/web_authentication_session/web_authenticate_session.dart
@@ -68,7 +68,8 @@ class WebAuthenticationSession {
   Future<void> cancel() => platform.cancel();
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformWebAuthenticationSession.dispose}
-  Future<void> dispose() => platform.dispose();
+  Future<void> dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformWebAuthenticationSession.isAvailable}
   static Future<bool> isAvailable() =>

--- a/zikzak_inappwebview/lib/src/web_message/web_message_channel.dart
+++ b/zikzak_inappwebview/lib/src/web_message/web_message_channel.dart
@@ -51,7 +51,8 @@ class WebMessageChannel {
       WebMessagePort.fromPlatform(platform: platform.port2);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformWebMessageChannel.dispose}
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 
   @override
   String toString() => platform.toString();

--- a/zikzak_inappwebview/lib/src/web_message/web_message_listener.dart
+++ b/zikzak_inappwebview/lib/src/web_message/web_message_listener.dart
@@ -39,7 +39,8 @@ class WebMessageListener {
   OnPostMessageCallback? get onPostMessage => platform.onPostMessage;
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformWebMessageListener.dispose}
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 
   Map<String, dynamic> toMap() => platform.toMap();
 

--- a/zikzak_inappwebview/lib/src/web_storage/web_storage.dart
+++ b/zikzak_inappwebview/lib/src/web_storage/web_storage.dart
@@ -38,7 +38,8 @@ class WebStorage {
       SessionStorage.fromPlatform(platform: platform.sessionStorage);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformWebStorage.dispose}
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 }
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformStorage}
@@ -89,7 +90,8 @@ abstract class Storage implements PlatformStorage {
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformStorage.dispose}
   @override
-  void dispose() => platform.dispose();
+  void dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 }
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformLocalStorage}

--- a/zikzak_inappwebview/lib/src/webview_environment/webview_environment.dart
+++ b/zikzak_inappwebview/lib/src/webview_environment/webview_environment.dart
@@ -52,5 +52,6 @@ class WebViewEnvironment {
   );
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformWebViewEnvironment.dispose}
-  Future<void> dispose() => platform.dispose();
+  Future<void> dispose({bool isKeepAlive = false}) =>
+      platform.dispose(isKeepAlive: isKeepAlive);
 }

--- a/zikzak_inappwebview/test/disposable_pattern_test.dart
+++ b/zikzak_inappwebview/test/disposable_pattern_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+
+/// Compile-time assertion that [T] implements the [Disposable] interface.
+///
+/// If a wrapper class ever drops `implements Disposable`, this file stops
+/// compiling, so `flutter analyze` and `flutter test` both fail.
+void expectDisposable<T extends Disposable>() {}
+
+void main() {
+  group('Disposable pattern standardization', () {
+    test('wrapper classes implement Disposable', () {
+      // Compile-time checks: the generic bound only resolves when the
+      // wrapper class is assignable to [Disposable].
+      expectDisposable<InAppWebViewController>();
+      expectDisposable<InAppWebView>();
+      expectDisposable<HeadlessInAppWebView>();
+      expectDisposable<InAppLocalhostServer>();
+    });
+
+    test('Disposable declares the standardized dispose signature', () {
+      // The canonical signature: dispose({bool isKeepAlive = false}).
+      // A reference with the standardized type must be assignable from any
+      // implementation's tear-off; this is verified by the type system at
+      // compile time through the generic bound above, and documented here
+      // for readers.
+      void Function({bool isKeepAlive})? ref;
+      expect(ref, isNull);
+    });
+  });
+}

--- a/zikzak_inappwebview/test/disposable_pattern_test.dart
+++ b/zikzak_inappwebview/test/disposable_pattern_test.dart
@@ -7,6 +7,17 @@ import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
 /// compiling, so `flutter analyze` and `flutter test` both fail.
 void expectDisposable<T extends Disposable>() {}
 
+/// Probe implementing [Disposable] with the canonical signature:
+/// `void dispose({bool isKeepAlive = false})`.
+///
+/// If the interface ever drifts (for example the named parameter is
+/// renamed or its type changes), this override stops being a valid
+/// implementation and the file no longer compiles.
+class _ProbeDisposable implements Disposable {
+  @override
+  void dispose({bool isKeepAlive = false}) {}
+}
+
 void main() {
   group('Disposable pattern standardization', () {
     test('wrapper classes implement Disposable', () {
@@ -19,13 +30,13 @@ void main() {
     });
 
     test('Disposable declares the standardized dispose signature', () {
-      // The canonical signature: dispose({bool isKeepAlive = false}).
-      // A reference with the standardized type must be assignable from any
-      // implementation's tear-off; this is verified by the type system at
-      // compile time through the generic bound above, and documented here
-      // for readers.
-      void Function({bool isKeepAlive})? ref;
-      expect(ref, isNull);
+      // Compile-time probe: tearing dispose off through the [Disposable]
+      // interface type must yield exactly the canonical type
+      // `void Function({bool isKeepAlive})`. A drifted interface
+      // declaration fails this assignment at compile time.
+      final Disposable probe = _ProbeDisposable();
+      final void Function({bool isKeepAlive}) dispose = probe.dispose;
+      expect(dispose, isNotNull);
     });
   });
 }

--- a/zikzak_inappwebview_android/lib/src/chrome_safari_browser/chrome_safari_browser.dart
+++ b/zikzak_inappwebview_android/lib/src/chrome_safari_browser/chrome_safari_browser.dart
@@ -397,7 +397,7 @@ class AndroidChromeSafariBrowser extends PlatformChromeSafariBrowser
 
   @override
   @mustCallSuper
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     super.dispose();
     disposeChannel();
   }

--- a/zikzak_inappwebview_android/lib/src/cookie_manager.dart
+++ b/zikzak_inappwebview_android/lib/src/cookie_manager.dart
@@ -227,7 +227,7 @@ class AndroidCookieManager extends PlatformCookieManager
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/http_auth_credentials_database.dart
+++ b/zikzak_inappwebview_android/lib/src/http_auth_credentials_database.dart
@@ -155,7 +155,7 @@ class AndroidHttpAuthCredentialDatabase
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/in_app_browser/in_app_browser.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_browser/in_app_browser.dart
@@ -358,7 +358,7 @@ class AndroidInAppBrowser extends PlatformInAppBrowser with ChannelController {
 
   @override
   @mustCallSuper
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     super.dispose();
     disposeChannel();
     _webViewController?.dispose();

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
@@ -190,6 +191,14 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   /// [run] is still in flight is not silently ignored.
   bool _disposed = false;
 
+  /// Completes when an in-flight [run] finishes, including the deferred
+  /// native teardown it performs when [dispose] was called mid-startup.
+  ///
+  /// [dispose] waits on this so that `await dispose()` only returns once
+  /// the native side has been fully released. `null` when no [run] is in
+  /// flight.
+  Completer<void>? _runCompleter;
+
   static const MethodChannel _sharedChannel = const MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -279,12 +288,22 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
         'initialSize': params.initialSize.toMap(),
       },
     );
-    await _sharedChannel.invokeMethod('run', args);
-    _running = true;
-    if (_disposed) {
-      // dispose() was called while the native WebView was still starting:
-      // tear it down now that the native side exists.
-      await _disposeNative();
+    final runCompleter = Completer<void>();
+    _runCompleter = runCompleter;
+    try {
+      await _sharedChannel.invokeMethod('run', args);
+      _running = true;
+      if (_disposed) {
+        // dispose() was called while the native WebView was still starting:
+        // tear it down now that the native side exists.
+        await _disposeNative();
+      }
+    } finally {
+      // Unblock a dispose() call waiting for this in-flight run().
+      runCompleter.complete();
+      if (identical(_runCompleter, runCompleter)) {
+        _runCompleter = null;
+      }
     }
   }
 
@@ -360,24 +379,39 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     _disposed = true;
     if (!_running) {
       // run() has not completed yet (or was never called). If it is still
-      // in flight, it performs the cleanup itself once the native side is
-      // up; otherwise there is nothing to release.
+      // in flight, wait for it: run() performs the native cleanup itself
+      // once the native side is up. Otherwise there is nothing to release.
+      await _runCompleter?.future;
       return;
     }
     await _disposeNative();
   }
 
   Future<void> _disposeNative() async {
-    Map<String, dynamic> args = <String, dynamic>{};
-    await channel?.invokeMethod('dispose', args);
+    // Isolate each teardown step so that a single failure (for example the
+    // native side already being gone) cannot leave the rest undisposed.
+    try {
+      Map<String, dynamic> args = <String, dynamic>{};
+      await channel?.invokeMethod('dispose', args);
+    } catch (_) {
+      // The native WebView may already be gone; continue local teardown.
+    }
     disposeChannel();
     _started = false;
     _running = false;
-    _webViewController?.dispose();
+    try {
+      _webViewController?.dispose();
+    } catch (_) {
+      // Ignore controller teardown failures.
+    }
     _webViewController = null;
     _controllerFromPlatform = null;
-    _androidParams.pullToRefreshController?.dispose();
-    _androidParams.findInteractionController?.dispose();
+    try {
+      _androidParams.pullToRefreshController?.dispose();
+      _androidParams.findInteractionController?.dispose();
+    } catch (_) {
+      // Ignore auxiliary controller teardown failures.
+    }
   }
 }
 

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -184,6 +184,12 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   bool _started = false;
   bool _running = false;
 
+  /// Tracks whether [dispose] has been called.
+  ///
+  /// Kept separate from [_running] so that a [dispose] call issued while
+  /// [run] is still in flight is not silently ignored.
+  bool _disposed = false;
+
   static const MethodChannel _sharedChannel = const MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -241,7 +247,7 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   }
 
   Future<void> run() async {
-    if (_started) {
+    if (_started || _disposed) {
       return;
     }
     _started = true;
@@ -275,6 +281,11 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     );
     await _sharedChannel.invokeMethod('run', args);
     _running = true;
+    if (_disposed) {
+      // dispose() was called while the native WebView was still starting:
+      // tear it down now that the native side exists.
+      await _disposeNative();
+    }
   }
 
   void _inferInitialSettings(InAppWebViewSettings settings) {
@@ -343,9 +354,20 @@ class AndroidHeadlessInAppWebView extends PlatformHeadlessInAppWebView
 
   @override
   Future<void> dispose({bool isKeepAlive = false}) async {
-    if (!_running) {
+    if (_disposed) {
       return;
     }
+    _disposed = true;
+    if (!_running) {
+      // run() has not completed yet (or was never called). If it is still
+      // in flight, it performs the cleanup itself once the native side is
+      // up; otherwise there is nothing to release.
+      return;
+    }
+    await _disposeNative();
+  }
+
+  Future<void> _disposeNative() async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('dispose', args);
     disposeChannel();

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/in_app_webview.dart
@@ -373,8 +373,17 @@ class AndroidInAppWebViewWidget extends PlatformInAppWebViewWidget {
     }
   }
 
+  /// Whether [dispose] has already run. Both the public widget-level
+  /// dispose and the owning State's dispose route through this method, so
+  /// the guard keeps the teardown idempotent.
+  bool _disposed = false;
+
   @override
   void dispose({bool isKeepAlive = false}) {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     dynamic viewId = _controller?.getViewId();
     debugLog(
       className: runtimeType.toString(),
@@ -383,11 +392,13 @@ class AndroidInAppWebViewWidget extends PlatformInAppWebViewWidget {
       method: "dispose",
       args: [],
     );
-    final isKeepAlive = params.keepAlive != null;
-    _controller?.dispose(isKeepAlive: isKeepAlive);
+    // Combine the explicit argument with the keep-alive creation param;
+    // previously the argument was silently shadowed and ignored.
+    final keepAlive = isKeepAlive || params.keepAlive != null;
+    _controller?.dispose(isKeepAlive: keepAlive);
     _controller = null;
-    params.pullToRefreshController?.dispose(isKeepAlive: isKeepAlive);
-    params.findInteractionController?.dispose(isKeepAlive: isKeepAlive);
+    params.pullToRefreshController?.dispose(isKeepAlive: keepAlive);
+    params.findInteractionController?.dispose(isKeepAlive: keepAlive);
   }
 
   @override

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/in_app_webview.dart
@@ -374,7 +374,7 @@ class AndroidInAppWebViewWidget extends PlatformInAppWebViewWidget {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     dynamic viewId = _controller?.getViewId();
     debugLog(
       className: runtimeType.toString(),

--- a/zikzak_inappwebview_android/lib/src/print_job/print_job_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/print_job/print_job_controller.dart
@@ -78,7 +78,7 @@ class AndroidPrintJobController extends PlatformPrintJobController
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose({bool isKeepAlive = false}) async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('dispose', args);
     disposeChannel();

--- a/zikzak_inappwebview_android/lib/src/process_global_config.dart
+++ b/zikzak_inappwebview_android/lib/src/process_global_config.dart
@@ -72,7 +72,7 @@ class AndroidProcessGlobalConfig extends PlatformProcessGlobalConfig
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/proxy_controller.dart
@@ -20,7 +20,8 @@ class AndroidProxyControllerCreationParams
 
   /// Creates a [AndroidProxyControllerCreationParams] instance based on [PlatformProxyControllerCreationParams].
   factory AndroidProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
-      PlatformProxyControllerCreationParams params) {
+    PlatformProxyControllerCreationParams params,
+  ) {
     return AndroidProxyControllerCreationParams(params);
   }
 }
@@ -30,14 +31,16 @@ class AndroidProxyController extends PlatformProxyController
     with ChannelController {
   /// Creates a new [AndroidProxyController].
   AndroidProxyController(PlatformProxyControllerCreationParams params)
-      : super.implementation(
-          params is AndroidProxyControllerCreationParams
-              ? params
-              : AndroidProxyControllerCreationParams
-                  .fromPlatformProxyControllerCreationParams(params),
-        ) {
+    : super.implementation(
+        params is AndroidProxyControllerCreationParams
+            ? params
+            : AndroidProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
+                params,
+              ),
+      ) {
     channel = const MethodChannel(
-        'wtf.zikzak/zikzak_inappwebview_proxycontroller');
+      'wtf.zikzak/zikzak_inappwebview_proxycontroller',
+    );
     handler = handleMethod;
     initMethodCallHandler();
   }
@@ -50,8 +53,11 @@ class AndroidProxyController extends PlatformProxyController
   }
 
   static AndroidProxyController _init() {
-    _instance = AndroidProxyController(AndroidProxyControllerCreationParams(
-        const PlatformProxyControllerCreationParams()));
+    _instance = AndroidProxyController(
+      AndroidProxyControllerCreationParams(
+        const PlatformProxyControllerCreationParams(),
+      ),
+    );
     return _instance!;
   }
 
@@ -71,7 +77,7 @@ class AndroidProxyController extends PlatformProxyController
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/service_worker_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/service_worker_controller.dart
@@ -159,7 +159,7 @@ class AndroidServiceWorkerController extends PlatformServiceWorkerController
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/tracing_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/tracing_controller.dart
@@ -85,7 +85,7 @@ class AndroidTracingController extends PlatformTracingController
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/web_message/web_message_channel.dart
+++ b/zikzak_inappwebview_android/lib/src/web_message/web_message_channel.dart
@@ -123,7 +123,7 @@ class AndroidWebMessageChannel extends PlatformWebMessageChannel
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     disposeChannel();
   }
 

--- a/zikzak_inappwebview_android/lib/src/web_message/web_message_listener.dart
+++ b/zikzak_inappwebview_android/lib/src/web_message/web_message_listener.dart
@@ -100,7 +100,7 @@ class AndroidWebMessageListener extends PlatformWebMessageListener
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     disposeChannel();
   }
 

--- a/zikzak_inappwebview_android/lib/src/web_storage/web_storage.dart
+++ b/zikzak_inappwebview_android/lib/src/web_storage/web_storage.dart
@@ -48,7 +48,7 @@ class AndroidWebStorage extends PlatformWebStorage {
   PlatformSessionStorage get sessionStorage => params.sessionStorage;
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     localStorage.dispose();
     sessionStorage.dispose();
   }
@@ -194,7 +194,7 @@ mixin AndroidStorage implements PlatformStorage {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     controller = null;
   }
 }

--- a/zikzak_inappwebview_android/lib/src/web_storage/web_storage_manager.dart
+++ b/zikzak_inappwebview_android/lib/src/web_storage/web_storage_manager.dart
@@ -117,7 +117,7 @@ class AndroidWebStorageManager extends PlatformWebStorageManager
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_android/lib/src/webview_asset_loader.dart
+++ b/zikzak_inappwebview_android/lib/src/webview_asset_loader.dart
@@ -70,7 +70,7 @@ mixin AndroidPathHandler implements ChannelController, PlatformPathHandler {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     disposeChannel();
     eventHandler = null;
   }

--- a/zikzak_inappwebview_android/lib/src/webview_feature.dart
+++ b/zikzak_inappwebview_android/lib/src/webview_feature.dart
@@ -30,7 +30,7 @@ class AndroidWebViewFeature extends PlatformWebViewFeature
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 

--- a/zikzak_inappwebview_ios/lib/src/chrome_safari_browser/chrome_safari_browser.dart
+++ b/zikzak_inappwebview_ios/lib/src/chrome_safari_browser/chrome_safari_browser.dart
@@ -215,7 +215,7 @@ class IOSChromeSafariBrowser extends PlatformChromeSafariBrowser
 
   @override
   @mustCallSuper
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     super.dispose();
     disposeChannel();
   }

--- a/zikzak_inappwebview_ios/lib/src/cookie_manager.dart
+++ b/zikzak_inappwebview_ios/lib/src/cookie_manager.dart
@@ -462,7 +462,7 @@ class IOSCookieManager extends PlatformCookieManager with ChannelController {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_ios/lib/src/http_auth_credentials_database.dart
+++ b/zikzak_inappwebview_ios/lib/src/http_auth_credentials_database.dart
@@ -154,7 +154,7 @@ class IOSHttpAuthCredentialDatabase extends PlatformHttpAuthCredentialDatabase
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_ios/lib/src/in_app_browser/in_app_browser.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_browser/in_app_browser.dart
@@ -338,7 +338,7 @@ class IOSInAppBrowser extends PlatformInAppBrowser with ChannelController {
 
   @override
   @mustCallSuper
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     super.dispose();
     disposeChannel();
     _webViewController?.dispose();

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
@@ -187,6 +188,14 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   /// [run] is still in flight is not silently ignored.
   bool _disposed = false;
 
+  /// Completes when an in-flight [run] finishes, including the deferred
+  /// native teardown it performs when [dispose] was called mid-startup.
+  ///
+  /// [dispose] waits on this so that `await dispose()` only returns once
+  /// the native side has been fully released. `null` when no [run] is in
+  /// flight.
+  Completer<void>? _runCompleter;
+
   static const MethodChannel _sharedChannel = const MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -281,12 +290,22 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
         'initialSize': params.initialSize.toMap(),
       },
     );
-    await _sharedChannel.invokeMethod('run', args);
-    _running = true;
-    if (_disposed) {
-      // dispose() was called while the native WebView was still starting:
-      // tear it down now that the native side exists.
-      await _disposeNative();
+    final runCompleter = Completer<void>();
+    _runCompleter = runCompleter;
+    try {
+      await _sharedChannel.invokeMethod('run', args);
+      _running = true;
+      if (_disposed) {
+        // dispose() was called while the native WebView was still starting:
+        // tear it down now that the native side exists.
+        await _disposeNative();
+      }
+    } finally {
+      // Unblock a dispose() call waiting for this in-flight run().
+      runCompleter.complete();
+      if (identical(_runCompleter, runCompleter)) {
+        _runCompleter = null;
+      }
     }
   }
 
@@ -362,24 +381,39 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     _disposed = true;
     if (!_running) {
       // run() has not completed yet (or was never called). If it is still
-      // in flight, it performs the cleanup itself once the native side is
-      // up; otherwise there is nothing to release.
+      // in flight, wait for it: run() performs the native cleanup itself
+      // once the native side is up. Otherwise there is nothing to release.
+      await _runCompleter?.future;
       return;
     }
     await _disposeNative();
   }
 
   Future<void> _disposeNative() async {
-    Map<String, dynamic> args = <String, dynamic>{};
-    await channel?.invokeMethod('dispose', args);
+    // Isolate each teardown step so that a single failure (for example the
+    // native side already being gone) cannot leave the rest undisposed.
+    try {
+      Map<String, dynamic> args = <String, dynamic>{};
+      await channel?.invokeMethod('dispose', args);
+    } catch (_) {
+      // The native WebView may already be gone; continue local teardown.
+    }
     disposeChannel();
     _started = false;
     _running = false;
-    _webViewController?.dispose();
+    try {
+      _webViewController?.dispose();
+    } catch (_) {
+      // Ignore controller teardown failures.
+    }
     _webViewController = null;
     _controllerFromPlatform = null;
-    _iosParams.pullToRefreshController?.dispose();
-    _iosParams.findInteractionController?.dispose();
+    try {
+      _iosParams.pullToRefreshController?.dispose();
+      _iosParams.findInteractionController?.dispose();
+    } catch (_) {
+      // Ignore auxiliary controller teardown failures.
+    }
   }
 }
 

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -181,6 +181,12 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   bool _started = false;
   bool _running = false;
 
+  /// Tracks whether [dispose] has been called.
+  ///
+  /// Kept separate from [_running] so that a [dispose] call issued while
+  /// [run] is still in flight is not silently ignored.
+  bool _disposed = false;
+
   static const MethodChannel _sharedChannel = const MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -235,7 +241,7 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   }
 
   Future<void> run() async {
-    if (_started) {
+    if (_started || _disposed) {
       return;
     }
     _started = true;
@@ -277,6 +283,11 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     );
     await _sharedChannel.invokeMethod('run', args);
     _running = true;
+    if (_disposed) {
+      // dispose() was called while the native WebView was still starting:
+      // tear it down now that the native side exists.
+      await _disposeNative();
+    }
   }
 
   void _inferInitialSettings(InAppWebViewSettings settings) {
@@ -345,9 +356,20 @@ class IOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
 
   @override
   Future<void> dispose({bool isKeepAlive = false}) async {
-    if (!_running) {
+    if (_disposed) {
       return;
     }
+    _disposed = true;
+    if (!_running) {
+      // run() has not completed yet (or was never called). If it is still
+      // in flight, it performs the cleanup itself once the native side is
+      // up; otherwise there is nothing to release.
+      return;
+    }
+    await _disposeNative();
+  }
+
+  Future<void> _disposeNative() async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('dispose', args);
     disposeChannel();

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/in_app_webview.dart
@@ -317,8 +317,17 @@ class IOSInAppWebViewWidget extends PlatformInAppWebViewWidget {
     }
   }
 
+  /// Whether [dispose] has already run. Both the public widget-level
+  /// dispose and the owning State's dispose route through this method, so
+  /// the guard keeps the teardown idempotent.
+  bool _disposed = false;
+
   @override
   void dispose({bool isKeepAlive = false}) {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     dynamic viewId = _controller?.getViewId();
     debugLog(
       className: runtimeType.toString(),
@@ -327,11 +336,13 @@ class IOSInAppWebViewWidget extends PlatformInAppWebViewWidget {
       method: "dispose",
       args: [],
     );
-    final isKeepAlive = params.keepAlive != null;
-    _controller?.dispose(isKeepAlive: isKeepAlive);
+    // Combine the explicit argument with the keep-alive creation param;
+    // previously the argument was silently shadowed and ignored.
+    final keepAlive = isKeepAlive || params.keepAlive != null;
+    _controller?.dispose(isKeepAlive: keepAlive);
     _controller = null;
-    params.pullToRefreshController?.dispose(isKeepAlive: isKeepAlive);
-    params.findInteractionController?.dispose(isKeepAlive: isKeepAlive);
+    params.pullToRefreshController?.dispose(isKeepAlive: keepAlive);
+    params.findInteractionController?.dispose(isKeepAlive: keepAlive);
   }
 
   @override

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/in_app_webview.dart
@@ -318,7 +318,7 @@ class IOSInAppWebViewWidget extends PlatformInAppWebViewWidget {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     dynamic viewId = _controller?.getViewId();
     debugLog(
       className: runtimeType.toString(),

--- a/zikzak_inappwebview_ios/lib/src/print_job/print_job_controller.dart
+++ b/zikzak_inappwebview_ios/lib/src/print_job/print_job_controller.dart
@@ -81,7 +81,7 @@ class IOSPrintJobController extends PlatformPrintJobController
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose({bool isKeepAlive = false}) async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('dispose', args);
     disposeChannel();

--- a/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
-class IosProxyControllerCreationParams extends PlatformProxyControllerCreationParams {
+class IosProxyControllerCreationParams
+    extends PlatformProxyControllerCreationParams {
   /// Creates a new [IosProxyControllerCreationParams] instance.
   const IosProxyControllerCreationParams(
     // This parameter prevents breaking changes later.
@@ -17,14 +18,19 @@ class IosProxyControllerCreationParams extends PlatformProxyControllerCreationPa
   }
 }
 
-class IosProxyController extends PlatformProxyController with ChannelController {
+class IosProxyController extends PlatformProxyController
+    with ChannelController {
   IosProxyController(PlatformProxyControllerCreationParams params)
-      : super.implementation(
-          params is IosProxyControllerCreationParams
-              ? params
-              : IosProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(params),
-        ) {
-    channel = const MethodChannel('wtf.zikzak/zikzak_inappwebview_proxycontroller');
+    : super.implementation(
+        params is IosProxyControllerCreationParams
+            ? params
+            : IosProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
+                params,
+              ),
+      ) {
+    channel = const MethodChannel(
+      'wtf.zikzak/zikzak_inappwebview_proxycontroller',
+    );
     handler = _handleMethod;
     initMethodCallHandler();
   }
@@ -36,7 +42,11 @@ class IosProxyController extends PlatformProxyController with ChannelController 
   }
 
   static IosProxyController _init() {
-    _instance = IosProxyController(IosProxyControllerCreationParams(const PlatformProxyControllerCreationParams()));
+    _instance = IosProxyController(
+      IosProxyControllerCreationParams(
+        const PlatformProxyControllerCreationParams(),
+      ),
+    );
     return _instance!;
   }
 
@@ -55,7 +65,7 @@ class IosProxyController extends PlatformProxyController with ChannelController 
   Future<dynamic> _handleMethod(MethodCall call) async {}
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty.
   }
 }

--- a/zikzak_inappwebview_ios/lib/src/web_authentication_session/web_authenticate_session.dart
+++ b/zikzak_inappwebview_ios/lib/src/web_authentication_session/web_authenticate_session.dart
@@ -156,7 +156,7 @@ class IOSWebAuthenticationSession extends PlatformWebAuthenticationSession
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose({bool isKeepAlive = false}) async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod("dispose", args);
     disposeChannel();

--- a/zikzak_inappwebview_ios/lib/src/web_message/web_message_channel.dart
+++ b/zikzak_inappwebview_ios/lib/src/web_message/web_message_channel.dart
@@ -115,7 +115,7 @@ class IOSWebMessageChannel extends PlatformWebMessageChannel
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     disposeChannel();
   }
 

--- a/zikzak_inappwebview_ios/lib/src/web_message/web_message_listener.dart
+++ b/zikzak_inappwebview_ios/lib/src/web_message/web_message_listener.dart
@@ -100,7 +100,7 @@ class IOSWebMessageListener extends PlatformWebMessageListener
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     disposeChannel();
   }
 

--- a/zikzak_inappwebview_ios/lib/src/web_storage/web_storage.dart
+++ b/zikzak_inappwebview_ios/lib/src/web_storage/web_storage.dart
@@ -48,7 +48,7 @@ class IOSWebStorage extends PlatformWebStorage {
   PlatformSessionStorage get sessionStorage => params.sessionStorage;
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     localStorage.dispose();
     sessionStorage.dispose();
   }
@@ -194,7 +194,7 @@ abstract mixin class IOSStorage implements PlatformStorage {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     controller = null;
   }
 }

--- a/zikzak_inappwebview_ios/lib/src/web_storage/web_storage_manager.dart
+++ b/zikzak_inappwebview_ios/lib/src/web_storage/web_storage_manager.dart
@@ -149,7 +149,7 @@ class IOSWebStorageManager extends PlatformWebStorageManager
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // empty
   }
 }

--- a/zikzak_inappwebview_linux/lib/src/cookie_manager.dart
+++ b/zikzak_inappwebview_linux/lib/src/cookie_manager.dart
@@ -74,7 +74,7 @@ class LinuxCookieManager extends PlatformCookieManager {
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose({bool isKeepAlive = false}) async {
     // TODO: implement dispose
   }
 }

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import '../find_interaction/find_interaction_controller.dart';
@@ -169,6 +171,14 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   /// [run] is still in flight is not silently ignored.
   bool _disposed = false;
 
+  /// Completes when an in-flight [run] finishes, including the deferred
+  /// native teardown it performs when [dispose] was called mid-startup.
+  ///
+  /// [dispose] waits on this so that `await dispose()` only returns once
+  /// the native side has been fully released. `null` when no [run] is in
+  /// flight.
+  Completer<void>? _runCompleter;
+
   static const MethodChannel _sharedChannel = MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -270,12 +280,22 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
         'initialSize': params.initialSize.toMap(),
       },
     );
-    await _sharedChannel.invokeMethod('run', args);
-    _running = true;
-    if (_disposed) {
-      // dispose() was called while the native WebView was still starting:
-      // tear it down now that the native side exists.
-      await _disposeNative();
+    final runCompleter = Completer<void>();
+    _runCompleter = runCompleter;
+    try {
+      await _sharedChannel.invokeMethod('run', args);
+      _running = true;
+      if (_disposed) {
+        // dispose() was called while the native WebView was still starting:
+        // tear it down now that the native side exists.
+        await _disposeNative();
+      }
+    } finally {
+      // Unblock a dispose() call waiting for this in-flight run().
+      runCompleter.complete();
+      if (identical(_runCompleter, runCompleter)) {
+        _runCompleter = null;
+      }
     }
   }
 
@@ -347,21 +367,36 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     _disposed = true;
     if (!_running) {
       // run() has not completed yet (or was never called). If it is still
-      // in flight, it performs the cleanup itself once the native side is
-      // up; otherwise there is nothing to release.
+      // in flight, wait for it: run() performs the native cleanup itself
+      // once the native side is up. Otherwise there is nothing to release.
+      await _runCompleter?.future;
       return;
     }
     await _disposeNative();
   }
 
   Future<void> _disposeNative() async {
-    await _sharedChannel.invokeMethod('dispose', <String, dynamic>{'id': id});
+    // Isolate each teardown step so that a single failure (for example the
+    // native side already being gone) cannot leave the rest undisposed.
+    try {
+      await _sharedChannel.invokeMethod('dispose', <String, dynamic>{'id': id});
+    } catch (_) {
+      // The native WebView may already be gone; continue local teardown.
+    }
     disposeChannel();
     _started = false;
     _running = false;
-    _webViewController?.dispose();
+    try {
+      _webViewController?.dispose();
+    } catch (_) {
+      // Ignore controller teardown failures.
+    }
     _webViewController = null;
     _controllerFromPlatform = null;
-    _linuxParams.findInteractionController?.dispose();
+    try {
+      _linuxParams.findInteractionController?.dispose();
+    } catch (_) {
+      // Ignore auxiliary controller teardown failures.
+    }
   }
 }

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -163,6 +163,12 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   bool _started = false;
   bool _running = false;
 
+  /// Tracks whether [dispose] has been called.
+  ///
+  /// Kept separate from [_running] so that a [dispose] call issued while
+  /// [run] is still in flight is not silently ignored.
+  bool _disposed = false;
+
   static const MethodChannel _sharedChannel = MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -224,7 +230,7 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
 
   @override
   Future<void> run() async {
-    if (_started) {
+    if (_started || _disposed) {
       return;
     }
     _started = true;
@@ -266,6 +272,11 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     );
     await _sharedChannel.invokeMethod('run', args);
     _running = true;
+    if (_disposed) {
+      // dispose() was called while the native WebView was still starting:
+      // tear it down now that the native side exists.
+      await _disposeNative();
+    }
   }
 
   void _inferInitialSettings(InAppWebViewSettings settings) {
@@ -330,9 +341,20 @@ class LinuxHeadlessInAppWebView extends PlatformHeadlessInAppWebView
 
   @override
   Future<void> dispose({bool isKeepAlive = false}) async {
-    if (!_running) {
+    if (_disposed) {
       return;
     }
+    _disposed = true;
+    if (!_running) {
+      // run() has not completed yet (or was never called). If it is still
+      // in flight, it performs the cleanup itself once the native side is
+      // up; otherwise there is nothing to release.
+      return;
+    }
+    await _disposeNative();
+  }
+
+  Future<void> _disposeNative() async {
     await _sharedChannel.invokeMethod('dispose', <String, dynamic>{'id': id});
     disposeChannel();
     _started = false;

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview.dart
@@ -105,7 +105,7 @@ class _LinuxInAppWebViewState extends State<_LinuxInAppWebView> {
 
   @override
   void dispose() {
-    _controller?.dispose();
+    _controller?.dispose(isKeepAlive: widget.params.keepAlive != null);
     _controller = null;
     super.dispose();
   }

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview.dart
@@ -14,7 +14,7 @@ class LinuxInAppWebViewWidget extends PlatformInAppWebViewWidget {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     // nothing to dispose here, the widget disposes the controller
   }
 
@@ -60,8 +60,10 @@ class _LinuxInAppWebViewState extends State<_LinuxInAppWebView> {
           'initialUrlRequest': widget.params.initialUrlRequest?.toMap(),
           'initialData': widget.params.initialData?.toMap(),
           'initialUserScripts':
-              widget.params.initialUserScripts?.map((e) => e.toMap()).toList() ??
-                  [],
+              widget.params.initialUserScripts
+                  ?.map((e) => e.toMap())
+                  .toList() ??
+              [],
         },
       });
       if (textureId != null && mounted) {

--- a/zikzak_inappwebview_macos/lib/src/cookie_manager.dart
+++ b/zikzak_inappwebview_macos/lib/src/cookie_manager.dart
@@ -180,7 +180,7 @@ class MacOSCookieManager extends PlatformCookieManager {
   }
 
   @override
-  Future<void> dispose() async {
+  Future<void> dispose({bool isKeepAlive = false}) async {
     // nothing to dispose
   }
 }

--- a/zikzak_inappwebview_macos/lib/src/in_app_browser/in_app_browser.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_browser/in_app_browser.dart
@@ -277,7 +277,7 @@ class MacOSInAppBrowser extends PlatformInAppBrowser with ChannelController {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     _channel?.setMethodCallHandler(null);
     _webViewController?.dispose();
     _webViewController = null;

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import '../find_interaction/find_interaction_controller.dart';
@@ -180,6 +182,14 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   /// [run] is still in flight is not silently ignored.
   bool _disposed = false;
 
+  /// Completes when an in-flight [run] finishes, including the deferred
+  /// native teardown it performs when [dispose] was called mid-startup.
+  ///
+  /// [dispose] waits on this so that `await dispose()` only returns once
+  /// the native side has been fully released. `null` when no [run] is in
+  /// flight.
+  Completer<void>? _runCompleter;
+
   static const MethodChannel _sharedChannel = const MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -283,12 +293,22 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
         'initialSize': params.initialSize.toMap(),
       },
     );
-    await _sharedChannel.invokeMethod('run', args);
-    _running = true;
-    if (_disposed) {
-      // dispose() was called while the native WebView was still starting:
-      // tear it down now that the native side exists.
-      await _disposeNative();
+    final runCompleter = Completer<void>();
+    _runCompleter = runCompleter;
+    try {
+      await _sharedChannel.invokeMethod('run', args);
+      _running = true;
+      if (_disposed) {
+        // dispose() was called while the native WebView was still starting:
+        // tear it down now that the native side exists.
+        await _disposeNative();
+      }
+    } finally {
+      // Unblock a dispose() call waiting for this in-flight run().
+      runCompleter.complete();
+      if (identical(_runCompleter, runCompleter)) {
+        _runCompleter = null;
+      }
     }
   }
 
@@ -364,24 +384,39 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     _disposed = true;
     if (!_running) {
       // run() has not completed yet (or was never called). If it is still
-      // in flight, it performs the cleanup itself once the native side is
-      // up; otherwise there is nothing to release.
+      // in flight, wait for it: run() performs the native cleanup itself
+      // once the native side is up. Otherwise there is nothing to release.
+      await _runCompleter?.future;
       return;
     }
     await _disposeNative();
   }
 
   Future<void> _disposeNative() async {
-    Map<String, dynamic> args = <String, dynamic>{};
-    await channel?.invokeMethod('dispose', args);
+    // Isolate each teardown step so that a single failure (for example the
+    // native side already being gone) cannot leave the rest undisposed.
+    try {
+      Map<String, dynamic> args = <String, dynamic>{};
+      await channel?.invokeMethod('dispose', args);
+    } catch (_) {
+      // The native WebView may already be gone; continue local teardown.
+    }
     disposeChannel();
     _started = false;
     _running = false;
-    _webViewController?.dispose();
+    try {
+      _webViewController?.dispose();
+    } catch (_) {
+      // Ignore controller teardown failures.
+    }
     _webViewController = null;
     _controllerFromPlatform = null;
-    // _macosParams.pullToRefreshController?.dispose();
-    _macosParams.findInteractionController?.dispose();
+    try {
+      // _macosParams.pullToRefreshController?.dispose();
+      _macosParams.findInteractionController?.dispose();
+    } catch (_) {
+      // Ignore auxiliary controller teardown failures.
+    }
   }
 }
 

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -174,6 +174,12 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   bool _started = false;
   bool _running = false;
 
+  /// Tracks whether [dispose] has been called.
+  ///
+  /// Kept separate from [_running] so that a [dispose] call issued while
+  /// [run] is still in flight is not silently ignored.
+  bool _disposed = false;
+
   static const MethodChannel _sharedChannel = const MethodChannel(
     'wtf.zikzak/flutter_headless_inappwebview',
   );
@@ -237,7 +243,7 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   }
 
   Future<void> run() async {
-    if (_started) {
+    if (_started || _disposed) {
       return;
     }
     _started = true;
@@ -279,6 +285,11 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
     );
     await _sharedChannel.invokeMethod('run', args);
     _running = true;
+    if (_disposed) {
+      // dispose() was called while the native WebView was still starting:
+      // tear it down now that the native side exists.
+      await _disposeNative();
+    }
   }
 
   void _inferInitialSettings(InAppWebViewSettings settings) {
@@ -347,9 +358,20 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
 
   @override
   Future<void> dispose({bool isKeepAlive = false}) async {
-    if (!_running) {
+    if (_disposed) {
       return;
     }
+    _disposed = true;
+    if (!_running) {
+      // run() has not completed yet (or was never called). If it is still
+      // in flight, it performs the cleanup itself once the native side is
+      // up; otherwise there is nothing to release.
+      return;
+    }
+    await _disposeNative();
+  }
+
+  Future<void> _disposeNative() async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('dispose', args);
     disposeChannel();

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart
@@ -55,9 +55,18 @@ class MacOSInAppWebViewWidget extends PlatformInAppWebViewWidget {
     }
   }
 
+  /// Whether [dispose] has already run. Both the public widget-level
+  /// dispose and the owning State's dispose route through this method, so
+  /// the guard keeps the teardown idempotent.
+  bool _disposed = false;
+
   @override
   void dispose({bool isKeepAlive = false}) {
-    _controller?.dispose();
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _controller?.dispose(isKeepAlive: isKeepAlive || params.keepAlive != null);
     _controller = null;
   }
 

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart
@@ -56,7 +56,7 @@ class MacOSInAppWebViewWidget extends PlatformInAppWebViewWidget {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     _controller?.dispose();
     _controller = null;
   }

--- a/zikzak_inappwebview_platform_interface/lib/src/chrome_safari_browser/platform_chrome_safari_browser.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/chrome_safari_browser/platform_chrome_safari_browser.dart
@@ -494,7 +494,7 @@ abstract class PlatformChromeSafariBrowser extends PlatformInterface
   ///{@endtemplate}
   @override
   @mustCallSuper
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     eventHandler = null;
   }
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_browser/platform_in_app_browser.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_browser/platform_in_app_browser.dart
@@ -506,7 +506,7 @@ abstract class PlatformInAppBrowser extends PlatformInterface
   ///{@endtemplate}
   @override
   @mustCallSuper
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     eventHandler = null;
   }
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_widget.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_widget.dart
@@ -204,5 +204,5 @@ abstract class PlatformInAppWebViewWidget extends PlatformInterface
   T controllerFromPlatform<T>(PlatformInAppWebViewController controller);
 
   @override
-  void dispose();
+  void dispose({bool isKeepAlive = false});
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/print_job/platform_print_job_controller.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/print_job/platform_print_job_controller.dart
@@ -152,7 +152,7 @@ abstract class PlatformPrintJobController extends PlatformInterface
   ///- MacOS
   ///{@endtemplate}
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'dispose is not implemented on the current platform',
     );

--- a/zikzak_inappwebview_platform_interface/lib/src/types/disposable.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/types/disposable.dart
@@ -1,3 +1,3 @@
 abstract class Disposable {
-  void dispose();
+  void dispose({bool isKeepAlive = false});
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/web_authentication_session/platform_web_authenticate_session.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/web_authentication_session/platform_web_authenticate_session.dart
@@ -212,7 +212,7 @@ abstract class PlatformWebAuthenticationSession extends PlatformInterface
   ///- MacOS
   ///{@endtemplate}
   @override
-  Future<void> dispose() {
+  Future<void> dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'cancel is not implemented on the current platform',
     );

--- a/zikzak_inappwebview_platform_interface/lib/src/web_message/platform_web_message_channel.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/web_message/platform_web_message_channel.dart
@@ -112,7 +112,7 @@ abstract class PlatformWebMessageChannel extends PlatformInterface
   ///Disposes the web message channel.
   ///{@endtemplate}
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'dispose is not implemented on the current platform',
     );

--- a/zikzak_inappwebview_platform_interface/lib/src/web_message/platform_web_message_listener.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/web_message/platform_web_message_listener.dart
@@ -114,7 +114,7 @@ abstract class PlatformWebMessageListener extends PlatformInterface
   ///Disposes the channel.
   ///{@endtemplate}
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'dispose is not implemented on the current platform.',
     );

--- a/zikzak_inappwebview_platform_interface/lib/src/web_storage/platform_web_storage.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/web_storage/platform_web_storage.dart
@@ -79,7 +79,7 @@ abstract class PlatformWebStorage extends PlatformInterface
   ///{@template zikzak_inappwebview_platform_interface.PlatformWebStorage.dispose}
   ///Disposes the web storage.
   ///{@endtemplate}
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'dispose is not implemented on the current platform',
     );
@@ -243,7 +243,7 @@ abstract mixin class PlatformStorage implements Disposable {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'dispose is not implemented on the current platform',
     );

--- a/zikzak_inappwebview_platform_interface/lib/src/webview_environment/platform_webview_environment.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/webview_environment/platform_webview_environment.dart
@@ -145,7 +145,7 @@ abstract class PlatformWebViewEnvironment extends PlatformInterface
   ///{@template zikzak_inappwebview_platform_interface.PlatformWebViewEnvironment.dispose}
   ///Disposes the WebView Environment reference.
   ///{@endtemplate}
-  Future<void> dispose() {
+  Future<void> dispose({bool isKeepAlive = false}) {
     throw UnimplementedError(
       'dispose is not implemented on the current platform',
     );

--- a/zikzak_inappwebview_web/lib/src/in_app_webview_web_element.dart
+++ b/zikzak_inappwebview_web/lib/src/in_app_webview_web_element.dart
@@ -86,8 +86,17 @@ class InAppWebViewWebElement extends PlatformInAppWebViewWidget {
     return controller as T;
   }
 
+  /// Whether [dispose] has already run. Both the public widget-level
+  /// dispose and the owning State's dispose route through this method, so
+  /// the guard keeps the teardown idempotent.
+  bool _disposed = false;
+
   @override
   void dispose({bool isKeepAlive = false}) {
-    _controller.dispose();
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _controller.dispose(isKeepAlive: isKeepAlive);
   }
 }

--- a/zikzak_inappwebview_web/lib/src/in_app_webview_web_element.dart
+++ b/zikzak_inappwebview_web/lib/src/in_app_webview_web_element.dart
@@ -87,7 +87,7 @@ class InAppWebViewWebElement extends PlatformInAppWebViewWidget {
   }
 
   @override
-  void dispose() {
+  void dispose({bool isKeepAlive = false}) {
     _controller.dispose();
   }
 }

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -27,7 +27,7 @@ class InAppWebViewWindowsWidget extends PlatformInAppWebViewWidget {
   }
 
   @override
-  void dispose() {}
+  void dispose({bool isKeepAlive = false}) {}
 
   @override
   T controllerFromPlatform<T>(dynamic platformController) {


### PR DESCRIPTION
Implements P1 from #161: standardize the Disposable interface across all wrapper classes and fix dispose-related bugs.

## Changes

- **Disposable interface**: adopt `dispose({bool isKeepAlive = false})` as the canonical signature; updated all implementations across every package (platform interface, main, android, ios, macos, linux, windows, web)
- **Wrapper classes now implement `Disposable`**: `InAppWebViewController`, `InAppWebView`, `HeadlessInAppWebView`, `InAppLocalhostServer`
- **`InAppLocalhostServer`**: added `dispose()` that stops the server (async close) and guards against double disposal; added `disposed` getter
- **`HeadlessInAppWebView` double-dispose fix** (android/ios/macos/linux): track `_disposed` separately from `_running`. Previously, calling `dispose()` before `run()` completed returned early (`_running` still false) and leaked the native WebView. Now the pending run tears down the native side as soon as it finishes starting, and repeated `dispose()` calls are no-ops.

## Tests (P2)

- `example/integration_test/lifecycle_test.dart`: hot restart (reassemble), background -> foreground without MissingPluginException, plugin registration without Activity (FlutterFragment scenario), HeadlessInAppWebView dispose-before-run + double-dispose, InAppLocalhostServer dispose stops server, runtime isA<Disposable> checks; Windows Program Files scenario included as skipped (requires Windows CI)
- `zikzak_inappwebview/test/disposable_pattern_test.dart`: compile-time assertions that the wrapper classes implement Disposable (regression guard)

## Verification

- `flutter analyze`: 0 errors across all 9 packages (platform_interface, main, android, ios, macos, linux, windows, web, example)
- `flutter test`: all existing + new unit tests pass (platform_interface 8, macos 9, main 2)
- `dart format` clean on all touched files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized disposal APIs with optional keep-alive support across WebView components and related services.
  * Added explicit disposable lifecycle support for WebViews, controllers, headless WebViews, and localhost servers.
  * Headless WebView disposal is now safe during startup and can be called repeatedly without errors.
* **Bug Fixes**
  * Improved lifecycle handling across hot restart, app pause/resume, and activity-less scenarios.
  * Localhost server disposal now reliably stops the server and safely handles repeated calls.
* **Tests**
  * Added comprehensive lifecycle, disposal, and interface conformance coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->