### PR TITLE
fix(macos): await shouldOverrideUrlLoading response so cancellations are honored (#192)

### DIFF
--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -820,8 +820,71 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             "targetFrame": targetFrame,
         ]
 
-        channel?.invokeMethod("shouldOverrideUrlLoading", arguments: arguments)
-        decisionHandler(.allow)
+        // Honor `useShouldOverrideUrlLoading` opt-in (mirrors iOS). When the
+        // Dart side has not enabled the callback, fall through to the default
+        // `.allow` policy without round-tripping through the method channel.
+        let useShouldOverrideUrlLoading =
+            (settings?.useShouldOverrideUrlLoading == true)
+        guard useShouldOverrideUrlLoading else {
+            decisionHandler(.allow)
+            return
+        }
+
+        guard let channel = self.channel else {
+            decisionHandler(.allow)
+            return
+        }
+
+        // Await the Dart-side `shouldOverrideUrlLoading` callback before
+        // resolving the navigation policy. Previously this was invoked
+        // fire-and-forget and `decisionHandler(.allow)` was called
+        // unconditionally, so the user's `NavigationActionPolicy.CANCEL`
+        // (e.g. to block `intent:` or custom schemes) was silently ignored.
+        //
+        // The Dart handler returns the `NavigationActionPolicy` native int:
+        //   0 = CANCEL, 1 = ALLOW, 2 = DOWNLOAD (iOS 14.5+ only — not yet
+        //   exposed on macOS; treat as CANCEL to honor the user's intent to
+        //   block rather than silently allow).
+        var decisionHandlerCalled = false
+        let resolvePolicy: (WKNavigationActionPolicy) -> Void = { policy in
+            guard !decisionHandlerCalled else { return }
+            decisionHandlerCalled = true
+            decisionHandler(policy)
+        }
+
+        channel.invokeMethod(
+            "shouldOverrideUrlLoading",
+            arguments: arguments
+        ) { result in
+            let policy: WKNavigationActionPolicy
+            if let action = result as? Int {
+                switch action {
+                case 1:
+                    policy = .allow
+                case 0, 2:
+                    // 0 = CANCEL; 2 = DOWNLOAD (not supported on macOS yet —
+                    // fall back to CANCEL so we never silently allow a
+                    // navigation the user explicitly tried to block).
+                    policy = .cancel
+                default:
+                    policy = .cancel
+                }
+            } else if let action = result as? NSNumber {
+                // The Flutter channel may surface the int as NSNumber on
+                // macOS. Normalize before comparing.
+                switch action.intValue {
+                case 1: policy = .allow
+                default: policy = .cancel
+                }
+            } else {
+                // Dart side returns ALLOW (1) when no callback is registered
+                // and CANCEL (0) when the callback returns null. Any other
+                // shape is treated as a safe-default CANCEL so a buggy
+                // handler can never accidentally allow a blocked scheme.
+                policy = .cancel
+            }
+            resolvePolicy(policy)
+        }
     }
 
     public func webView(

--- a/zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart
+++ b/zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_macos/src/in_app_webview/in_app_webview_controller.dart';
@@ -125,5 +126,113 @@ void main() {
       expect(controller.hasJavaScriptHandler(handlerName: 'persist'), isFalse);
       expect(controller.hasJavaScriptHandler(handlerName: 'persist2'), isFalse);
     });
