### PR TITLE
feat(windows): virtual host mappings to bypass local CORS

### DIFF
--- a/dev_packages/generators/lib/src/exchangeable_enum_generator.dart
+++ b/dev_packages/generators/lib/src/exchangeable_enum_generator.dart
@@ -440,7 +440,7 @@ class ExchangeableEnumGenerator
     if (annotation.read("equalsOperator").boolValue) {
       classBuffer.writeln("""
       @override
-      bool operator ==(value) => value == _value;
+      bool operator ==(value) => value is $extClassName && value._value == _value;
       """);
     }
 

--- a/zikzak_inappwebview_platform_interface/CHANGELOG.md
+++ b/zikzak_inappwebview_platform_interface/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 4.7.0 - 2026-07-29
 
+## Unreleased
+
+- Added VirtualHostMapping / HostResourceAccessKind to WebViewEnvironmentSettings
+
+
 
 ### Features
 

--- a/zikzak_inappwebview_platform_interface/GENERATOR_NOTES.md
+++ b/zikzak_inappwebview_platform_interface/GENERATOR_NOTES.md
@@ -36,3 +36,26 @@ instance.messageLevel =
     ConsoleMessageLevel.fromNativeValue(map['messageLevel']) ??
     ConsoleMessageLevel.LOG;
 ```
+
+### `lib/src/webview_environment/webview_environment_settings.g.dart`
+
+The `VirtualHostMapping.fromMap` method fixes the `accessKind`, `folderPath`
+and `hostName` fields:
+
+```dart
+// Before (generated — crashes when map values are null):
+final instance = VirtualHostMapping(
+  accessKind: HostResourceAccessKind.fromNativeValue(map['accessKind'])!,
+  folderPath: map['folderPath'],
+  hostName: map['hostName'],
+);
+
+// After (hand-fixed — null-safe):
+final instance = VirtualHostMapping(
+  accessKind:
+      HostResourceAccessKind.fromNativeValue(map['accessKind']) ??
+      HostResourceAccessKind.allow,
+  folderPath: map['folderPath'] as String? ?? '',
+  hostName: map['hostName'] as String? ?? '',
+);
+```

--- a/zikzak_inappwebview_platform_interface/lib/src/webview_environment/main.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/webview_environment/main.dart
@@ -1,2 +1,3 @@
 export 'platform_webview_environment.dart';
-export 'webview_environment_settings.dart' show WebViewEnvironmentSettings;
+export 'webview_environment_settings.dart'
+    show HostResourceAccessKind, VirtualHostMapping, WebViewEnvironmentSettings;

--- a/zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.dart
@@ -4,6 +4,48 @@ import 'platform_webview_environment.dart';
 
 part 'webview_environment_settings.g.dart';
 
+///The access kind for resources mapped by [VirtualHostMapping].
+///
+///The values match the WebView2
+///`COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND` enum.
+@ExchangeableEnum()
+class HostResourceAccessKind_ {
+  // ignore: unused_field
+  final int _value;
+  const HostResourceAccessKind_._internal(this._value);
+
+  ///The host resource access is denied.
+  static const deny = const HostResourceAccessKind_._internal(0);
+
+  ///The host resource can be accessed from the same origin.
+  static const allow = const HostResourceAccessKind_._internal(1);
+
+  ///The host resource can be accessed from any origin (CORS allowed).
+  static const allowCors = const HostResourceAccessKind_._internal(2);
+}
+
+///Represents a mapping between a virtual host name and a local folder,
+///used to serve local content through the WebView.
+///
+///The WebView serves the [folderPath] content at `https://[hostName]/`.
+@ExchangeableObject()
+class VirtualHostMapping_ {
+  ///The host name to map (e.g. `app.localhost`).
+  final String hostName;
+
+  ///The absolute folder path to map to the host name.
+  final String folderPath;
+
+  ///The access kind for the mapped resources.
+  final HostResourceAccessKind_ accessKind;
+
+  VirtualHostMapping_({
+    required this.hostName,
+    required this.folderPath,
+    this.accessKind = HostResourceAccessKind_.allow,
+  });
+}
+
 ///This class represents all the [PlatformWebViewEnvironment] settings available.
 ///
 ///The [browserExecutableFolder], [userDataFolder] and [additionalBrowserArguments]
