### PR TITLE
fix(windows): implement addJavaScriptHandler + JS bridge (closes #177)

### DIFF
--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_controller.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_controller.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
@@ -7,13 +8,210 @@ import 'package:path/path.dart' as p;
 import 'package:webview_windows/webview_windows.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
+/// Names reserved by the platform and not allowed for user-registered
+/// JavaScript handlers. Mirrors the lists used by the Android, iOS, macOS
+/// and Linux implementations so behaviour stays consistent across platforms.
+final _JAVASCRIPT_HANDLER_FORBIDDEN_NAMES = UnmodifiableListView<String>([
+  "onLoadResource",
+  "shouldInterceptAjaxRequest",
+  "onAjaxReadyStateChange",
+  "onAjaxProgress",
+  "shouldInterceptFetchRequest",
+  "onPrintRequest",
+  "onWindowFocus",
+  "onWindowBlur",
+  "callAsyncJavaScript",
+  "evaluateJavaScriptWithContentWorld",
+]);
+
 class InAppWebViewWindowsController extends PlatformInAppWebViewController {
   final WebviewController _controller;
+
+  /// Handlers registered through [addJavaScriptHandler], keyed by name.
+  final Map<String, JavaScriptHandlerCallback> _javaScriptHandlersMap = {};
+
+  StreamSubscription<dynamic>? _webMessageSubscription;
+
+  /// Whether the JavaScript handler bridge has already been installed on the
+  /// underlying [WebviewController]. The bridge is idempotent so it is safe to
+  /// install it only once.
+  bool _isJsBridgeInstalled = false;
 
   InAppWebViewWindowsController(
     PlatformInAppWebViewControllerCreationParams params,
     this._controller,
   ) : super.implementation(params);
+
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) {
+    assert(
+      !_JAVASCRIPT_HANDLER_FORBIDDEN_NAMES.contains(handlerName),
+      '"$handlerName" is a forbidden name!',
+    );
+    _javaScriptHandlersMap[handlerName] = callback;
+    _ensureJavaScriptHandlerBridge();
+  }
+
+  @override
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
+    required String handlerName,
+  }) {
+    return _javaScriptHandlersMap.remove(handlerName);
+  }
+
+  @override
+  bool hasJavaScriptHandler({required String handlerName}) {
+    return _javaScriptHandlersMap.containsKey(handlerName);
+  }
+
+  /// Installs (once) the JavaScript bridge that exposes
+  /// `window.zikzak_inappwebview.callHandler(handlerName, ...args)` and wires
+  /// the incoming [WebviewController.webMessage] stream to the registered
+  /// Dart handlers. The bridge follows the same contract documented by the
+  /// platform interface (see [PlatformInAppWebViewController.addJavaScriptHandler]):
+  /// `callHandler` returns a `Promise` that resolves with the JSON-encoded
+  /// value returned by the Dart callback, and the
+  /// `flutterInAppWebViewPlatformReady` event is dispatched once the bridge
+  /// is available.
+  void _ensureJavaScriptHandlerBridge() {
+    if (_isJsBridgeInstalled) return;
+    _isJsBridgeInstalled = true;
+    _webMessageSubscription = _controller.webMessage.listen(
+      _dispatchWebMessage,
+      onError: (_) {
+        // Ignore malformed messages — they are not part of the handler
+        // protocol and must not crash the webview.
+      },
+    );
+    // Inject the bridge on every new document so it survives navigation.
+    // The script is idempotent (guards against double installation).
+    const bridge = r'''
+(function() {
+  if (window.zikzak_inappwebview && window.zikzak_inappwebview._isZikzakBridge) {
+    return;
+  }
+  var pending = {};
+  var nextCallId = 0;
+  function asArray(value) {
+    if (Array.isArray(value)) return value;
+    return [];
+  }
+  window.zikzak_inappwebview = {
+    _isZikzakBridge: true,
+    callHandler: function(handlerName) {
+      var args = asArray(Array.prototype.slice.call(arguments, 1));
+      return new Promise(function(resolve, reject) {
+        var callId = ++nextCallId;
+        pending[callId] = { resolve: resolve, reject: reject };
+        try {
+          window.chrome.webview.postMessage(JSON.stringify({
+            _zikzakHandlerCall: true,
+            callId: callId,
+            handlerName: handlerName,
+            args: args
+          }));
+        } catch (e) {
+          delete pending[callId];
+          reject(e);
+        }
+      });
+    }
+  };
+  window._zikzakInAppWebViewResolveHandler = function(callId, success, jsonResult) {
+    var entry = pending[callId];
+    if (!entry) return;
+    delete pending[callId];
+    var value = null;
+    if (jsonResult != null) {
+      try { value = JSON.parse(jsonResult); }
+      catch (e) {
+        if (success) { entry.resolve(null); } else { entry.reject(new Error("Failed to parse handler result")); }
+        return;
+      }
+    }
+    if (success) { entry.resolve(value); } else { entry.reject(value); }
+  };
+  window.dispatchEvent(new Event("flutterInAppWebViewPlatformReady"));
+})();
+''';
+    try {
+      _controller
+          .addScriptToExecuteOnDocumentCreated(bridge)
+          .catchError((Object _) => null);
+      // Best-effort: if injection fails (e.g. controller disposed), the
+      // bridge simply won't be available and JS calls will reject — but
+      // addJavaScriptHandler itself must not throw.
+    } catch (_) {
+      // Same as above — never propagate injection errors to the caller.
+    }
+  }
+
+  void _dispatchWebMessage(dynamic message) {
+    Map<dynamic, dynamic>? payload;
+    if (message is Map) {
+      payload = message;
+    } else if (message is String) {
+      try {
+        final decoded = jsonDecode(message);
+        if (decoded is Map) payload = decoded;
+      } catch (_) {
+        return;
+      }
+    } else {
+      return;
+    }
+    if (payload == null) return;
+    if (payload['_zikzakHandlerCall'] != true) return;
+    final handlerName = payload['handlerName'];
+    if (handlerName is! String) return;
+    final callId = payload['callId'];
+    final rawArgs = payload['args'];
+    final args = rawArgs is List ? rawArgs : <dynamic>[];
+    final handler = _javaScriptHandlersMap[handlerName];
+    if (handler == null) {
+      _reply(callId, false, 'Handler "$handlerName" is not registered');
+      return;
+    }
+    dynamic result;
+    try {
+      result = handler(args);
+    } catch (e) {
+      _reply(callId, false, e.toString());
+      return;
+    }
+    if (result is Future) {
+      result.then((Object? value) {
+        _reply(callId, true, value);
+      }).catchError((Object error) {
+        _reply(callId, false, error.toString());
+      });
+    } else {
+      _reply(callId, true, result);
+    }
+  }
+
+  void _reply(dynamic callId, bool success, dynamic result) {
+    String jsonResult;
+    try {
+      jsonResult = jsonEncode(result);
+    } catch (_) {
+      jsonResult = 'null';
+    }
+    final js = 'window._zikzakInAppWebViewResolveHandler && '
+        'window._zikzakInAppWebViewResolveHandler('
+        '${jsonEncode(callId)}, ${success ? 'true' : 'false'}, '
+        '${jsonEncode(jsonResult)});';
+    try {
+      _controller.executeScript(js).catchError((Object _) {
+        // Best-effort delivery — ignore failures.
+      });
+    } catch (_) {
+      // Ignore — controller may be disposed between calls.
+    }
+  }
 
   @override
   Future<void> loadUrl({
@@ -133,8 +331,20 @@ class InAppWebViewWindowsController extends PlatformInAppWebViewController {
 
   @override
   void dispose({bool isKeepAlive = false}) {
+    _webMessageSubscription?.cancel();
+    _webMessageSubscription = null;
+    _javaScriptHandlersMap.clear();
     if (!isKeepAlive) {
-      _controller.dispose();
+      try {
+        // Only dispose the underlying WebviewController when it has actually
+        // been initialized; calling dispose on a never-initialized controller
+        // throws a LateInitializationError inside the webview_windows package.
+        if (_controller.value.isInitialized) {
+          _controller.dispose();
+        }
+      } catch (_) {
+        // Best-effort — never let cleanup crash the host.
+      }
     }
   }
 }

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_controller_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_controller_test.dart
@@ -1,0 +1,123 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_windows/webview_windows.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_controller.dart';
+
+/// Constructs a Windows controller backed by a real (but uninitialized)
+/// [WebviewController]. The handler-map operations exercised below never
+/// touch the platform channel, so this is safe to run on the Dart VM.
+InAppWebViewWindowsController _buildController() {
+  final params = PlatformInAppWebViewControllerCreationParams(id: 0);
+  return InAppWebViewWindowsController(params, WebviewController());
+}
+
+void main() {
+  group('addJavaScriptHandler', () {
+    test('registers a handler that hasJavaScriptHandler reports', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      controller.addJavaScriptHandler(
+        handlerName: 'testHandler',
+        callback: (args) => 'ok: ${args.length}',
+      );
+
+      expect(controller.hasJavaScriptHandler(handlerName: 'testHandler'), true);
+    });
+
+    test('does not throw UnimplementedError (regression for issue #177)', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      // The defining symptom of issue #177 was that this call threw
+      // UnimplementedError because the Windows controller did not override
+      // addJavaScriptHandler. It must now complete synchronously without
+      // throwing.
+      expect(
+        () => controller.addJavaScriptHandler(
+          handlerName: 'noThrow',
+          callback: (args) => null,
+        ),
+        returnsNormally,
+      );
+    });
+  });
+
+  group('hasJavaScriptHandler', () {
+    test('returns false for an unregistered handler', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      expect(
+        controller.hasJavaScriptHandler(handlerName: 'missing'),
+        false,
+      );
+    });
+  });
+
+  group('removeJavaScriptHandler', () {
+    test('returns the previously registered callback and clears the slot', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      dynamic received(List<dynamic> args) => 'pong';
+      controller.addJavaScriptHandler(
+        handlerName: 'ping',
+        callback: received,
+      );
+
+      final removed = controller.removeJavaScriptHandler(handlerName: 'ping');
+      expect(identical(removed, received), true);
+      expect(controller.hasJavaScriptHandler(handlerName: 'ping'), false);
+    });
+
+    test('returns null when removing an unknown handler', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      expect(
+        controller.removeJavaScriptHandler(handlerName: 'unknown'),
+        isNull,
+      );
+    });
+  });
+
+  group('forbidden handler names', () {
+    test('asserts when registering a reserved name', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      // The Windows controller must reject the same reserved names used by
+      // the Android / iOS / macOS / Linux implementations so users cannot
+      // shadow internal handlers.
+      expect(
+        () => controller.addJavaScriptHandler(
+          handlerName: 'onLoadResource',
+          callback: (args) => null,
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('bridge idempotency', () {
+    test('registers multiple handlers without re-installing the bridge', () {
+      final controller = _buildController();
+      addTearDown(controller.dispose);
+
+      controller.addJavaScriptHandler(
+        handlerName: 'first',
+        callback: (args) => null,
+      );
+      // A second registration must be cheap and must not throw even though
+      // the underlying WebviewController is not initialized on this platform.
+      controller.addJavaScriptHandler(
+        handlerName: 'second',
+        callback: (args) => null,
+      );
+
+      expect(controller.hasJavaScriptHandler(handlerName: 'first'), true);
+      expect(controller.hasJavaScriptHandler(handlerName: 'second'), true);
+    });
+  });
+}


### PR DESCRIPTION
Closes #177

InAppWebViewWindowsController did not override addJavaScriptHandler / removeJavaScriptHandler / hasJavaScriptHandler, so calling addJavaScriptHandler (typically inside onWebViewCreated) fell through to the platform interface base class which throws UnimplementedError. That exception was caught by the try/catch in initPlatformState() and surfaced as 'Failed to initialize webview: UnimplementedError: addJavaScriptHandler is not implemented on the current platform' — exactly the symptom reported in #177 (confirmed on Windows).

This change implements the three handlers on Windows using the webview_windows package's webMessage stream + addScriptToExecuteOnDocumentCreated API, matching the window.zikzak_inappwebview.callHandler contract documented by the platform interface (returns a Promise that resolves with the JSON-encoded return value of the Dart callback, dispatches the flutterInAppWebViewPlatformReady event). It also adds the shared _JAVASCRIPT_HANDLER_FORBIDDEN_NAMES guard used by Android/iOS/macOS/Linux, makes dispose() defensive against partially-initialized controllers, and ships unit tests covering registration, removal, hasJavaScriptHandler, the forbidden-names assertion, bridge idempotency, and the #177 regression (no UnimplementedError).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JavaScript handler support for Windows web views.
  * Register, remove, and check available JavaScript handlers.
  * Supports synchronous and asynchronous callbacks with JSON results or errors.
  * JavaScript communication remains available across page navigations.

* **Bug Fixes**
  * Improved handling of malformed messages, script failures, serialization issues, and disposal scenarios.
  * Prevented use of reserved handler names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->