### PR TITLE
fix(macos): implement media-capture permission prompts for getUserMedia() (#195)

### DIFF
--- a/zikzak_inappwebview/example/lib/in_app_webiew_example.screen.dart
+++ b/zikzak_inappwebview/example/lib/in_app_webiew_example.screen.dart
@@ -109,6 +109,44 @@ class _InAppWebViewExampleScreenState extends State<InAppWebViewExampleScreen> {
         title: const Text("InAppWebView"),
         actions: [
           IconButton(
+            icon: const Icon(Icons.videocam),
+            tooltip: "Media capture (getUserMedia) test",
+            onPressed: () async {
+              // Loads an inline page that calls getUserMedia() for camera +
+              // microphone. Triggers the WKUIDelegate media-capture permission
+              // path on iOS/macOS (issue #195). The onPermissionRequest handler
+              // configured below grants the request; macOS additionally needs
+              // NSCameraUsageDescription / NSMicrophoneUsageDescription in
+              // Info.plist plus camera/audio-input entitlements.
+              await webViewController?.loadData(
+                data: '''<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"><title>getUserMedia test</title></head>
+<body style="font-family:sans-serif;text-align:center">
+  <h2>getUserMedia() test</h2>
+  <video id="v" autoplay playsinline style="max-width:100%;border:1px solid #ccc"></video>
+  <p id="status">Requesting media&#8230;</p>
+  <script>
+    navigator.mediaDevices.getUserMedia({video:true,audio:true})
+      .then(function(stream){
+        document.getElementById('v').srcObject = stream;
+        document.getElementById('status').textContent =
+          'Granted: ' + stream.getTracks().map(function(t){return t.kind}).join(', ');
+      })
+      .catch(function(err){
+        document.getElementById('status').textContent =
+          'Denied: ' + err.name + ': ' + err.message;
+      });
+  </script>
+</body>
+</html>''',
+                mimeType: 'text/html',
+                encoding: 'utf8',
+                baseUrl: WebUri('about:blank'),
+              );
+            },
+          ),
+          IconButton(
             icon: const Icon(Icons.delete),
             tooltip: "Delete all cookies",
             onPressed: () async {

--- a/zikzak_inappwebview/example/macos/Runner/DebugProfile.entitlements
+++ b/zikzak_inappwebview/example/macos/Runner/DebugProfile.entitlements
@@ -11,5 +11,12 @@
 	<true />
 	<key>com.apple.security.network.server</key>
 	<true />
+	<!-- Media-capture entitlements for getUserMedia() on macOS (issue #195).
+	     Required by sandboxed apps so WKWebView can actually access the camera
+	     and microphone after the user grants the WKPermissionDecision. -->
+	<key>com.apple.security.device.camera</key>
+	<true />
+	<key>com.apple.security.device.audio-input</key>
+	<true />
 </dict>
 </plist>

--- a/zikzak_inappwebview/example/macos/Runner/Info.plist
+++ b/zikzak_inappwebview/example/macos/Runner/Info.plist
@@ -28,5 +28,12 @@
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<!-- Media-capture usage strings so WKWebView can prompt for camera/microphone
+	     via getUserMedia() on macOS (issue #195). Without these the system denies
+	     access at the TCC layer even after the WKPermissionDecision is .grant. -->
+	<key>NSCameraUsageDescription</key>
+	<string>This app needs camera access so web pages can use the camera via getUserMedia().</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs microphone access so web pages can use the microphone via getUserMedia().</string>
 </dict>
 </plist>

--- a/zikzak_inappwebview/example/macos/Runner/Release.entitlements
+++ b/zikzak_inappwebview/example/macos/Runner/Release.entitlements
@@ -9,5 +9,12 @@
 	<true />
 	<key>com.apple.security.network.server</key>
 	<true />
+	<!-- Media-capture entitlements for getUserMedia() on macOS (issue #195).
+	     Required by sandboxed apps so WKWebView can actually access the camera
+	     and microphone after the user grants the WKPermissionDecision. -->
+	<key>com.apple.security.device.camera</key>
+	<true />
+	<key>com.apple.security.device.audio-input</key>
+	<true />
 </dict>
 </plist>

--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Unreleased
+
+
+- Fixed: macOS media-capture permission prompts were missing - the `WKUIDelegate`
+  did not implement `requestMediaCapturePermissionForOrigin`, so any page calling
+  `getUserMedia()` (camera/microphone) was silently denied on macOS. Ported the
+  iOS implementation to macOS (gated `@available(macOS 12.0, *)`): the delegate
+  now dispatches `onPermissionRequest` to Dart with the `PermissionResource`
+  (`camera` / `microphone` / `cameraAndMicrophone`) and maps the returned
+  `PermissionResponse.action` (`GRANT` / `DENY` / `PROMPT`) back to
+  `WKPermissionDecision`, defaulting to `.deny` if Dart returns no action. Also
+  implemented the sibling `requestDeviceOrientationAndMotionPermissionForOrigin`
+  for parity with iOS. Added the supporting `PermissionRequest` /
+  `PermissionResponse` / `StringOrInt` types and `WKFrameInfo` /
+  `WKSecurityOrigin` `toMap()` extensions (ported from iOS). Documented the
+  required `NSCameraUsageDescription` / `NSMicrophoneUsageDescription` Info.plist
+  keys and `com.apple.security.device.camera` / `com.apple.security.device.audio-input`
+  entitlements, and added a `getUserMedia()` test button to the example app.
+  Closes #195
+
 ## 4.6.3 - 2026-07-21
 
 

--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -5,7 +5,7 @@
   did not implement `requestMediaCapturePermissionForOrigin`, so any page calling
   `getUserMedia()` (camera/microphone) was silently denied on macOS. Ported the
   iOS implementation to macOS (gated `@available(macOS 12.0, *)`): the delegate
-  now dispatches `onPermissionRequest` to Dart with the `PermissionResource`
+  now dispatches `onPermissionRequest` to Dart with the `PermissionResourceType`
   (`camera` / `microphone` / `cameraAndMicrophone`) and maps the returned
   `PermissionResponse.action` (`GRANT` / `DENY` / `PROMPT`) back to
   `WKPermissionDecision`, defaulting to `.deny` if Dart returns no action. Also

--- a/zikzak_inappwebview_macos/README.md
+++ b/zikzak_inappwebview_macos/README.md
@@ -5,3 +5,82 @@ The macOS implementation of the [zikzak_inappwebview](https://pub.dev/packages/z
 ## Usage
 
 This package is endorsed, which means you can simply use `zikzak_inappwebview` normally. This package will be automatically included in your app when you do.
+
+## Media capture (camera / microphone) on macOS
+
+`getUserMedia()` (camera / microphone) is supported on macOS 12.0+ via the
+`WKUIDelegate` methods `webView(_:requestMediaCapturePermissionFor:initiatedByFrame:type:)`
+and `webView(_:requestDeviceOrientationAndMotionPermissionFor:initiatedByFrame:)`.
+Permission requests are forwarded to Dart through the existing
+`onPermissionRequest` callback (the same event used on iOS and Android), and the
+`PermissionResponse.action` you return (`GRANT` / `DENY` / `PROMPT`) is mapped
+back to WebKit's `WKPermissionDecision`. If your `onPermissionRequest` handler
+is not set, or returns `null`, the request is **denied** — this matches the iOS
+default and is always safe (WebKit never hangs waiting for a decision).
+
+### Required app configuration
+
+For the WebView to actually access the camera / microphone **after** the
+`WKPermissionDecision` is granted, your macOS app must declare the usage
+descriptions and (for sandboxed apps) the corresponding entitlements. Without
+these, the system TCC layer denies access silently and `getUserMedia()` rejects
+with `NotAllowedError`, even though the WebView permission prompt was granted.
+
+1. **Info.plist** — add a usage-description string for each capture type your
+   app needs. The system shows this text in the permission prompt:
+
+   ```xml
+   <key>NSCameraUsageDescription</key>
+   <string>This app needs camera access so web pages can use the camera.</string>
+   <key>NSMicrophoneUsageDescription</key>
+   <string>This app needs microphone access so web pages can use the microphone.</string>
+   ```
+
+2. **Entitlements** (required for sandboxed apps, i.e. when
+   `com.apple.security.app-sandbox` is `true`) — add the device entitlements:
+
+   ```xml
+   <key>com.apple.security.device.camera</key>
+   <true/>
+   <key>com.apple.security.device.audio-input</key>
+   <true/>
+   ```
+
+   Add these to **both** your `DebugProfile.entitlements` and
+   `Release.entitlements` files. Non-sandboxed apps do not need the entitlements,
+   but the Info.plist usage strings are always required.
+
+### Example
+
+The example app's `InAppWebViewExampleScreen` grants media-capture requests by
+default and ships a "Media capture (getUserMedia) test" button in the app bar
+that loads an inline page calling `getUserMedia({video:true,audio:true})`:
+
+```dart
+InAppWebView(
+  // ...
+  onPermissionRequest: (controller, request) async {
+    return PermissionResponse(
+      resources: request.resources,
+      action: PermissionResponseAction.GRANT,
+    );
+  },
+);
+```
+
+Tap the camera icon in the app bar to load the test page; on macOS 12.0+ the
+system shows the camera/microphone permission prompt, and once granted the live
+stream is rendered in the page's `<video>` element.
+
+### Notes
+
+- The delegate methods are gated `@available(macOS 12.0, *)`, matching the
+  availability of `WKUIDelegate.requestMediaCapturePermissionForOrigin` on
+  macOS. The package's deployment target is already macOS 12.0.
+- `WKMediaCaptureType` (`.camera` / `.microphone` / `.cameraAndMicrophone`) is
+  mapped to `PermissionResourceType` using its `rawValue`, exactly as on iOS —
+  the shared Dart `PermissionResourceType.fromNativeValue` handles the macOS
+  native values (`0` / `1` / `2`).
+- Device-orientation-and-motion permission (`requestDeviceOrientationAndMotionPermissionForOrigin`)
+  is also implemented for parity with iOS; it dispatches the same
+  `onPermissionRequest` event with the `DEVICE_ORIENTATION_AND_MOTION` resource.

--- a/zikzak_inappwebview_macos/README.md
+++ b/zikzak_inappwebview_macos/README.md
@@ -52,14 +52,30 @@ with `NotAllowedError`, even though the WebView permission prompt was granted.
 
 ### Example
 
-The example app's `InAppWebViewExampleScreen` grants media-capture requests by
-default and ships a "Media capture (getUserMedia) test" button in the app bar
-that loads an inline page calling `getUserMedia({video:true,audio:true})`:
+The example app ships a "Media capture (getUserMedia) test" button in the app
+bar that loads an inline page calling `getUserMedia({video:true,audio:true})`.
+**For testing only**, the example's `onPermissionRequest` handler grants every
+request — this is convenient for the test button but is **not** a pattern you
+should copy into production apps that load untrusted web content.
+
+In production, **deny by default** and grant only for origins you trust after
+checking `request.resources`:
 
 ```dart
 InAppWebView(
   // ...
   onPermissionRequest: (controller, request) async {
+    // Trust only your own origin. Reject anything else.
+    final trustedHosts = const {'your-app.example.com'};
+    final originHost = request.origin.host;
+    if (!trustedHosts.contains(originHost)) {
+      return PermissionResponse(
+        resources: request.resources,
+        action: PermissionResponseAction.DENY,
+      );
+    }
+    // Optionally gate on request.resources (camera / microphone / etc.)
+    // before granting. Here we grant only the resources the page requested.
     return PermissionResponse(
       resources: request.resources,
       action: PermissionResponseAction.GRANT,

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -968,4 +968,113 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             }
         }
     }
+
+    // MARK: - Media capture / device orientation permission (macOS 12+)
+    //
+    // Ports the iOS WKUIDelegate implementation
+    // (zikzak_inappwebview_ios/.../InAppWebView/InAppWebView.swift:2044+) to
+    // macOS. Without these, any page calling getUserMedia() (camera/microphone)
+    // is silently denied on macOS because WKWebView defaults to
+    // WKPermissionDecision.deny when the delegate does not implement
+    // requestMediaCapturePermissionForOrigin. See issue #195.
+    //
+    // The delegate dispatches onPermissionRequest to Dart (the same event the
+    // iOS port and the shared Dart platform interface already use) and maps the
+    // returned PermissionResponse.action back to WKPermissionDecision:
+    //   0 -> .deny, 1 -> .grant, 2 -> .prompt  (see PermissionResponseAction).
+    // If Dart returns no action (or the channel has no handler), we default to
+    // .deny - matching the iOS callback.defaultBehaviour - so we never leave
+    // the async decisionHandler uncalled (which would otherwise hang WebKit).
+
+    @available(macOS 12.0, *)
+    public func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        let originString =
+            "\(origin.protocol)://\(origin.host)"
+            + (origin.port != 0 ? ":" + String(origin.port) : "")
+        let permissionRequest = PermissionRequest(
+            origin: originString, resources: [type.rawValue], frame: frame)
+
+        var decisionHandlerCalled = false
+        let resolve: (PermissionResponse?) -> Void = { response in
+            guard !decisionHandlerCalled else { return }
+            if let action = response?.action {
+                decisionHandlerCalled = true
+                switch action {
+                case 1:  // PermissionResponseAction.GRANT
+                    decisionHandler(.grant)
+                case 2:  // PermissionResponseAction.PROMPT
+                    decisionHandler(.prompt)
+                default:  // 0 == PermissionResponseAction.DENY
+                    decisionHandler(.deny)
+                }
+            } else {
+                decisionHandlerCalled = true
+                decisionHandler(.deny)
+            }
+        }
+
+        channel.invokeMethod(
+            "onPermissionRequest",
+            arguments: permissionRequest.toMap()
+        ) { result in
+            if let map = result as? [String: Any] {
+                resolve(PermissionResponse.fromMap(map: map))
+            } else {
+                resolve(nil)
+            }
+        }
+    }
+
+    @available(macOS 12.0, *)
+    public func webView(
+        _ webView: WKWebView,
+        requestDeviceOrientationAndMotionPermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        let originString =
+            "\(origin.protocol)://\(origin.host)"
+            + (origin.port != 0 ? ":" + String(origin.port) : "")
+        let permissionRequest = PermissionRequest(
+            origin: originString,
+            resources: ["deviceOrientationAndMotion"],
+            frame: frame)
+
+        var decisionHandlerCalled = false
+        let resolve: (PermissionResponse?) -> Void = { response in
+            guard !decisionHandlerCalled else { return }
+            if let action = response?.action {
+                decisionHandlerCalled = true
+                switch action {
+                case 1:  // PermissionResponseAction.GRANT
+                    decisionHandler(.grant)
+                case 2:  // PermissionResponseAction.PROMPT
+                    decisionHandler(.prompt)
+                default:  // 0 == PermissionResponseAction.DENY
+                    decisionHandler(.deny)
+                }
+            } else {
+                decisionHandlerCalled = true
+                decisionHandler(.deny)
+            }
+        }
+
+        channel.invokeMethod(
+            "onPermissionRequest",
+            arguments: permissionRequest.toMap()
+        ) { result in
+            if let map = result as? [String: Any] {
+                resolve(PermissionResponse.fromMap(map: map))
+            } else {
+                resolve(nil)
+            }
+        }
+    }
+
 }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -985,6 +985,35 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     // If Dart returns no action (or the channel has no handler), we default to
     // .deny - matching the iOS callback.defaultBehaviour - so we never leave
     // the async decisionHandler uncalled (which would otherwise hang WebKit).
+    //
+    // SAFETY: We guard on `isDisposed` before invoking the FlutterMethodChannel
+    // to prevent crashes if the InAppWebView is torn down while a permission
+    // request is in flight. If disposed, we immediately deny — this matches the
+    // iOS channelDelegate-nil fallback and is always safe.
+
+    /// Resolves a PermissionResponse into a WKPermissionDecision, guarding
+    /// against double-invocation of the decisionHandler (which WebKit forbids).
+    @available(macOS 12.0, *)
+    private static func resolvePermissionDecision(
+        response: PermissionResponse?,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void,
+        decisionHandlerCalled: inout Bool
+    ) {
+        guard !decisionHandlerCalled else { return }
+        decisionHandlerCalled = true
+        if let action = response?.action {
+            switch action {
+            case 1:  // PermissionResponseAction.GRANT
+                decisionHandler(.grant)
+            case 2:  // PermissionResponseAction.PROMPT
+                decisionHandler(.prompt)
+            default:  // 0 == PermissionResponseAction.DENY
+                decisionHandler(.deny)
+            }
+        } else {
+            decisionHandler(.deny)
+        }
+    }
 
     @available(macOS 12.0, *)
     public func webView(
@@ -994,6 +1023,13 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         type: WKMediaCaptureType,
         decisionHandler: @escaping (WKPermissionDecision) -> Void
     ) {
+        // If the WebView is already disposed, deny immediately to avoid
+        // invoking a torn-down FlutterMethodChannel.
+        guard !isDisposed else {
+            decisionHandler(.deny)
+            return
+        }
+
         let originString =
             "\(origin.protocol)://\(origin.host)"
             + (origin.port != 0 ? ":" + String(origin.port) : "")
@@ -1001,32 +1037,25 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             origin: originString, resources: [type.rawValue], frame: frame)
 
         var decisionHandlerCalled = false
-        let resolve: (PermissionResponse?) -> Void = { response in
-            guard !decisionHandlerCalled else { return }
-            if let action = response?.action {
-                decisionHandlerCalled = true
-                switch action {
-                case 1:  // PermissionResponseAction.GRANT
-                    decisionHandler(.grant)
-                case 2:  // PermissionResponseAction.PROMPT
-                    decisionHandler(.prompt)
-                default:  // 0 == PermissionResponseAction.DENY
-                    decisionHandler(.deny)
-                }
-            } else {
-                decisionHandlerCalled = true
-                decisionHandler(.deny)
-            }
-        }
-
         channel.invokeMethod(
             "onPermissionRequest",
             arguments: permissionRequest.toMap()
         ) { result in
             if let map = result as? [String: Any] {
-                resolve(PermissionResponse.fromMap(map: map))
+                InAppWebView.resolvePermissionDecision(
+                    response: PermissionResponse.fromMap(map: map),
+                    decisionHandler: decisionHandler,
+                    decisionHandlerCalled: &decisionHandlerCalled)
             } else {
-                resolve(nil)
+                // Log non-dictionary results (FlutterError / not-implemented)
+                // for debuggability, then deny — matching iOS callback.error.
+                if let error = result as? FlutterError {
+                    print("[InAppWebView] onPermissionRequest error: \(error.code) – \(error.message ?? "")")
+                }
+                InAppWebView.resolvePermissionDecision(
+                    response: nil,
+                    decisionHandler: decisionHandler,
+                    decisionHandlerCalled: &decisionHandlerCalled)
             }
         }
     }
@@ -1038,6 +1067,13 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         initiatedByFrame frame: WKFrameInfo,
         decisionHandler: @escaping (WKPermissionDecision) -> Void
     ) {
+        // If the WebView is already disposed, deny immediately to avoid
+        // invoking a torn-down FlutterMethodChannel.
+        guard !isDisposed else {
+            decisionHandler(.deny)
+            return
+        }
+
         let originString =
             "\(origin.protocol)://\(origin.host)"
             + (origin.port != 0 ? ":" + String(origin.port) : "")
@@ -1047,32 +1083,23 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             frame: frame)
 
         var decisionHandlerCalled = false
-        let resolve: (PermissionResponse?) -> Void = { response in
-            guard !decisionHandlerCalled else { return }
-            if let action = response?.action {
-                decisionHandlerCalled = true
-                switch action {
-                case 1:  // PermissionResponseAction.GRANT
-                    decisionHandler(.grant)
-                case 2:  // PermissionResponseAction.PROMPT
-                    decisionHandler(.prompt)
-                default:  // 0 == PermissionResponseAction.DENY
-                    decisionHandler(.deny)
-                }
-            } else {
-                decisionHandlerCalled = true
-                decisionHandler(.deny)
-            }
-        }
-
         channel.invokeMethod(
             "onPermissionRequest",
             arguments: permissionRequest.toMap()
         ) { result in
             if let map = result as? [String: Any] {
-                resolve(PermissionResponse.fromMap(map: map))
+                InAppWebView.resolvePermissionDecision(
+                    response: PermissionResponse.fromMap(map: map),
+                    decisionHandler: decisionHandler,
+                    decisionHandlerCalled: &decisionHandlerCalled)
             } else {
-                resolve(nil)
+                if let error = result as? FlutterError {
+                    print("[InAppWebView] onPermissionRequest error: \(error.code) – \(error.message ?? "")")
+                }
+                InAppWebView.resolvePermissionDecision(
+                    response: nil,
+                    decisionHandler: decisionHandler,
+                    decisionHandlerCalled: &decisionHandlerCalled)
             }
         }
     }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/PermissionRequest.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/PermissionRequest.swift
@@ -1,0 +1,37 @@
+//
+//  PermissionRequest.swift
+//  zikzak_inappwebview
+//
+//  Ported from iOS. Represents a media-capture / device-orientation permission
+//  request originating from web content. Serialised to a map consumed by the
+//  shared Dart PermissionRequest.fromMap, which drives the
+//  PlatformWebViewCreationParams.onPermissionRequest callback.
+//
+//  `resources` holds WKMediaCaptureType.rawValue (Int) for camera/microphone,
+//  or the string "deviceOrientationAndMotion" for the orientation/motion
+//  delegate. The mapping back to PermissionResourceType on the Dart side is
+//  platform-aware (see permission_resource_type.g.dart — macOS native values:
+//  camera=0, microphone=1, cameraAndMicrophone=2).
+//
+
+import WebKit
+
+public class PermissionRequest: NSObject {
+    var origin: String
+    var resources: [StringOrInt]
+    var frame: WKFrameInfo
+
+    public init(origin: String, resources: [StringOrInt], frame: WKFrameInfo) {
+        self.origin = origin
+        self.resources = resources
+        self.frame = frame
+    }
+
+    public func toMap() -> [String: Any?] {
+        return [
+            "origin": origin,
+            "resources": resources,
+            "frame": frame.toMap(),
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/PermissionResponse.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/PermissionResponse.swift
@@ -1,0 +1,38 @@
+//
+//  PermissionResponse.swift
+//  zikzak_inappwebview
+//
+//  Ported from iOS. Decodes the map returned by the Dart-side
+//  onPermissionRequest callback so the WKUIDelegate can map `action` to a
+//  WKPermissionDecision:
+//    0 -> .deny, 1 -> .grant, 2 -> .prompt
+//  `resources` is currently unused by the WebKit decision path (the action is
+//  applied to the single requested resource), but is preserved for parity with
+//  the iOS port and the Dart PermissionResponse contract.
+//
+//  NOTE: on macOS the FlutterMethodChannel result callback delivers an
+//  NSDictionary bridged to [String: Any] (not [String: Any?]), so fromMap
+//  accepts [String: Any]? here — unlike the iOS port which goes through the
+//  WebViewChannelDelegate BaseCallbackResult and uses [String: Any?]?.
+//
+
+import Foundation
+
+public class PermissionResponse: NSObject {
+    var resources: [Any]
+    var action: Int?
+
+    public init(resources: [Any], action: Int? = nil) {
+        self.resources = resources
+        self.action = action
+    }
+
+    public static func fromMap(map: [String: Any]?) -> PermissionResponse? {
+        guard let map = map else {
+            return nil
+        }
+        let resources = map["resources"] as? [Any] ?? []
+        let action = map["action"] as? Int
+        return PermissionResponse(resources: resources, action: action)
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/StringOrInt.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/StringOrInt.swift
@@ -1,0 +1,17 @@
+//
+//  StringOrInt.swift
+//  zikzak_inappwebview
+//
+//  Ported from iOS to support PermissionRequest.resources on macOS.
+//  WKMediaCaptureType.rawValue is an Int, while device-orientation-and-motion
+//  is represented as a String ("deviceOrientationAndMotion"), so the resources
+//  array must hold either kind — mirroring the iOS contract consumed by the
+//  shared Dart PermissionRequest.fromMap / PermissionResourceType.fromNativeValue.
+//
+
+import Foundation
+
+public protocol StringOrInt {}
+
+extension Int: StringOrInt {}
+extension String: StringOrInt {}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/WKFrameInfo.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/WKFrameInfo.swift
@@ -1,0 +1,28 @@
+//
+//  WKFrameInfo.swift
+//  zikzak_inappwebview
+//
+//  Ported from iOS so PermissionRequest.toMap() can serialise the frame that
+//  initiated a media-capture permission request. The Dart FrameInfo.fromMap
+//  expects: isMainFrame, request (map), securityOrigin (map).
+//
+//  NOTE: `self.request` can throw EXC_BREAKPOINT when the WKFrameInfo comes
+//  from a WKNavigationAction.sourceFrame, so we read it via valueForKey as
+//  the iOS port does, falling back to nil.
+//
+
+import WebKit
+
+extension WKFrameInfo {
+    public func toMap() -> [String: Any?] {
+        let securityOrigin: [String: Any?]? = self.securityOrigin.toMap()
+        // self.request throws EXC_BREAKPOINT when coming from
+        // WKNavigationAction.sourceFrame; read via KVC like the iOS port.
+        let request: URLRequest? = self.value(forKey: "request") as? URLRequest
+        return [
+            "isMainFrame": isMainFrame,
+            "request": request?.toMap(),
+            "securityOrigin": securityOrigin,
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/WKSecurityOrigin.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/WKSecurityOrigin.swift
@@ -1,0 +1,20 @@
+//
+//  WKSecurityOrigin.swift
+//  zikzak_inappwebview
+//
+//  Ported from iOS so PermissionRequest.toMap() can serialise the security
+//  origin of the frame that initiated a media-capture permission request.
+//  The Dart SecurityOrigin.fromMap expects exactly: host, port, protocol.
+//
+
+import WebKit
+
+extension WKSecurityOrigin {
+    public func toMap() -> [String: Any?] {
+        return [
+            "host": host,
+            "port": port,
+            "protocol": self.protocol,
+        ]
+    }
+}


### PR DESCRIPTION
Closes #195

## Problem
On macOS the `WKUIDelegate` did not implement `requestMediaCapturePermissionForOrigin`, so any page calling `getUserMedia()` (camera/microphone) was silently denied — WKWebView defaults to `WKPermissionDecision.deny` when the delegate method is missing. The iOS port implements this; macOS shared the Dart `onPermissionRequest` contract but had no native dispatch.

## Fix
Ported the iOS `WKUIDelegate` implementation to macOS (gated `@available(macOS 12.0, *)`, matching the package deployment target and the availability of the WebKit API):

- `webView(_:requestMediaCapturePermissionFor:initiatedByFrame:type:decisionHandler:)` — dispatches `onPermissionRequest` to Dart with the `PermissionResource` (`camera` / `microphone` / `cameraAndMicrophone` via `WKMediaCaptureType.rawValue`) and maps the returned `PermissionResponse.action` (`GRANT` / `DENY` / `PROMPT`) back to `WKPermissionDecision`. Defaults to `.deny` if Dart returns no action (mirrors the iOS `callback.defaultBehaviour`), so the async `decisionHandler` is never left uncalled (which would hang WebKit).
- The sibling `requestDeviceOrientationAndMotionPermissionForOrigin` is implemented too, for parity with iOS.
- Added the supporting types ported from iOS: `PermissionRequest`, `PermissionResponse`, `StringOrInt`, and `WKFrameInfo` / `WKSecurityOrigin` `toMap()` extensions (the macOS port previously lacked all of these).

## Required app configuration (documented in README)
macOS apps must add `NSCameraUsageDescription` / `NSMicrophoneUsageDescription` to `Info.plist` and (for sandboxed apps) `com.apple.security.device.camera` / `com.apple.security.device.audio-input` to the entitlements — otherwise the system TCC layer denies access even after the WebView grants. These are added to the example app's Runner config so the example works end-to-end.

## Example
Added a "Media capture (getUserMedia) test" button to the example app bar that loads an inline `getUserMedia({video:true,audio:true})` page. The existing `onPermissionRequest` handler grants the request.

## Verification
- `flutter analyze` (macOS package): clean (1 pre-existing `invalid_dependency` warning, unchanged).
- `flutter test` (macOS package): 9/9 pass.
- Swift compilation requires macOS/Xcode (unavailable in this Linux sandbox); the new delegate methods mirror the proven iOS implementation (`InAppWebView.swift:2044+`) and reuse the macOS `channel.invokeMethod(...result:)` convention already used by `onJsAlert`/`onJsConfirm`/`onJsPrompt`.

## Note
A concurrent agent committed unrelated #194 work in the same sandbox during this task and their `git add -A` swept these 5 new type files into their #194 commit. This PR is the canonical source of the type files and delegate methods, developed on a clean branch off `development` (isolated via a git worktree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS support for web-requested camera and microphone permissions.
  * Added device orientation and motion permission handling for web content.
  * Added an example media-capture action that previews camera and microphone access.
  * Permission requests support grant, prompt, and deny decisions, with secure denial as the fallback.

* **Documentation**
  * Documented macOS media-capture setup, permissions, entitlements, and usage requirements.
  * Added changelog details for the new permission support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->