### PR TITLE
fix(macos): align JS bridge name so Network Capture events reach Dart

### DIFF
--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 4.7.0 - 2026-07-29
 
+## Unreleased
+
+- Fixed macOS: Network Capture API callbacks never fired — the JS bridge was
+  exposed as `window.flutter_inappwebview` while iOS/Android and the Network
+  Capture interceptor use `window.zikzak_inappwebview`, so captured events
+  never reached the Dart side (fixes `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished`)
+
+
 
 ### Features
 

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FindInteractionJS.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FindInteractionJS.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let JAVASCRIPT_BRIDGE_NAME = "flutter_inappwebview"
+let JAVASCRIPT_BRIDGE_NAME = "zikzak_inappwebview"
 
 let FIND_TEXT_HIGHLIGHT_JS_SOURCE = """
 window.\(JAVASCRIPT_BRIDGE_NAME) = window.\(JAVASCRIPT_BRIDGE_NAME) || {};


### PR DESCRIPTION
## Summary

Fixes #181 — on macOS, `onNetworkRequest` / `onNetworkResponse` / `onNetworkLoadingFinished` never fired even though the Network Capture interceptor JavaScript was injected correctly (the same configuration works on iOS).

### Root cause

The Network Capture interceptor is platform-independent and delivers events through the JS bridge:

```js
// network_capture_interceptor_js.dart
function bridge() {
  var b = window.zikzak_inappwebview;   // looks up this name
  if (b && typeof b.callHandler === 'function') return b;
  ...
}
```

On **iOS** (`zikzak_inappwebview_ios/.../JavaScriptBridgeJS.swift`) and **Android** (`JavaScriptBridgeJS.java`) the bridge is named `window.zikzak_inappwebview` — matching the interceptor.

On **macOS**, `JAVASCRIPT_BRIDGE_NAME` was still the upstream name `"flutter_inappwebview"` (inherited from the upstream 4.5.x fork; the fork renamed iOS/Android but missed macOS). So on macOS the interceptor's `bridge()` lookup returned `null`, every `send()` silently failed, and captured events stayed queued in-page — the Dart side never received anything.

### Fix

`zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FindInteractionJS.swift` — rename the bridge constant:

```diff
-let JAVASCRIPT_BRIDGE_NAME = "flutter_inappwebview"
+let JAVASCRIPT_BRIDGE_NAME = "zikzak_inappwebview"
```

All macOS bridge consumers (bridge script, find-in-page scripts, callHandler promise resolution) reference the constant, so they follow the rename consistently. This also fixes **any** `addJavaScriptHandler` usage on macOS, not just Network Capture — the page could never call the bridge under the expected name.

> **Note on the original patch approach:** the attached patch proposed registering `__zikzakNetworkCapture__` directly in the `WKUserContentController` and invoking `onNetworkRequest` etc. on the method channel. That matches the upstream flutter_inappwebview architecture, but this fork's interceptor posts through the JS bridge's `callHandler` (`window.zikzak_inappwebview.callHandler('__zikzakNetworkCapture__', payload)`), and nothing on the Dart side listens for `onNetworkRequest` method calls. The bridge-name fix addresses the actual root cause with a 1-line change.

### Validation

- `swiftc -parse` on the changed Swift file: OK
- `flutter test` `zikzak_inappwebview_macos` (9 tests, incl. `addJavaScriptHandler` coverage): pass
- `flutter test` `zikzak_inappwebview_platform_interface` (8 tests): pass
- No tests reference the old bridge name

### Files changed

- `zikzak_inappwebview_macos/macos/.../FindInteractionJS.swift` — bridge name fix
- `zikzak_inappwebview_macos/CHANGELOG.md` — Unreleased entry

Closes #181