### PR TITLE
feat(macos): implement print page support reusing iOS pattern (#188)

### DIFF
--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -5,6 +5,7 @@ import 'dart:core';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+import '../print_job/print_job_controller.dart';
 
 final _JAVASCRIPT_HANDLER_FORBIDDEN_NAMES = UnmodifiableListView<String>([
   "onLoadResource",
@@ -387,6 +388,25 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
     args.putIfAbsent('source', () => source);
     args.putIfAbsent('contentWorld', () => contentWorld?.toMap());
     return await _channel.invokeMethod('evaluateJavascript', args);
+  }
+
+
+  @override
+  Future<MacOSPrintJobController?> printCurrentPage({
+    PrintJobSettings? settings,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent("settings", () => settings?.toMap());
+    String? jobId = await _channel.invokeMethod<String?>(
+      'printCurrentPage',
+      args,
+    );
+    if (jobId != null) {
+      return MacOSPrintJobController(
+        PlatformPrintJobControllerCreationParams(id: jobId),
+      );
+    }
+    return null;
   }
 
   @override

--- a/zikzak_inappwebview_macos/lib/src/inappwebview_platform.dart
+++ b/zikzak_inappwebview_macos/lib/src/inappwebview_platform.dart
@@ -6,6 +6,7 @@ import 'in_app_webview/in_app_webview.dart';
 import 'in_app_webview/in_app_webview_controller.dart';
 import 'in_app_webview/headless_in_app_webview.dart';
 import 'in_app_browser/in_app_browser.dart';
+import 'print_job/print_job_controller.dart';
 
 /// Implementation of [InAppWebViewPlatform] using the WebKit API for macOS.
 class MacOSInAppWebViewPlatform extends InAppWebViewPlatform {
@@ -64,5 +65,12 @@ class MacOSInAppWebViewPlatform extends InAppWebViewPlatform {
   @override
   PlatformInAppBrowser createPlatformInAppBrowserStatic() {
     return MacOSInAppBrowser.static();
+  }
+
+  @override
+  PlatformPrintJobController createPlatformPrintJobController(
+    PlatformPrintJobControllerCreationParams params,
+  ) {
+    return MacOSPrintJobController(params);
   }
 }

--- a/zikzak_inappwebview_macos/lib/src/print_job/print_job_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/print_job/print_job_controller.dart
@@ -34,7 +34,7 @@ class MacOSPrintJobController extends PlatformPrintJobController
         ) {
     onComplete = params.onComplete;
     channel = MethodChannel(
-      "wtf.zikzak/zikzak_inappwebview_printjobcontroller_\${params.id}",
+      "wtf.zikzak/zikzak_inappwebview_printjobcontroller_${params.id}",
     );
     handler = _handleMethod;
     initMethodCallHandler();
@@ -50,7 +50,7 @@ class MacOSPrintJobController extends PlatformPrintJobController
         }
         break;
       default:
-        throw UnimplementedError("Unimplemented \${call.method} method");
+        throw UnimplementedError("Unimplemented ${call.method} method");
     }
   }
 

--- a/zikzak_inappwebview_macos/lib/src/print_job/print_job_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/print_job/print_job_controller.dart
@@ -1,0 +1,80 @@
+import "package:flutter/foundation.dart";
+import "package:flutter/services.dart";
+import "package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart";
+
+/// Object specifying creation parameters for creating a [MacOSPrintJobController].
+@immutable
+class MacOSPrintJobControllerCreationParams
+    extends PlatformPrintJobControllerCreationParams {
+  const MacOSPrintJobControllerCreationParams({
+    required super.id,
+    super.onComplete,
+  });
+
+  factory MacOSPrintJobControllerCreationParams.fromPlatformPrintJobControllerCreationParams(
+    PlatformPrintJobControllerCreationParams params,
+  ) {
+    return MacOSPrintJobControllerCreationParams(
+      id: params.id,
+      onComplete: params.onComplete,
+    );
+  }
+}
+
+///{@macro zikzak_inappwebview_platform_interface.PlatformPrintJobController}
+class MacOSPrintJobController extends PlatformPrintJobController
+    with ChannelController {
+  MacOSPrintJobController(PlatformPrintJobControllerCreationParams params)
+      : super.implementation(
+          params is MacOSPrintJobControllerCreationParams
+              ? params
+              : MacOSPrintJobControllerCreationParams.fromPlatformPrintJobControllerCreationParams(
+                  params,
+                ),
+        ) {
+    onComplete = params.onComplete;
+    channel = MethodChannel(
+      "wtf.zikzak/zikzak_inappwebview_printjobcontroller_\${params.id}",
+    );
+    handler = _handleMethod;
+    initMethodCallHandler();
+  }
+
+  Future<dynamic> _handleMethod(MethodCall call) async {
+    switch (call.method) {
+      case "onComplete":
+        bool completed = call.arguments["completed"];
+        String? error = call.arguments["error"];
+        if (onComplete != null) {
+          onComplete!(completed, error);
+        }
+        break;
+      default:
+        throw UnimplementedError("Unimplemented \${call.method} method");
+    }
+  }
+
+  @override
+  Future<void> dismiss({bool animated = true}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent("animated", () => animated);
+    await channel?.invokeMethod("dismiss", args);
+  }
+
+  @override
+  Future<PrintJobInfo?> getInfo() async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    Map<String, dynamic>? infoMap = (await channel?.invokeMethod(
+      "getInfo",
+      args,
+    ))?.cast<String, dynamic>();
+    return PrintJobInfo.fromMap(infoMap);
+  }
+
+  @override
+  Future<void> dispose({bool isKeepAlive = false}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    await channel?.invokeMethod("dispose", args);
+    disposeChannel();
+  }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FlutterWebViewController.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/FlutterWebViewController.swift
@@ -16,7 +16,7 @@ public class FlutterWebViewController: NSObject {
 
     init(
         registrar: FlutterPluginRegistrar, withFrame frame: NSRect, viewId: Any,
-        arguments args: Any?
+        arguments args: Any?, plugin: InAppWebViewFlutterPlugin? = nil
     ) {
         super.init()
 
@@ -26,7 +26,7 @@ public class FlutterWebViewController: NSObject {
         container.autoresizingMask = [.width, .height]
 
         let webView = InAppWebView(
-            registrar: registrar, viewId: viewId, arguments: args)
+            registrar: registrar, viewId: viewId, arguments: args, plugin: plugin)
         webView.autoresizingMask = [.width, .height]
         webView.frame = container.bounds
         container.addSubview(webView)

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -6,8 +6,6 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     var channel: FlutterMethodChannel!
     var registrar: FlutterPluginRegistrar
     var plugin: InAppWebViewFlutterPlugin?
-    var registrar: FlutterPluginRegistrar
-    var plugin: InAppWebViewFlutterPlugin?
     private var findInteractionChannel: FlutterMethodChannel!
     private var searchText: String?
     private var isDisposed = false

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -4,19 +4,25 @@ import WebKit
 
 public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate {
     var channel: FlutterMethodChannel!
+    var registrar: FlutterPluginRegistrar
+    var plugin: InAppWebViewFlutterPlugin?
+    var registrar: FlutterPluginRegistrar
+    var plugin: InAppWebViewFlutterPlugin?
     private var findInteractionChannel: FlutterMethodChannel!
     private var searchText: String?
     private var isDisposed = false
     public var settings: InAppWebViewSettings?
 
     init(
-        registrar: FlutterPluginRegistrar, viewId: Any, arguments: Any?, channelName: String? = nil
+        registrar: FlutterPluginRegistrar, viewId: Any, arguments: Any?, channelName: String? = nil, plugin: InAppWebViewFlutterPlugin? = nil
     ) {
         let configuration = WKWebViewConfiguration()
         let userContentController = WKUserContentController()
         configuration.userContentController = userContentController
 
         super.init(frame: .zero, configuration: configuration)
+        self.registrar = registrar
+        self.plugin = plugin
         self.autoresizingMask = [.width, .height]
         self.navigationDelegate = self
         self.uiDelegate = self
@@ -56,6 +62,9 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             source: JAVASCRIPT_BRIDGE_JS_SOURCE, injectionTime: .atDocumentStart,
             forMainFrameOnly: false)
         userContentController.addUserScript(bridgeScript)
+        let printScript = WKUserScript(
+            source: PRINT_JS_SOURCE, injectionTime: .atDocumentStart, forMainFrameOnly: true)
+        userContentController.addUserScript(printScript)
 
         let findInteractionUserScript = WKUserScript(
             source: FIND_TEXT_HIGHLIGHT_JS_SOURCE, injectionTime: .atDocumentStart,
@@ -105,6 +114,53 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         self.addObserver(self, forKeyPath: "title", options: .new, context: nil)
     }
 
+
+    public func printCurrentPage(
+        settings: PrintJobSettings? = nil
+    ) -> String? {
+        var printJobId: String? = nil
+        if let settings = settings, settings.handledByClient {
+            printJobId = UUID().uuidString
+        }
+
+        let printInfo = NSPrintInfo(dictionary: nil)
+        printInfo.jobName =
+            settings?.jobName ?? (title ?? url?.absoluteString ?? "") + " Document"
+        if let settings = settings {
+            if let orientationValue = settings.orientation,
+               let orientation = NSPrintInfo.PaperOrientation.init(rawValue: orientationValue)
+            {
+                printInfo.orientation = orientation
+            }
+            if let duplexModeValue = settings.duplexMode,
+               let duplexMode = NSPrintInfo.DuplexMode.init(rawValue: duplexModeValue)
+            {
+                printInfo.duplex = duplexMode
+            }
+            if let margins = settings.margins {
+                printInfo.topMargin = margins.top
+                printInfo.bottomMargin = margins.bottom
+                printInfo.leftMargin = margins.left
+                printInfo.rightMargin = margins.right
+            }
+        }
+
+        let printOperation = NSPrintOperation(view: self, printInfo: printInfo)
+        printOperation.showsPrintPanel = settings?.animated ?? true
+        printOperation.showsProgressPanel = true
+
+        let animated = settings?.animated ?? true
+        if let id = printJobId, let plugin = plugin {
+            let printJob = PrintJobController(
+                plugin: plugin, id: id, printOperation: printOperation, settings: settings, webView: self)
+            plugin.printJobManager?.jobs[id] = printJob
+            printJob.present(animated: animated)
+        } else {
+            printOperation.run()
+        }
+
+        return printJobId
+    }
     deinit {
         dispose()
     }
@@ -358,6 +414,16 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             } else {
                 result([String: Any?]())
             }
+        case "printCurrentPage":
+            if let args = call.arguments as? [String: Any],
+               let settingsMap = args["settings"] as? [String: Any?] {
+                let settings = PrintJobSettings()
+                let _ = settings.parse(settings: settingsMap)
+                result(self.printCurrentPage(settings: settings))
+            } else {
+                result(self.printCurrentPage())
+            }
+            break
         default:
             result(FlutterMethodNotImplemented)
         }
@@ -604,6 +670,24 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             let body = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
         {
             let handlerName = body["handlerName"] as? String ?? ""
+            if handlerName == "onPrintRequest" {
+                let url = self.url
+                let settings = PrintJobSettings()
+                settings.handledByClient = true
+                if let printJobId = printCurrentPage(settings: settings) {
+                    channel?.invokeMethod("onPrintRequest", arguments: [
+                        "url": url?.absoluteString,
+                        "printJobId": printJobId
+                    ]) { (result) in
+                        if let handledByClient = result as? Bool, !handledByClient {
+                            if let printJob = self.plugin?.printJobManager?.jobs[printJobId] {
+                                printJob?.dispose()
+                            }
+                        }
+                    }
+                }
+                return
+            }
             let _callHandlerID = body["_callHandlerID"] as? Int64 ?? 0
             let args = body["args"] as? String ?? ""
 

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFactory.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFactory.swift
@@ -3,10 +3,12 @@ import FlutterMacOS
 
 public class InAppWebViewFactory: NSObject, FlutterPlatformViewFactory {
     private var registrar: FlutterPluginRegistrar
+    private var plugin: InAppWebViewFlutterPlugin?
     private static var associationKey: UInt8 = 0
 
-    init(registrar: FlutterPluginRegistrar) {
+    init(registrar: FlutterPluginRegistrar, plugin: InAppWebViewFlutterPlugin? = nil) {
         self.registrar = registrar
+        self.plugin = plugin
         super.init()
     }
 
@@ -15,7 +17,7 @@ public class InAppWebViewFactory: NSObject, FlutterPlatformViewFactory {
             registrar: registrar,
             withFrame: .zero,
             viewId: viewId,
-            arguments: args)
+            arguments: args, plugin: plugin)
 
         // Keep the FlutterWebViewController alive by associating it with the
         // container view. Flutter retains the view, so the controller stays

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
@@ -5,21 +5,33 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
     var headlessInAppWebViewManager: HeadlessInAppWebViewManager?
     var inAppBrowserManager: InAppBrowserManager?
     var myCookieManager: MyCookieManager?
+    var printJobManager: PrintJobManager?
+    var registrar: FlutterPluginRegistrar?
     
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "dev.zuzu/flutter_inappwebview", binaryMessenger: registrar.messenger)
         let instance = InAppWebViewFlutterPlugin()
+        instance.registrar = registrar
         registrar.addMethodCallDelegate(instance, channel: channel)
         
-        let factory = InAppWebViewFactory(registrar: registrar)
+        let factory = InAppWebViewFactory(registrar: registrar, plugin: instance)
         registrar.register(factory, withId: "dev.zuzu/flutter_inappwebview")
         
         instance.headlessInAppWebViewManager = HeadlessInAppWebViewManager(registrar: registrar)
         instance.inAppBrowserManager = InAppBrowserManager(registrar: registrar)
         instance.myCookieManager = MyCookieManager(registrar: registrar)
+        instance.printJobManager = PrintJobManager(plugin: instance)
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         result(FlutterMethodNotImplemented)
+    }
+
+    public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+        headlessInAppWebViewManager = nil
+        inAppBrowserManager = nil
+        myCookieManager = nil
+        printJobManager?.dispose()
+        printJobManager = nil
     }
 }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PluginScriptsJS/PrintJS.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PluginScriptsJS/PrintJS.swift
