### PR TITLE
chore: rename remaining flutter_inappwebview residuals to zikzak_inappwebview

### DIFF
--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/FlutterWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/FlutterWebView.java
@@ -127,7 +127,7 @@ public class FlutterWebView implements PlatformWebView {
       // Defer the initial load so the JS bridge is registered before
       // the renderer receives the page load. This prevents a race where
       // pages served from cache or sleeping-tab wake-ups could execute
-      // @document-start userscripts before window.flutter_inappwebview is defined.
+      // @document-start userscripts before window.zikzak_inappwebview is defined.
       webView.post(new Runnable() {
         @Override
         public void run() {

--- a/zikzak_inappwebview_linux/linux/in_app_webview.cc
+++ b/zikzak_inappwebview_linux/linux/in_app_webview.cc
@@ -739,7 +739,7 @@ void in_app_webview_handle_method_call(InAppWebView *self,
     GtkPrintSettings *settings = gtk_print_settings_new();
 
     gchar *filename = g_strdup_printf(
-        "/tmp/flutter_inappwebview_print_%p_%ld.pdf", self, g_get_real_time());
+        "/tmp/zikzak_inappwebview_print_%p_%ld.pdf", self, g_get_real_time());
     gchar *uri = g_strdup_printf("file://%s", filename);
 
     gtk_print_settings_set(settings, GTK_PRINT_SETTINGS_OUTPUT_URI, uri);

--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 4.7.0 - 2026-07-29
+## Unreleased
+
+- Renamed remaining flutter_inappwebview residuals to zikzak_inappwebview
+  (JS bridge name, method channel and platform view type id)
+
+
 
 
 ### Features

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart
@@ -26,7 +26,7 @@ class MacOSInAppWebViewWidget extends PlatformInAppWebViewWidget {
     };
 
     return AppKitView(
-      viewType: 'dev.zuzu/flutter_inappwebview',
+      viewType: 'dev.zuzu/zikzak_inappwebview',
       onPlatformViewCreated: _onPlatformViewCreated,
       creationParams: creationParams,
       creationParamsCodec: const StandardMessageCodec(),

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FindInteractionJS.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FindInteractionJS.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-let JAVASCRIPT_BRIDGE_NAME = "flutter_inappwebview"
+let JAVASCRIPT_BRIDGE_NAME = "zikzak_inappwebview"
 
 let FIND_TEXT_HIGHLIGHT_JS_SOURCE = """
 window.\(JAVASCRIPT_BRIDGE_NAME) = window.\(JAVASCRIPT_BRIDGE_NAME) || {};

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
@@ -7,12 +7,12 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
     var myCookieManager: MyCookieManager?
     
     public static func register(with registrar: FlutterPluginRegistrar) {
-        let channel = FlutterMethodChannel(name: "dev.zuzu/flutter_inappwebview", binaryMessenger: registrar.messenger)
+        let channel = FlutterMethodChannel(name: "dev.zuzu/zikzak_inappwebview", binaryMessenger: registrar.messenger)
         let instance = InAppWebViewFlutterPlugin()
         registrar.addMethodCallDelegate(instance, channel: channel)
         
         let factory = InAppWebViewFactory(registrar: registrar)
-        registrar.register(factory, withId: "dev.zuzu/flutter_inappwebview")
+        registrar.register(factory, withId: "dev.zuzu/zikzak_inappwebview")
         
         instance.headlessInAppWebViewManager = HeadlessInAppWebViewManager(registrar: registrar)
         instance.inAppBrowserManager = InAppBrowserManager(registrar: registrar)

--- a/zikzak_inappwebview_platform_interface/lib/src/platform_webview_feature.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/platform_webview_feature.dart
@@ -30,7 +30,7 @@ abstract class PlatformWebViewFeature extends PlatformInterface
   factory PlatformWebViewFeature(PlatformWebViewFeatureCreationParams params) {
     assert(
       InAppWebViewPlatform.instance != null,
-      'A platform implementation for `flutter_inappwebview` has not been set. Please '
+      'A platform implementation for `zikzak_inappwebview` has not been set. Please '
       'ensure that an implementation of `InAppWebViewPlatform` has been set to '
       '`WebViewPlatform.instance` before use. For unit testing, '
       '`WebViewPlatform.instance` can be set with your own test implementation.',
@@ -45,7 +45,7 @@ abstract class PlatformWebViewFeature extends PlatformInterface
   factory PlatformWebViewFeature.static() {
     assert(
       InAppWebViewPlatform.instance != null,
-      'A platform implementation for `flutter_inappwebview` has not been set. Please '
+      'A platform implementation for `zikzak_inappwebview` has not been set. Please '
       'ensure that an implementation of `InAppWebViewPlatform` has been set to '
       '`WebViewPlatform.instance` before use. For unit testing, '
       '`WebViewPlatform.instance` can be set with your own test implementation.',


### PR DESCRIPTION
## Summary

Renames the last remaining `flutter_inappwebview` residuals to `zikzak_inappwebview`, completing the fork's namespace consistency (iOS/Android already use `zikzak_inappwebview`).

### Changes (7 files, +14/−8)

| File | Change |
|---|---|
| `zikzak_inappwebview_macos/.../FindInteractionJS.swift` | JS bridge name `window.flutter_inappwebview` → `window.zikzak_inappwebview` (matches iOS/Android and the Network Capture interceptor) |
| `zikzak_inappwebview_macos/.../InAppWebViewFlutterPlugin.swift` | Method channel + platform view type id `dev.zuzu/flutter_inappwebview` → `dev.zuzu/zikzak_inappwebview` |
| `zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview.dart` | `AppKitView(viewType:)` → `dev.zuzu/zikzak_inappwebview` (**paired** with the native registration above — must stay in sync) |
| `zikzak_inappwebview_linux/linux/in_app_webview.cc` | Print temp file name → `/tmp/zikzak_inappwebview_print_*.pdf` |
| `zikzak_inappwebview_android/.../FlutterWebView.java` | Stale comment → `window.zikzak_inappwebview` (no JS code referenced the old name) |
| `zikzak_inappwebview_platform_interface/lib/src/platform_webview_feature.dart` | "platform implementation not set" error message → `zikzak_inappwebview` (consistency with the other ~10 files already using the new name) |
| `zikzak_inappwebview_macos/CHANGELOG.md` | Unreleased entry |

### Notes

- **The macOS platform view type id change is paired** across Dart (`AppKitView(viewType:)`) and native (`registrar.register(factory, withId:)`) — both renamed together so they stay in sync. Shipped within one release this is safe; mid-upgrade mismatches between an old native plugin and a new Dart side (or vice versa) are not a supported scenario.
- The macOS JS bridge rename overlaps with the fix in PR #182 (network capture) — both converge to the same value, so no merge conflict on content.
- `dev.zuzu/flutter_inappbrowser` ids were left untouched (different name, out of scope).

### Validation

- `swiftc -parse` on both changed Swift files: OK
- `flutter analyze` (macOS package): no issues
- `flutter analyze` (platform interface): 0 errors
- `flutter test` (macOS package): 9/9 pass
- Verified the Dart `viewType` ↔ native registration id match