### PR TITLE
refactor: split InAppWebViewController into domain-specific controllers

### DIFF
--- a/zikzak_inappwebview/lib/src/in_app_webview/controllers/cookie_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/controllers/cookie_controller.dart
@@ -1,0 +1,130 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../../cookie_manager.dart';
+import '../in_app_webview_controller.dart';
+
+///Domain-specific facade of [InAppWebViewController] for cookie management
+///scoped to this WebView.
+///
+///Part of the domain controller split (issue #161, P3). Wraps the shared
+///[CookieManager] so cookie operations default to the WebView's current URL
+///and pass this controller as context — while still allowing explicit URLs
+///and global operations.
+class CookieController {
+  final InAppWebViewController _controller;
+  CookieManager? _cookieManager;
+
+  ///Creates a [CookieController] bound to the given controller.
+  CookieController(this._controller);
+
+  CookieManager get _cookies => _cookieManager ??= CookieManager.instance();
+
+  Future<WebUri?> _resolveUrl(WebUri? url) async =>
+      url ?? await _controller.getUrl();
+
+  ///Gets the cookies for [url], or for the WebView's current URL when
+  ///[url] is omitted. Returns an empty list when no URL is available.
+  Future<List<Cookie>> getCookies({WebUri? url}) async {
+    final resolved = await _resolveUrl(url);
+    if (resolved == null) {
+      return [];
+    }
+    return _cookies.getCookies(url: resolved, webViewController: _controller);
+  }
+
+  ///Gets the cookie named [name] for [url], or for the WebView's current
+  ///URL when [url] is omitted.
+  Future<Cookie?> getCookie({required String name, WebUri? url}) async {
+    final resolved = await _resolveUrl(url);
+    if (resolved == null) {
+      return null;
+    }
+    return _cookies.getCookie(
+      url: resolved,
+      name: name,
+      webViewController: _controller,
+    );
+  }
+
+  ///Sets a cookie for [url], or for the WebView's current URL when [url]
+  ///is omitted. Returns `false` when no URL is available.
+  Future<bool> setCookie({
+    required String name,
+    required String value,
+    WebUri? url,
+    String path = "/",
+    String? domain,
+    int? expiresDate,
+    int? maxAge,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async {
+    final resolved = await _resolveUrl(url);
+    if (resolved == null) {
+      return false;
+    }
+    return _cookies.setCookie(
+      url: resolved,
+      name: name,
+      value: value,
+      path: path,
+      domain: domain,
+      expiresDate: expiresDate,
+      maxAge: maxAge,
+      isSecure: isSecure,
+      isHttpOnly: isHttpOnly,
+      sameSite: sameSite,
+      webViewController: _controller,
+    );
+  }
+
+  ///Deletes the cookie named [name] for [url], or for the WebView's
+  ///current URL when [url] is omitted.
+  Future<bool> deleteCookie({
+    required String name,
+    WebUri? url,
+    String path = "/",
+    String? domain,
+  }) async {
+    final resolved = await _resolveUrl(url);
+    if (resolved == null) {
+      return false;
+    }
+    return _cookies.deleteCookie(
+      url: resolved,
+      name: name,
+      path: path,
+      domain: domain,
+      webViewController: _controller,
+    );
+  }
+
+  ///Deletes all cookies for [url], or for the WebView's current URL when
+  ///[url] is omitted.
+  Future<bool> deleteCookies({
+    WebUri? url,
+    String path = "/",
+    String? domain,
+  }) async {
+    final resolved = await _resolveUrl(url);
+    if (resolved == null) {
+      return false;
+    }
+    return _cookies.deleteCookies(
+      url: resolved,
+      path: path,
+      domain: domain,
+      webViewController: _controller,
+    );
+  }
+
+  ///Gets every cookie in the cookie store.
+  Future<List<Cookie>> getAllCookies() => _cookies.getAllCookies();
+
+  ///Deletes every cookie in the cookie store.
+  Future<bool> deleteAllCookies() => _cookies.deleteAllCookies();
+
+  ///Removes all session cookies.
+  Future<bool> removeSessionCookies() => _cookies.removeSessionCookies();
+}

--- a/zikzak_inappwebview/lib/src/in_app_webview/controllers/cookie_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/controllers/cookie_controller.dart
@@ -12,12 +12,15 @@ import '../in_app_webview_controller.dart';
 ///and global operations.
 class CookieController {
   final InAppWebViewController _controller;
+  final CookieManager? _cookieManagerOverride;
   CookieManager? _cookieManager;
 
   ///Creates a [CookieController] bound to the given controller.
-  CookieController(this._controller);
+  CookieController(this._controller, {CookieManager? cookieManager})
+    : _cookieManagerOverride = cookieManager;
 
-  CookieManager get _cookies => _cookieManager ??= CookieManager.instance();
+  CookieManager get _cookies =>
+      _cookieManager ??= _cookieManagerOverride ?? CookieManager.instance();
 
   Future<WebUri?> _resolveUrl(WebUri? url) async =>
       url ?? await _controller.getUrl();

--- a/zikzak_inappwebview/lib/src/in_app_webview/controllers/javascript_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/controllers/javascript_controller.dart
@@ -1,0 +1,94 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+///Domain-specific facade of [InAppWebViewController] for JavaScript
+///evaluation, JavaScript handlers and user script management.
+///
+///Part of the domain controller split (issue #161, P3). Every method
+///delegates to the parent [InAppWebViewController].
+class JavaScriptController {
+  final InAppWebViewController _controller;
+
+  ///Creates a [JavaScriptController] bound to the given controller.
+  const JavaScriptController(this._controller);
+
+  ///Evaluates the given JavaScript [source].
+  Future<dynamic> evaluateJavascript({
+    required String source,
+    ContentWorld? contentWorld,
+  }) => _controller.evaluateJavascript(
+    source: source,
+    contentWorld: contentWorld,
+  );
+
+  ///Calls the given async JavaScript [functionBody].
+  Future<CallAsyncJavaScriptResult?> callAsyncJavaScript({
+    required String functionBody,
+    Map<String, dynamic> arguments = const <String, dynamic>{},
+    ContentWorld? contentWorld,
+  }) => _controller.callAsyncJavaScript(
+    functionBody: functionBody,
+    arguments: arguments,
+    contentWorld: contentWorld,
+  );
+
+  ///Injects a JavaScript file from the given [urlFile] into the page.
+  Future<void> injectJavascriptFileFromUrl({
+    required WebUri urlFile,
+    ScriptHtmlTagAttributes? scriptHtmlTagAttributes,
+  }) => _controller.injectJavascriptFileFromUrl(
+    urlFile: urlFile,
+    scriptHtmlTagAttributes: scriptHtmlTagAttributes,
+  );
+
+  ///Injects a JavaScript file from the app assets into the page.
+  Future<dynamic> injectJavascriptFileFromAsset({
+    required String assetFilePath,
+  }) => _controller.injectJavascriptFileFromAsset(assetFilePath: assetFilePath);
+
+  ///Registers a JavaScript handler with the given [handlerName].
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) => _controller.addJavaScriptHandler(
+    handlerName: handlerName,
+    callback: callback,
+  );
+
+  ///Removes the JavaScript handler with the given [handlerName].
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
+    required String handlerName,
+  }) => _controller.removeJavaScriptHandler(handlerName: handlerName);
+
+  ///Whether a JavaScript handler with the given [handlerName] exists.
+  bool hasJavaScriptHandler({required String handlerName}) =>
+      _controller.hasJavaScriptHandler(handlerName: handlerName);
+
+  ///Adds the given [userScript].
+  Future<void> addUserScript({required UserScript userScript}) =>
+      _controller.addUserScript(userScript: userScript);
+
+  ///Adds the given [userScripts].
+  Future<void> addUserScripts({required List<UserScript> userScripts}) =>
+      _controller.addUserScripts(userScripts: userScripts);
+
+  ///Removes the given [userScript].
+  Future<bool> removeUserScript({required UserScript userScript}) =>
+      _controller.removeUserScript(userScript: userScript);
+
+  ///Removes the given [userScripts].
+  Future<void> removeUserScripts({required List<UserScript> userScripts}) =>
+      _controller.removeUserScripts(userScripts: userScripts);
+
+  ///Removes all user scripts of the given [groupName].
+  Future<void> removeUserScriptsByGroupName({required String groupName}) =>
+      _controller.removeUserScriptsByGroupName(groupName: groupName);
+
+  ///Removes all user scripts.
+  Future<void> removeAllUserScripts() => _controller.removeAllUserScripts();
+
+  ///Whether the given [userScript] is currently injected.
+  bool hasUserScript({required UserScript userScript}) =>
+      _controller.hasUserScript(userScript: userScript);
+}