@@ -1,0 +1,16 @@
+//
+//  PrintJS.swift
+//  zikzak_inappwebview
+//
+//  Created by ARRRRNY on 16/02/21.
+//
+
+import Foundation
+
+let PRINT_JS_PLUGIN_SCRIPT_GROUP_NAME = "IN_APP_WEBVIEW_PRINT_JS_PLUGIN_SCRIPT"
+
+let PRINT_JS_SOURCE = """
+window.print = function() {
+    window.\(JAVASCRIPT_BRIDGE_NAME).callHandler("onPrintRequest", window.location.href);
+}
+"""

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintAttributes.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintAttributes.swift
@@ -1,0 +1,36 @@
+import Cocoa
+
+public class PrintAttributes: NSObject {
+    var orientation: Int?
+    var duplex: Int?
+    var margins: NSEdgeInsets?
+
+    public init(fromPrintJobController: PrintJobController) {
+        super.init()
+        if let printInfo = fromPrintJobController.printInfo {
+            orientation = printInfo.orientation.rawValue
+            duplex = printInfo.duplex.rawValue
+            margins = NSEdgeInsets(
+                top: printInfo.topMargin,
+                left: printInfo.leftMargin,
+                bottom: printInfo.bottomMargin,
+                right: printInfo.rightMargin
+            )
+        }
+    }
+
+    public func toMap() -> [String: Any?] {
+        return [
+            "margins": margins?.toMap(),
+            "orientation": orientation,
+            "duplex": duplex,
+            "outputType": nil,
+            "footerHeight": nil,
+            "headerHeight": nil,
+            "paperRect": nil,
+            "printableRect": nil,
+            "maximumContentHeight": nil,
+            "maximumContentWidth": nil
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobChannelDelegate.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobChannelDelegate.swift
@@ -1,0 +1,57 @@
+import Cocoa
+import FlutterMacOS
+
+public class PrintJobChannelDelegate: ChannelDelegate {
+    private weak var printJobController: PrintJobController?
+
+    public init(printJobController: PrintJobController, channel: FlutterMethodChannel) {
+        super.init(channel: channel)
+        self.printJobController = printJobController
+    }
+
+    public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? NSDictionary
+
+        switch call.method {
+            case "dismiss":
+                // macOS NSPrintOperation does not support dismissing an active print panel
+                result(false)
+                break
+            case "getInfo":
+                if let printJobController = printJobController {
+                    result(printJobController.getInfo()?.toMap())
+                } else {
+                    result(false)
+                }
+                break
+            case "dispose":
+                if let printJobController = printJobController {
+                    printJobController.dispose()
+                    result(true)
+                } else {
+                    result(false)
+                }
+                break
+            default:
+                result(FlutterMethodNotImplemented)
+                break
+        }
+    }
+
+    public func onComplete(completed: Bool, error: String?) {
+        let arguments: [String: Any?] = [
+            "completed": completed,
+            "error": error
+        ]
+        channel?.invokeMethod("onComplete", arguments: arguments)
+    }
+
+    public override func dispose() {
+        super.dispose()
+        printJobController = nil
+    }
+
+    deinit {
+        dispose()
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobController.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobController.swift
@@ -1,0 +1,79 @@
+import Cocoa
+import FlutterMacOS
+
+public enum PrintJobState: Int {
+    case created = 1
+    case started = 3
+    case completed = 5
+    case failed = 6
+    case canceled = 7
+}
+
+public class PrintJobController: NSObject, Disposable {
+    static let METHOD_CHANNEL_NAME_PREFIX = "wtf.zikzak/zikzak_inappwebview_printjobcontroller_"
+    var id: String
+    var plugin: InAppWebViewFlutterPlugin?
+    var printOperation: NSPrintOperation?
+    var printInfo: NSPrintInfo?
+    var settings: PrintJobSettings?
+    var jobName: String?
+    var channelDelegate: PrintJobChannelDelegate?
+    var state = PrintJobState.created
+    var creationTime = Int64(Date().timeIntervalSince1970 * 1000)
+    var webView: InAppWebView?
+
+    public init(plugin: InAppWebViewFlutterPlugin, id: String, printOperation: NSPrintOperation? = nil, settings: PrintJobSettings? = nil, webView: InAppWebView? = nil) {
+        self.id = id
+        self.plugin = plugin
+        super.init()
+        self.printOperation = printOperation
+        self.settings = settings
+        self.webView = webView
+        self.printInfo = printOperation?.printInfo
+        self.jobName = self.printInfo?.jobName
+        if let registrar = plugin.registrar {
+            let channel = FlutterMethodChannel(name: PrintJobController.METHOD_CHANNEL_NAME_PREFIX + id,
+                                               binaryMessenger: registrar.messenger())
+            self.channelDelegate = PrintJobChannelDelegate(printJobController: self, channel: channel)
+        }
+    }
+
+    public func present(animated: Bool, completionHandler: ((Bool, Error?) -> Void)? = nil) {
+        guard let printOperation = printOperation else {
+            completionHandler?(false, nil)
+            return
+        }
+
+        printOperation.showsPrintPanel = animated
+        printOperation.showsProgressPanel = true
+        state = .started
+
+        DispatchQueue.main.async { [weak self] in
+            let completed = printOperation.run()
+            if completed {
+                self?.state = .completed
+            } else {
+                self?.state = .canceled
+            }
+            self?.channelDelegate?.onComplete(completed: completed, error: nil)
+            completionHandler?(completed, nil)
+        }
+    }
+
+    public func getInfo() -> PrintJobInfo? {
+        guard let _ = printOperation else {
+            return nil
+        }
+        return PrintJobInfo.init(fromPrintJobController: self)
+    }
+
+    public func dispose() {
+        channelDelegate?.dispose()
+        channelDelegate = nil
+        printOperation = nil
+        printInfo = nil
+        webView = nil
+        plugin?.printJobManager?.jobs[id] = nil
+        plugin = nil
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobInfo.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobInfo.swift
@@ -1,0 +1,32 @@
+import Cocoa
+
+public class PrintJobInfo: NSObject {
+    var state: PrintJobState
+    var attributes: PrintAttributes
+    var creationTime: Int64
+    var label: String?
+
+    public init(fromPrintJobController: PrintJobController) {
+        state = fromPrintJobController.state
+        creationTime = fromPrintJobController.creationTime
+        attributes = PrintAttributes.init(fromPrintJobController: fromPrintJobController)
+        super.init()
+        if let jobName = fromPrintJobController.jobName {
+            label = jobName
+        }
+    }
+
+    public func toMap() -> [String: Any?] {
+        return [
+            "state": state.rawValue,
+            "attributes": attributes.toMap(),
+            "copies": nil,
+            "numberOfPages": nil,
+            "creationTime": creationTime,
+            "label": label,
+            "printer": [
+                "id": nil
+            ]
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobManager.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobManager.swift
@@ -1,0 +1,25 @@
+import Cocoa
+import FlutterMacOS
+
+public class PrintJobManager: NSObject, Disposable {
+    var plugin: InAppWebViewFlutterPlugin?
+    var jobs: [String: PrintJobController?] = [:]
+
+    public init(plugin: InAppWebViewFlutterPlugin?) {
+        super.init()
+        self.plugin = plugin
+    }
+
+    public func dispose() {
+        let jobValues = jobs.values
+        jobValues.forEach { (job: PrintJobController?) in
+            job?.dispose()
+        }
+        jobs.removeAll()
+        plugin = nil
+    }
+
+    deinit {
+        dispose()
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobSettings.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/PrintJob/PrintJobSettings.swift
@@ -1,0 +1,54 @@
+import Cocoa
+import FlutterMacOS
+
+@objcMembers
+public class PrintJobSettings: ISettings<PrintJobController> {
+
+    public var handledByClient = false
+    public var jobName: String?
+    public var animated = true
+    public var _orientation: NSNumber?
+    public var orientation: Int? {
+        get {
+            return _orientation?.intValue
+        }
+        set {
+            if let newValue = newValue {
+                _orientation = NSNumber.init(value: newValue)
+            } else {
+                _orientation = nil
+            }
+        }
+    }
+    public var _duplexMode: NSNumber?
+    public var duplexMode: Int? {
+        get {
+            return _duplexMode?.intValue
+        }
+        set {
+            if let newValue = newValue {
+                _duplexMode = NSNumber.init(value: newValue)
+            } else {
+                _duplexMode = nil
+            }
+        }
+    }
+    public var margins: NSEdgeInsets?
+
+    override init() {
+        super.init()
+    }
+
+    override func parse(settings: [String: Any?]) -> PrintJobSettings {
+        let _ = super.parse(settings: settings)
+        if let marginsMap = settings["margins"] as? [String: Double] {
+            margins = NSEdgeInsets.fromMap(map: marginsMap)
+        }
+        return self
+    }
+
+    override func getRealSettings(obj: PrintJobController?) -> [String: Any?] {
+        let realOptions: [String: Any?] = toMap()
+        return realOptions
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/CGRect.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/CGRect.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension CGRect {
+    public static func fromMap(map: [String: Double]) -> CGRect {
+        return CGRect(x: map["x"]!, y: map["y"]!, width: map["width"]!, height: map["height"]!)
+    }
+
+    public func toMap() -> [String: Any?] {
+        return [
+            "x": minX,
+            "y": minY,
+            "width": width,
+            "height": height
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ChannelDelegate.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ChannelDelegate.swift
@@ -1,0 +1,20 @@
+import FlutterMacOS
+
+public class ChannelDelegate: FlutterMethodCallDelegate, Disposable {
+    var channel: FlutterMethodChannel?
+
+    public init(channel: FlutterMethodChannel) {
+        super.init()
+        self.channel = channel
+        self.channel?.setMethodCallHandler(handle)
+    }
+
+    public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+
+    }
+
+    public func dispose() {
+        channel?.setMethodCallHandler(nil)
+        channel = nil
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/Disposable.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/Disposable.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol Disposable {
+    func dispose() -> Void
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/NSEdgeInsets.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/NSEdgeInsets.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension NSEdgeInsets {
+    public static func fromMap(map: [String: Double]) -> NSEdgeInsets {
+        return NSEdgeInsets(
+            top: map["top"]!,
+            left: map["left"]!,
+            bottom: map["bottom"]!,
+            right: map["right"]!
+        )
+    }
+
+    public func toMap() -> [String: Any?] {
+        return [
+            "top": top,
+            "right": right,
+            "bottom": bottom,
+            "left": left
+        ]
+    }
+}


### PR DESCRIPTION
Closes #188

## Summary\n\nImplements print page / print functionality for the macOS platform in zikzak_inappwebview, reusing the existing iOS implementation pattern. Closes #188.\n\n### Changes\n\n**Native (Swift):**\n- Added PrintJob module (6 files): PrintJobManager, PrintJobController, PrintJobSettings, PrintJobInfo, PrintAttributes, PrintJobChannelDelegate\n- Added type extensions: Disposable protocol, ChannelDelegate base class, CGRect/NSEdgeInsets fromMap/toMap\n- Modified InAppWebView: injects PRINT_JS_SOURCE, handles printCurrentPage method call, handles onPrintRequest from JS via callHandler routing\n- Modified InAppWebViewFlutterPlugin: initializes/disposes PrintJobManager\n- Modified InAppWebViewFactory & FlutterWebViewController: pass plugin reference through to InAppWebView\n\n**Dart:**\n- Added MacOSPrintJobController (mirrors IOSPrintJobController)\n- Added printCurrentPage override to MacOSInAppWebViewController\n- Registered MacOSPrintJobController in MacOSInAppWebViewPlatform\n\n### How it works\n- When the Dart side calls printCurrentPage(), it invokes the native printCurrentPage method which creates an NSPrintOperation with the WKWebView and presents the macOS print dialog\n- When JavaScript calls window.print(), the injected PRINT_JS_SOURCE routes it through the onPrintRequest handler, which creates a print job with handledByClient=true so the Dart side can control it via the PrintJobController\n\n### Supported settings\n- jobName, orientation, duplexMode, margins, animated (shows/hides print panel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS printing support for web pages.
  * Added configurable print settings, including job name, orientation, duplex mode, margins, and animation.
  * Added print-job status, information retrieval, completion callbacks, dismissal, and disposal controls.
  * Web pages can now intercept `window.print()` requests and coordinate print jobs through the app.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->