+  });
+
+  // Regression test for issue #192:
+  // https://github.com/arrrrny/zikzak_inappwebview/issues/192
+  //
+  // On macOS, `InAppWebView.swift` `decidePolicyFor navigationAction:` used
+  // to invoke `shouldOverrideUrlLoading` on the method channel fire-and-
+  // forget and then unconditionally call `decisionHandler(.allow)`. The fix
+  // awaits the Dart-side response and maps the returned
+  // `NavigationActionPolicy` int (0=cancel, 1=allow, 2=download) to the
+  // `WKNavigationActionPolicy` handed to `decisionHandler`.
+  //
+  // These tests pin the *Dart-side* channel contract that the Swift fix
+  // relies on: the integer returned by `handleMethod('shouldOverrideUrlLoading')`
+  // must match `NavigationActionPolicy.*.toNativeValue()` so the native side
+  // can decode it correctly.
+  group('shouldOverrideUrlLoading channel contract (issue #192)', () {
+    /// Build a `MethodCall` that mirrors the payload the macOS
+    /// `InAppWebView.swift` sends to Dart when a navigation action is about
+    /// to occur. Only the fields consumed by `NavigationAction.fromMap` are
+    /// populated; the rest default to `null` on the Dart side.
+    MethodCall shouldOverrideUrlLoadingCall(String url) {
+      return MethodCall('shouldOverrideUrlLoading', {
+        'navigationAction': {
+          'request': {'url': url},
+          'isForMainFrame': true,
+        },
+      });
+    }
+
+    test('returns ALLOW (1) when no callback is registered', () async {
+      // `controller` from setUp has no `shouldOverrideUrlLoading` wired up.
+      final result = await controller.handleMethod(
+        shouldOverrideUrlLoadingCall('https://example.com'),
+      );
+      expect(result, NavigationActionPolicy.ALLOW.toNativeValue());
+    });
+
+    test(
+      'returns CANCEL (0) when the callback blocks a non-allowed scheme (intent:)',
+      () async {
+        final widgetParams = PlatformInAppWebViewWidgetCreationParams(
+          controllerFromPlatform: (c) => c,
+          shouldOverrideUrlLoading: (c, navigationAction) async {
+            final url = navigationAction.request.url;
+            if (url != null && url.scheme == 'intent') {
+              return NavigationActionPolicy.CANCEL;
+            }
+            return NavigationActionPolicy.ALLOW;
+          },
+        );
+        final controllerParams = PlatformInAppWebViewControllerCreationParams(
+          id: 54321,
+          webviewParams: widgetParams,
+        );
+        final ctrl = MacOSInAppWebViewController(controllerParams);
+        addTearDown(ctrl.dispose);
+
+        final blockedResult = await ctrl.handleMethod(
+          shouldOverrideUrlLoadingCall('intent://example.com#Intent;end;'),
+        );
+        expect(
+          blockedResult,
+          NavigationActionPolicy.CANCEL.toNativeValue(),
+          reason:
+              'A blocked scheme must surface as CANCEL (0) so the macOS '
+              'native side calls `decisionHandler(.cancel)` and stops the '
+              'navigation. This is the exact regression from issue #192.',
+        );
+
+        final allowedResult = await ctrl.handleMethod(
+          shouldOverrideUrlLoadingCall('https://example.com'),
+        );
+        expect(
+          allowedResult,
+          NavigationActionPolicy.ALLOW.toNativeValue(),
+          reason: 'Allowed schemes must surface as ALLOW (1).',
+        );
+      },
+    );
+
+    test(
+      'returns CANCEL (0) when the callback returns null (safe default)',
+      () async {
+        final widgetParams = PlatformInAppWebViewWidgetCreationParams(
+          controllerFromPlatform: (c) => c,
+          shouldOverrideUrlLoading: (c, navigationAction) async => null,
+        );
+        final controllerParams = PlatformInAppWebViewControllerCreationParams(
+          id: 67890,
+          webviewParams: widgetParams,
+        );
+        final ctrl = MacOSInAppWebViewController(controllerParams);
+        addTearDown(ctrl.dispose);
+
+        final result = await ctrl.handleMethod(
+          shouldOverrideUrlLoadingCall('https://example.com'),
+        );
+        expect(
+          result,
+          NavigationActionPolicy.CANCEL.toNativeValue(),
+          reason:
+              'When the callback is registered but returns null, the Dart '
+              'side must default to CANCEL so the native side never silently '
+              'allows a navigation the user did not explicitly approve.',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
Closes #192

On macOS, InAppWebView.swift decidePolicyFor navigationAction: invoked the shouldOverrideUrlLoading method channel fire-and-forget and unconditionally called decisionHandler(.allow), so the Dart-side NavigationActionPolicy.CANCEL (e.g. to block intent: or custom schemes) was silently ignored.

This patch mirrors the iOS implementation:
- Honor the useShouldOverrideUrlLoading opt-in (allow fast-path when false).
- Await the FlutterMethodChannel result callback before resolving the policy.
- Decode the returned NavigationActionPolicy native int (0=cancel, 1=allow, 2=download) into the corresponding WKNavigationActionPolicy. DOWNLOAD (iOS 14.5+ only) is mapped to .cancel on macOS so a navigation the user tried to block is never silently allowed.
- Guard decisionHandler with a decisionHandlerCalled flag so it is never invoked twice.
- Fall back to .allow when the channel is nil and to .cancel for unrecognized payload shapes (safe defaults).

Adds a Dart-side regression test (zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart) that pins the channel contract the Swift fix relies on: returns ALLOW (1) when no callback is registered, CANCEL (0) when the callback blocks an intent: scheme, ALLOW (1) for an allowed https: scheme, and CANCEL (0) when the callback returns null. All 12 tests pass; dart analyze introduces no new warnings.

Closes #192.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation handling on macOS when URL-loading overrides are enabled or unavailable.
  * Prevented duplicate navigation decisions and safely cancels unsupported or invalid callback results.

* **Tests**
  * Added regression coverage for default navigation, callback-driven cancellation or approval, and null callback responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->