--- a/zikzak_inappwebview/lib/src/in_app_webview/controllers/main.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/controllers/main.dart
@@ -1,0 +1,4 @@
+export 'cookie_controller.dart';
+export 'javascript_controller.dart';
+export 'navigation_controller.dart';
+export 'settings_controller.dart';

--- a/zikzak_inappwebview/lib/src/in_app_webview/controllers/navigation_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/controllers/navigation_controller.dart
@@ -1,0 +1,110 @@
+import 'dart:typed_data';
+
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+///Domain-specific facade of [InAppWebViewController] for navigation,
+///page loading and history management.
+///
+///Part of the domain controller split (issue #161, P3): related operations
+///are grouped behind focused facades so the main controller stays easy to
+///reason about. Every method delegates to the parent
+///[InAppWebViewController] — behavior is identical to calling it directly.
+class NavigationController {
+  final InAppWebViewController _controller;
+
+  ///Creates a [NavigationController] bound to the given controller.
+  const NavigationController(this._controller);
+
+  ///The current URL of the WebView.
+  Future<WebUri?> getUrl() => _controller.getUrl();
+
+  ///Loads the given [urlRequest].
+  Future<void> loadUrl({
+    required URLRequest urlRequest,
+    WebUri? allowingReadAccessTo,
+  }) => _controller.loadUrl(
+    urlRequest: urlRequest,
+    allowingReadAccessTo: allowingReadAccessTo,
+  );
+
+  ///Loads the given [url] with POST method using [postData].
+  Future<void> postUrl({required WebUri url, required Uint8List postData}) =>
+      _controller.postUrl(url: url, postData: postData);
+
+  ///Loads the given [data] as HTML content.
+  Future<void> loadData({
+    required String data,
+    String mimeType = "text/html",
+    String encoding = "utf8",
+    WebUri? baseUrl,
+    WebUri? historyUrl,
+    WebUri? allowingReadAccessTo,
+  }) => _controller.loadData(
+    data: data,
+    mimeType: mimeType,
+    encoding: encoding,
+    baseUrl: baseUrl,
+    historyUrl: historyUrl,
+    allowingReadAccessTo: allowingReadAccessTo,
+  );
+
+  ///Loads the given [assetFilePath].
+  Future<void> loadFile({required String assetFilePath}) =>
+      _controller.loadFile(assetFilePath: assetFilePath);
+
+  ///Loads a simulated request with the given [data] payload.
+  Future<void> loadSimulatedRequest({
+    required URLRequest urlRequest,
+    required Uint8List data,
+    URLResponse? urlResponse,
+  }) => _controller.loadSimulatedRequest(
+    urlRequest: urlRequest,
+    data: data,
+    urlResponse: urlResponse,
+  );
+
+  ///Reloads the current page.
+  Future<void> reload() => _controller.reload();
+
+  ///Reloads the current page from the origin, bypassing the cache.
+  Future<void> reloadFromOrigin() => _controller.reloadFromOrigin();
+
+  ///Stops the current page load.
+  Future<void> stopLoading() => _controller.stopLoading();
+
+  ///Whether the WebView is currently loading a page.
+  Future<bool> isLoading() => _controller.isLoading();
+
+  ///Goes back in the navigation history.
+  Future<void> goBack() => _controller.goBack();
+
+  ///Goes forward in the navigation history.
+  Future<void> goForward() => _controller.goForward();
+
+  ///Moves [steps] through the navigation history (negative goes back).
+  Future<void> goBackOrForward({required int steps}) =>
+      _controller.goBackOrForward(steps: steps);
+
+  ///Whether there is a back item in the navigation history.
+  Future<bool> canGoBack() => _controller.canGoBack();
+
+  ///Whether there is a forward item in the navigation history.
+  Future<bool> canGoForward() => _controller.canGoForward();
+
+  ///Whether [steps] can be taken through the navigation history.
+  Future<bool> canGoBackOrForward({required int steps}) =>
+      _controller.canGoBackOrForward(steps: steps);
+
+  ///Goes to the given [historyItem].
+  Future<void> goTo({required WebHistoryItem historyItem}) =>
+      _controller.goTo(historyItem: historyItem);
+
+  ///A copy of the back/forward navigation list.
+  Future<WebHistory?> getCopyBackForwardList() =>
+      _controller.getCopyBackForwardList();
+
+  ///Clears the navigation history.
+  Future<void> clearHistory() => _controller.clearHistory();
+}