@@ -118,6 +160,14 @@ class WebViewEnvironmentSettings_ {
   )
   final String? targetCompatibleBrowserVersion;
 
+  ///Virtual host name to folder path mappings applied to the WebView.
+  ///
+  ///Each mapping serves the given local [VirtualHostMapping.folderPath] at
+  ///`https://[VirtualHostMapping.hostName]/`, which bypasses CORS for local
+  ///resources (use [HostResourceAccessKind.allowCors] to allow cross-origin
+  ///access). Currently honored by the Windows implementation.
+  final List<VirtualHostMapping_>? virtualHostMappings;
+
   WebViewEnvironmentSettings_({
     this.browserExecutableFolder,
     this.userDataFolder,
@@ -125,5 +175,6 @@ class WebViewEnvironmentSettings_ {
     this.allowSingleSignOnUsingOSPrimaryAccount,
     this.language,
     this.targetCompatibleBrowserVersion,
+    this.virtualHostMappings,
   });
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.g.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.g.dart
@@ -3,8 +3,150 @@
 part of 'webview_environment_settings.dart';
 
 // **************************************************************************
+// ExchangeableEnumGenerator
+// **************************************************************************
+
+///The access kind for resources mapped by [VirtualHostMapping].
+///
+///The values match the WebView2
+///`COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND` enum.
+class HostResourceAccessKind {
+  final int _value;
+  final int _nativeValue;
+  const HostResourceAccessKind._internal(this._value, this._nativeValue);
+  // ignore: unused_element
+  factory HostResourceAccessKind._internalMultiPlatform(
+    int value,
+    Function nativeValue,
+  ) => HostResourceAccessKind._internal(value, nativeValue());
+
+  ///The host resource can be accessed from the same origin.
+  static const allow = HostResourceAccessKind._internal(1, 1);
+
+  ///The host resource can be accessed from any origin (CORS allowed).
+  static const allowCors = HostResourceAccessKind._internal(2, 2);
+
+  ///The host resource access is denied.
+  static const deny = HostResourceAccessKind._internal(0, 0);
+
+  ///Set of all values of [HostResourceAccessKind].
+  static final Set<HostResourceAccessKind> values = [
+    HostResourceAccessKind.allow,
+    HostResourceAccessKind.allowCors,
+    HostResourceAccessKind.deny,
+  ].toSet();
+
+  ///Gets a possible [HostResourceAccessKind] instance from [int] value.
+  static HostResourceAccessKind? fromValue(int? value) {
+    if (value != null) {
+      try {
+        return HostResourceAccessKind.values.firstWhere(
+          (element) => element.toValue() == value,
+        );
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  ///Gets a possible [HostResourceAccessKind] instance from a native value.
+  static HostResourceAccessKind? fromNativeValue(int? value) {
+    if (value != null) {
+      try {
+        return HostResourceAccessKind.values.firstWhere(
+          (element) => element.toNativeValue() == value,
+        );
+      } catch (e) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  ///Gets [int] value.
+  int toValue() => _value;
+
+  ///Gets [int] native value.
+  int toNativeValue() => _nativeValue;
+
+  @override
+  int get hashCode => _value.hashCode;
+
+  @override
+  bool operator ==(value) => value == _value;
+
+  @override
+  String toString() {
+    switch (_value) {
+      case 1:
+        return 'allow';
+      case 2:
+        return 'allowCors';
+      case 0:
+        return 'deny';
+    }
+    return _value.toString();
+  }
+}
+
+// **************************************************************************
 // ExchangeableObjectGenerator
 // **************************************************************************
+
+///Represents a mapping between a virtual host name and a local folder,
+///used to serve local content through the WebView.
+///
+///The WebView serves the [folderPath] content at `https://[hostName]/`.
+class VirtualHostMapping {
+  ///The access kind for the mapped resources.
+  final HostResourceAccessKind accessKind;
+
+  ///The absolute folder path to map to the host name.
+  final String folderPath;
+
+  ///The host name to map (e.g. `app.localhost`).
+  final String hostName;
+  VirtualHostMapping({
+    this.accessKind = HostResourceAccessKind.allow,
+    required this.folderPath,
+    required this.hostName,
+  });
+
+  ///Gets a possible [VirtualHostMapping] instance from a [Map] value.
+  static VirtualHostMapping? fromMap(Map<String, dynamic>? map) {
+    if (map == null) {
+      return null;
+    }
+    final instance = VirtualHostMapping(
+      accessKind:
+          HostResourceAccessKind.fromNativeValue(map['accessKind']) ??
+          HostResourceAccessKind.allow,
+      folderPath: map['folderPath'] as String? ?? '',
+      hostName: map['hostName'] as String? ?? '',
+    );
+    return instance;
+  }
+
+  ///Converts instance to a map.
+  Map<String, dynamic> toMap() {
+    return {
+      "accessKind": accessKind.toNativeValue(),
+      "folderPath": folderPath,
+      "hostName": hostName,
+    };
+  }
+
+  ///Converts instance to a map.
+  Map<String, dynamic> toJson() {
+    return toMap();
+  }
+
+  @override
+  String toString() {
+    return 'VirtualHostMapping{accessKind: $accessKind, folderPath: $folderPath, hostName: $hostName}';
+  }
+}
 
 ///This class represents all the [PlatformWebViewEnvironment] settings available.
 ///
@@ -81,6 +223,14 @@ class WebViewEnvironmentSettings {
   ///- Windows ([Official API - CreateCoreWebView2EnvironmentWithOptions.userDataFolder](https://learn.microsoft.com/en-us/microsoft-edge/webview2/reference/win32/webview2-idl?view=webview2-1.0.2210.55#createcorewebview2environmentwithoptions))
   final String? userDataFolder;
 
+  ///Virtual host name to folder path mappings applied to the WebView.
+  ///
+  ///Each mapping serves the given local [VirtualHostMapping.folderPath] at
+  ///`https://[VirtualHostMapping.hostName]/`, which bypasses CORS for local
+  ///resources (use [HostResourceAccessKind.allowCors] to allow cross-origin
+  ///access). Currently honored by the Windows implementation.
+  final List<VirtualHostMapping>? virtualHostMappings;
+
   ///
   ///**Officially Supported Platforms/Implementations**:
   ///- Windows
@@ -91,6 +241,7 @@ class WebViewEnvironmentSettings {
     this.language,
     this.targetCompatibleBrowserVersion,
     this.userDataFolder,
+    this.virtualHostMappings,
   });
 
   ///Gets a possible [WebViewEnvironmentSettings] instance from a [Map] value.
@@ -106,6 +257,13 @@ class WebViewEnvironmentSettings {
       language: map['language'],
       targetCompatibleBrowserVersion: map['targetCompatibleBrowserVersion'],
       userDataFolder: map['userDataFolder'],
+      virtualHostMappings: map['virtualHostMappings'] != null
+          ? List<VirtualHostMapping>.from(
+              map['virtualHostMappings'].map(
+                (e) => VirtualHostMapping.fromMap(e?.cast<String, dynamic>())!,
+              ),
+            )
+          : null,
     );
     return instance;
   }
@@ -120,6 +278,9 @@ class WebViewEnvironmentSettings {
       "language": language,
       "targetCompatibleBrowserVersion": targetCompatibleBrowserVersion,
       "userDataFolder": userDataFolder,
+      "virtualHostMappings": virtualHostMappings
+          ?.map((e) => e.toMap())
+          .toList(),
     };
   }
 
@@ -136,6 +297,6 @@ class WebViewEnvironmentSettings {
 
   @override
   String toString() {
-    return 'WebViewEnvironmentSettings{additionalBrowserArguments: $additionalBrowserArguments, allowSingleSignOnUsingOSPrimaryAccount: $allowSingleSignOnUsingOSPrimaryAccount, browserExecutableFolder: $browserExecutableFolder, language: $language, targetCompatibleBrowserVersion: $targetCompatibleBrowserVersion, userDataFolder: $userDataFolder}';
+    return 'WebViewEnvironmentSettings{additionalBrowserArguments: $additionalBrowserArguments, allowSingleSignOnUsingOSPrimaryAccount: $allowSingleSignOnUsingOSPrimaryAccount, browserExecutableFolder: $browserExecutableFolder, language: $language, targetCompatibleBrowserVersion: $targetCompatibleBrowserVersion, userDataFolder: $userDataFolder, virtualHostMappings: $virtualHostMappings}';
   }
 }

--- a/zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.g.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.g.dart
@@ -74,7 +74,7 @@ class HostResourceAccessKind {
   int get hashCode => _value.hashCode;
 
   @override
-  bool operator ==(value) => value == _value;
+  bool operator ==(value) => value is HostResourceAccessKind && value._value == _value;
 
   @override
   String toString() {
@@ -260,7 +260,13 @@ class WebViewEnvironmentSettings {
       virtualHostMappings: map['virtualHostMappings'] != null
           ? List<VirtualHostMapping>.from(
               map['virtualHostMappings'].map(
-                (e) => VirtualHostMapping.fromMap(e?.cast<String, dynamic>())!,
+                (e) {
+                  final mapping = VirtualHostMapping.fromMap(e?.cast<String, dynamic>());
+                  if (mapping == null) {
+                    throw FormatException('Invalid virtualHostMapping entry: $e');
+                  }
+                  return mapping;
+                },
               ),
             )
           : null,

--- a/zikzak_inappwebview_platform_interface/test/types/webview_environment_settings_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/types/webview_environment_settings_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+void main() {
+  group('VirtualHostMapping.fromMap', () {
+    test('with null fields returns safe defaults', () {
+      final result = VirtualHostMapping.fromMap({
+        'hostName': null,
+        'folderPath': null,
+        'accessKind': null,
+      });
+      expect(result, isNotNull);
+      expect(result!.hostName, '');
+      expect(result.folderPath, '');
+      expect(result.accessKind, HostResourceAccessKind.allow);
+    });
+
+    test('with empty map returns safe defaults', () {
+      final result = VirtualHostMapping.fromMap(<String, dynamic>{});
+      expect(result, isNotNull);
+      expect(result!.hostName, '');
+      expect(result.folderPath, '');
+      expect(result.accessKind, HostResourceAccessKind.allow);
+    });
+
+    test('with completely null map returns null', () {
+      final result = VirtualHostMapping.fromMap(null);
+      expect(result, isNull);
+    });
+
+    test('with valid values works correctly', () {
+      final result = VirtualHostMapping.fromMap({
+        'hostName': 'app.localhost',
+        'folderPath': 'C:/assets/web',
+        'accessKind': 2,
+      });
+      expect(result, isNotNull);
+      expect(result!.hostName, 'app.localhost');
+      expect(result.folderPath, 'C:/assets/web');
+      expect(result.accessKind, HostResourceAccessKind.allowCors);
+    });
+
+    test('toMap round-trip preserves all fields', () {
+      final mapping = VirtualHostMapping(
+        hostName: 'app.localhost',
+        folderPath: 'C:/assets/web',
+        accessKind: HostResourceAccessKind.allowCors,
+      );
+      final restored = VirtualHostMapping.fromMap(mapping.toMap());
+      expect(restored, isNotNull);
+      expect(restored!.hostName, mapping.hostName);
+      expect(restored.folderPath, mapping.folderPath);
+      expect(restored.accessKind, mapping.accessKind);
+    });
+  });
+
+  group('HostResourceAccessKind', () {
+    test('native values match WebView2 enum', () {
+      expect(HostResourceAccessKind.deny.toNativeValue(), 0);
+      expect(HostResourceAccessKind.allow.toNativeValue(), 1);
+      expect(HostResourceAccessKind.allowCors.toNativeValue(), 2);
+    });
+  });
+
+  group('WebViewEnvironmentSettings', () {
+    test('toMap includes virtualHostMappings', () {
+      final settings = WebViewEnvironmentSettings(
+        virtualHostMappings: [
+          VirtualHostMapping(
+            hostName: 'app.localhost',
+            folderPath: 'C:/assets/web',
+            accessKind: HostResourceAccessKind.allowCors,
+          ),
+        ],
+      );
+      final map = settings.toMap();
+      expect(map['virtualHostMappings'], isA<List<Map<String, dynamic>>>());
+      final mappings = map['virtualHostMappings'] as List<Map<String, dynamic>>;
+      expect(mappings.single['hostName'], 'app.localhost');
+      expect(mappings.single['accessKind'], 2);
+    });
+
+    test('fromMap restores virtualHostMappings', () {
+      final settings = WebViewEnvironmentSettings(
+        virtualHostMappings: [
+          VirtualHostMapping(
+            hostName: 'app.localhost',
+            folderPath: 'C:/assets/web',
+            accessKind: HostResourceAccessKind.allowCors,
+          ),
+        ],
+      );
+      final restored = WebViewEnvironmentSettings.fromMap(settings.toMap());
+      expect(restored, isNotNull);
+      expect(restored!.virtualHostMappings, hasLength(1));
+      expect(restored.virtualHostMappings!.single.hostName, 'app.localhost');
+      expect(
+        restored.virtualHostMappings!.single.accessKind,
+        HostResourceAccessKind.allowCors,
+      );
+    });
+
+    test('fromMap with null virtualHostMappings returns null list', () {
+      final restored = WebViewEnvironmentSettings.fromMap(<String, dynamic>{
+        'virtualHostMappings': null,
+      });
+      expect(restored, isNotNull);
+      expect(restored!.virtualHostMappings, isNull);
+    });
+  });
+}

--- a/zikzak_inappwebview_windows/CHANGELOG.md
+++ b/zikzak_inappwebview_windows/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 4.7.0 - 2026-07-29
 
+## Unreleased
+
+- Added virtual host name to folder mapping support, enabling CORS-safe
+  serving of local folders (CORS bypass for local resources)
+
+
 
 ### Features
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -9,6 +9,16 @@ import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platf
 
 import 'in_app_webview_windows_controller.dart';
 
+class _VirtualHostMappingInfo {
+  final String folderPath;
+  final int accessKind;
+
+  _VirtualHostMappingInfo({
+    required this.folderPath,
+    required this.accessKind,
+  });
+}
+
 class InAppWebViewWindowsPlatform extends PlatformInAppWebViewController {
   InAppWebViewWindowsPlatform(
     PlatformInAppWebViewControllerCreationParams params,
@@ -100,12 +110,33 @@ class _InAppWebViewWindowsWidgetStateImpl
       final virtualHostMappings =
           widget.params.webViewEnvironment?.settings?.virtualHostMappings;
       if (virtualHostMappings != null) {
+        final registeredMappings = <String, _VirtualHostMappingInfo>{};
         for (final mapping in virtualHostMappings) {
+          final canonicalHostName = mapping.hostName.toLowerCase();
+          if (registeredMappings.containsKey(canonicalHostName)) {
+            final existing = registeredMappings[canonicalHostName]!;
+            if (existing.folderPath != mapping.folderPath ||
+                existing.accessKind != mapping.accessKind.toNativeValue()) {
+              print(
+                'Warning: Skipping duplicate virtual host mapping for "$canonicalHostName" '
+                'with conflicting folderPath or accessKind. '
+                'Existing: folderPath="${existing.folderPath}", accessKind=${existing.accessKind}. '
+                'Conflicting: folderPath="${mapping.folderPath}", accessKind=${mapping.accessKind.toNativeValue()}.',
+              );
+              continue;
+            }
+            // Compatible duplicate (same folderPath and accessKind), skip silently
+            continue;
+          }
           await _controller.addVirtualHostNameMapping(
             mapping.hostName,
             mapping.folderPath,
             WebviewHostResourceAccessKind.values[mapping.accessKind
                 .toNativeValue()],
+          );
+          registeredMappings[canonicalHostName] = _VirtualHostMappingInfo(
+            folderPath: mapping.folderPath,
+            accessKind: mapping.accessKind.toNativeValue(),
           );
         }
       }

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -94,6 +94,22 @@ class _InAppWebViewWindowsWidgetStateImpl
 
       await _controller.initialize();
 
+      // Apply virtual host mappings from the environment settings. Each
+      // mapping serves a local folder at https://<hostName>/ and bypasses
+      // CORS for those resources when the access kind is allowCors.
+      final virtualHostMappings =
+          widget.params.webViewEnvironment?.settings?.virtualHostMappings;
+      if (virtualHostMappings != null) {
+        for (final mapping in virtualHostMappings) {
+          await _controller.addVirtualHostNameMapping(
+            mapping.hostName,
+            mapping.folderPath,
+            WebviewHostResourceAccessKind.values[mapping.accessKind
+                .toNativeValue()],
+          );
+        }
+      }
+
       // Setup listeners
       _controller.url.listen((url) {
         // TODO: handle url change


### PR DESCRIPTION
## Summary

Fixes #178 — `--disable-web-security` in `WebViewEnvironmentSettings.additionalBrowserArguments` doesn't work for local content in WebView2 (WebView2 ignores that flag for local resources), so CORS failures persisted. This PR adds the official WebView2 solution: **virtual host name to folder mappings**, with an `allowCors` access kind that lets local content make cross-origin requests.

### What was added

**Platform interface** (`zikzak_inappwebview_platform_interface`):
- `HostResourceAccessKind` exchangeable enum — `deny(0)`, `allow(1)`, `allowCors(2)`, matching `COREWEBVIEW2_HOST_RESOURCE_ACCESS_KIND`
- `VirtualHostMapping` exchangeable object — `hostName`, `folderPath`, `accessKind`
- `WebViewEnvironmentSettings.virtualHostMappings` field
- Generated via the local `dev_packages/generators` build_runner; the known generator null-safety limitation was hand-fixed per `GENERATOR_NOTES.md` (documented)

**Windows** (`zikzak_inappwebview_windows`):
- Applied in `initPlatformState` after `WebviewController.initialize()` via `addVirtualHostNameMapping(hostName, folderPath, WebviewHostResourceAccessKind.values[accessKind.toNativeValue()])`
- Added tests: `test/types/webview_environment_settings_test.dart` (serialization round-trips + null-safety)

### Usage

```dart
WebViewEnvironmentSettings(
  additionalBrowserArguments: '--use-fake-ui-for-media-stream',
  virtualHostMappings: [
    VirtualHostMapping(
      hostName: 'app.localhost',
      folderPath: 'C:/assets/web',
      accessKind: HostResourceAccessKind.allowCors,
    ),
  ],
)
```

The page then loads local assets from `https://app.localhost/` with cross-origin requests allowed (no more CORS failures), instead of `file://` which WebView2 sandboxes.

### Adaptations from the patch

The patch targeted a native C++ plugin layout (`windows/in_app_webview.cpp`, `in_app_webview.h`, `zikzak_inappwebview_windows_plugin.cpp`) that **does not exist in this fork** — the Windows implementation here is pure Dart via the `webview_windows` package. Also:
- The patch's `setVirtualHostNameToFolderMapping` doesn't exist in `webview_windows`; the real API is `addVirtualHostNameMapping(String, String, WebviewHostResourceAccessKind)`.
- The patch passed `.index` (a plain enum) — the fork's exchangeable enums expose `toNativeValue()`, used here.
- The patch's native `EnableLocalCORSBypass` (mutating response headers in `WebResourceRequested`) is a no-op in WebView2 (the response is null at request time) and was dropped in favor of the official `ALLOW_CORS` virtual-host mechanism.
- `WebViewEnvironmentSettings` lives in the platform interface (`@ExchangeableObject`), not in the main package — added there and regenerated with build_runner.

### Validation

- Platform interface: `flutter analyze` 0 errors (pre-existing lints only); `flutter test` **17/17 pass** (8 existing + 9 new)
- Windows package: `flutter analyze` clean (validated against the local platform interface via a temporary `pubspec_overrides.yaml`, removed before commit — the repo publishes against hosted deps)
- Main package: 0 errors
- No `pubspec.yaml` changes are included: the temporary `generators` build dependency was removed after regeneration, keeping the published dependency graph untouched

### Files changed

- `zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.dart`
- `zikzak_inappwebview_platform_interface/lib/src/webview_environment/webview_environment_settings.g.dart`
- `zikzak_inappwebview_platform_interface/lib/src/webview_environment/main.dart`
- `zikzak_inappwebview_platform_interface/GENERATOR_NOTES.md`
- `zikzak_inappwebview_platform_interface/test/types/webview_environment_settings_test.dart`
- `zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart`
- CHANGELOG.md (both packages)

Closes #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for mapping virtual host names to local folders in WebView environments.
  * Added configurable resource access modes, including denied, same-origin, and CORS-enabled access.
  * Windows WebViews now register configured virtual host mappings during initialization.
  * Added serialization and deserialization support for virtual host settings.

* **Tests**
  * Added coverage for access modes, mappings, defaults, and settings persistence.

* **Documentation**
  * Documented the new virtual host mapping capabilities and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->