--- a/zikzak_inappwebview/lib/src/in_app_webview/controllers/settings_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/controllers/settings_controller.dart
@@ -1,0 +1,22 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+///Domain-specific facade of [InAppWebViewController] for reading and
+///updating the WebView settings.
+///
+///Part of the domain controller split (issue #161, P3). Every method
+///delegates to the parent [InAppWebViewController].
+class SettingsController {
+  final InAppWebViewController _controller;
+
+  ///Creates a [SettingsController] bound to the given controller.
+  const SettingsController(this._controller);
+
+  ///The current settings of the WebView.
+  Future<InAppWebViewSettings?> getSettings() => _controller.getSettings();
+
+  ///Updates the WebView with the given [settings].
+  Future<void> setSettings({required InAppWebViewSettings settings}) =>
+      _controller.setSettings(settings: settings);
+}

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -10,6 +10,7 @@ import '../web_message/main.dart';
 import '../web_storage/web_storage.dart';
 
 import '../print_job/print_job_controller.dart';
+import 'controllers/main.dart';
 import 'network_capture/network_capture_manager.dart';
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController}
@@ -41,6 +42,30 @@ class InAppWebViewController implements Disposable {
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.webStorage}
   WebStorage get webStorage =>
       WebStorage.fromPlatform(platform: platform.webStorage);
+
+  NavigationController? _navigationController;
+  JavaScriptController? _javaScriptController;
+  CookieController? _cookieController;
+  SettingsController? _settingsController;
+
+  ///Domain-specific facade for navigation, page loading and history.
+  ///
+  ///Part of the domain controller split (issue #161, P3): the growing API
+  ///surface is grouped into focused facades without changing behavior.
+  NavigationController get navigation =>
+      _navigationController ??= NavigationController(this);
+
+  ///Domain-specific facade for JavaScript evaluation, handlers and
+  ///user scripts.
+  JavaScriptController get javaScript =>
+      _javaScriptController ??= JavaScriptController(this);
+
+  ///Domain-specific facade for cookie management scoped to this WebView.
+  CookieController get cookies => _cookieController ??= CookieController(this);
+
+  ///Domain-specific facade for reading and updating settings.
+  SettingsController get settings =>
+      _settingsController ??= SettingsController(this);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.getUrl}
   Future<WebUri?> getUrl() => platform.getUrl();

--- a/zikzak_inappwebview/lib/src/in_app_webview/main.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/main.dart
@@ -1,5 +1,6 @@
 export 'in_app_webview.dart';
 export 'in_app_webview_controller.dart';
+export 'controllers/main.dart';
 export 'headless_in_app_webview.dart';
 export 'network_capture/network_capture_manager.dart'
     show

--- a/zikzak_inappwebview/test/domain_controllers_test.dart
+++ b/zikzak_inappwebview/test/domain_controllers_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+
+/// Compile-time probes for the domain controller split (issue #161, P3).
+///
+/// The domain facades group the [InAppWebViewController] API surface into
+/// focused controllers. If a facade or method is removed, or its type
+/// drifts, this file stops compiling, so `flutter analyze` and
+/// `flutter test` both fail.
+
+NavigationController _navigation(InAppWebViewController c) => c.navigation;
+JavaScriptController _javaScript(InAppWebViewController c) => c.javaScript;
+CookieController _cookiesFacade(InAppWebViewController c) => c.cookies;
+SettingsController _settings(InAppWebViewController c) => c.settings;
+
+Future<void> _reload(NavigationController c) => c.reload();
+Future<bool> _canGoBack(NavigationController c) => c.canGoBack();
+Future<dynamic> _eval(JavaScriptController c, String source) =>
+    c.evaluateJavascript(source: source);
+bool _hasHandler(JavaScriptController c, String name) =>
+    c.hasJavaScriptHandler(handlerName: name);
+Future<List<Cookie>> _getCookies(CookieController c) => c.getCookies();
+Future<InAppWebViewSettings?> _getSettings(SettingsController c) =>
+    c.getSettings();
+
+void main() {
+  group('Domain-specific controllers (issue #161 P3)', () {
+    test('InAppWebViewController exposes all four domain facades', () {
+      expect(_navigation, isNotNull);
+      expect(_javaScript, isNotNull);
+      expect(_cookiesFacade, isNotNull);
+      expect(_settings, isNotNull);
+    });
+
+    test('facades expose their domain methods with expected signatures', () {
+      expect(_reload, isNotNull);
+      expect(_canGoBack, isNotNull);
+      expect(_eval, isNotNull);
+      expect(_hasHandler, isNotNull);
+      expect(_getCookies, isNotNull);
+      expect(_getSettings, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
Completes the final open workstream of #161.

## Epic status

| Priority | Workstream | Status |
|---|---|---|
| P1 | Standardize dispose patterns | ✅ Merged in #175 |
| P2 | Lifecycle integration tests | ✅ Merged in #175 (Windows Program Files case present as CI-gated skip) |
| P3 | Domain-specific controllers | ✅ This PR |
| P4 | Pigeon migration | Deferred by the issue itself (revisit if channel bugs emerge) |

## Changes (P3)

New `lib/src/in_app_webview/controllers/` directory in the main package with four focused facades, exposed as lazy getters on `InAppWebViewController`:

- **`controller.navigation` → `NavigationController`** — page loading, navigation and history: `loadUrl`, `postUrl`, `loadData`, `loadFile`, `loadSimulatedRequest`, `reload`, `reloadFromOrigin`, `stopLoading`, `isLoading`, `goBack`/`goForward`/`goBackOrForward`, `canGoBack`/`canGoForward`/`canGoBackOrForward`, `goTo`, `getCopyBackForwardList`, `clearHistory`, `getUrl`
- **`controller.javaScript` → `JavaScriptController`** — `evaluateJavascript`, `callAsyncJavaScript`, JS file injection (URL/asset), `add/remove/hasJavaScriptHandler`, full user-script management
- **`controller.cookies` → `CookieController`** — cookie management scoped to this WebView: wraps the shared `CookieManager`, defaults `url` to the WebView's current URL, passes the controller as context; global ops (`getAllCookies`, `deleteAllCookies`, `removeSessionCookies`) included
- **`controller.settings` → `SettingsController`** — `getSettings`, `setSettings`

## Design

- **Non-breaking, additive**: every facade delegates to the existing `InAppWebViewController` — the public API is unchanged, behavior identical.
- **SOLID/DRY**: one domain per facade (SRP), a single delegation chain with zero duplicated logic, facades depend on the controller abstraction (DIP).
- Enables parallel work on separate domains without touching one growing controller file, per the issue's rationale.

## Tests

- `test/domain_controllers_test.dart` — compile-time probes: removing a facade or drifting a signature breaks compilation (same style as `disposable_pattern_test.dart`).

## Verification

- `flutter analyze`: 0 errors, no new lints in changed files
- `flutter test`: all tests pass (4/4)
- `dart format`: clean on all touched files

Closes #161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated navigation, JavaScript, cookie, and WebView settings controllers.
  * Added convenient access to these controllers through the WebView controller.
  * Added support for page navigation, history management, JavaScript execution and injection, cookie management, user scripts, and settings updates.
  * Made the new controllers available through the package’s public exports.

* **Tests**
  * Added coverage to verify the new controller interfaces and methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->