### PR TITLE
[macOS] Implement WKNavigationDelegate authentication challenges (fixes #193)

- Add webView(_:didReceive:completionHandler:) to macOS InAppWebView.swift
- Implement onReceivedHttpAuthRequest for HTTP basic/digest/NTLM/Negotiate auth
- Implement onReceivedServerTrustAuthRequest for TLS server-trust validation
- Implement onReceivedClientCertRequest for client-certificate (PKCS#12) auth
- Port all required Swift types from iOS (SslCertificate, SslError, URLProtectionSpace extension, etc.)
- Add WebViewChannelDelegate with auth callback classes
- Add CredentialDatabase for HTTP auth credential storage
- Add Util.getAbsPathAsset for client certificate path resolution
- Add IdentityAndTrust struct and extractIdentity() for PKCS#12 import
- Wire Dart-side handlers in MacOSInAppWebViewController.handleMethod()
- Register CredentialDatabase in InAppWebViewFlutterPlugin

Mirrors the iOS implementation at InAppWebView.swift:2411-2750.
Closes #193

### DIFF
--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -218,6 +218,44 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
           }
         }
         break;
+      case 'onReceivedHttpAuthRequest':
+        if (params.webviewParams?.onReceivedHttpAuthRequest != null) {
+          Map<String, dynamic> arguments = call.arguments
+              .cast<String, dynamic>();
+          HttpAuthenticationChallenge challenge =
+              HttpAuthenticationChallenge.fromMap(arguments)!;
+          return (await params.webviewParams!.onReceivedHttpAuthRequest!(
+            controller,
+            challenge,
+          ))?.toMap();
+        }
+        break;
+      case 'onReceivedServerTrustAuthRequest':
+        if (params.webviewParams?.onReceivedServerTrustAuthRequest != null) {
+          Map<String, dynamic> arguments = call.arguments
+              .cast<String, dynamic>();
+          ServerTrustChallenge challenge = ServerTrustChallenge.fromMap(
+            arguments,
+          )!;
+          return (await params.webviewParams!.onReceivedServerTrustAuthRequest!(
+            controller,
+            challenge,
+          ))?.toMap();
+        }
+        break;
+      case 'onReceivedClientCertRequest':
+        if (params.webviewParams?.onReceivedClientCertRequest != null) {
+          Map<String, dynamic> arguments = call.arguments
+              .cast<String, dynamic>();
+          ClientCertChallenge challenge = ClientCertChallenge.fromMap(
+            arguments,
+          )!;
+          return (await params.webviewParams!.onReceivedClientCertRequest!(
+            controller,
+            challenge,
+          ))?.toMap();
+        }
+        break;
       default:
         throw UnimplementedError("Unimplemented ${call.method} method");
     }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/CredentialDatabase.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/CredentialDatabase.swift
@@ -1,0 +1,142 @@
+import FlutterMacOS
+
+public class CredentialDatabase: ChannelDelegate {
+    static let METHOD_CHANNEL_NAME = "wtf.zikzak/zikzak_inappwebview_credential_database"
+    static let credentialStore = URLCredentialStorage.shared
+
+    private var plugin: InAppWebViewFlutterPlugin?
+
+    init(plugin: InAppWebViewFlutterPlugin) {
+        super.init(channel: FlutterMethodChannel(name: CredentialDatabase.METHOD_CHANNEL_NAME, binaryMessenger: plugin.registrar!.messenger()))
+        self.plugin = plugin
+    }
+
+    public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? NSDictionary
+        switch call.method {
+            case "getAllAuthCredentials":
+                var allCredentials: [[String: Any?]] = []
+                for (protectionSpace, credentials) in CredentialDatabase.credentialStore.allCredentials {
+                    var crendentials: [[String: Any?]] = []
+                    for c in credentials {
+                        let credential: [String: Any?] = c.value.toMap()
+                        crendentials.append(credential)
+                    }
+                    if crendentials.count > 0 {
+                        let dict: [String : Any] = [
+                            "protectionSpace": protectionSpace.toMap(),
+                            "credentials": crendentials
+                        ]
+                        allCredentials.append(dict)
+                    }
+                }
+                result(allCredentials)
+                break
+            case "getHttpAuthCredentials":
+                var crendentials: [[String: Any?]] = []
+                let host = arguments!["host"] as! String
+                let urlProtocol = arguments!["protocol"] as? String
+                let urlPort = arguments!["port"] as? Int ?? 0
+                var realm = arguments!["realm"] as? String
+                if let r = realm, r.isEmpty { realm = nil }
+                for (protectionSpace, credentials) in CredentialDatabase.credentialStore.allCredentials {
+                    if protectionSpace.host == host && protectionSpace.realm == realm &&
+                    protectionSpace.protocol == urlProtocol && protectionSpace.port == urlPort {
+                        for c in credentials { crendentials.append(c.value.toMap()) }
+                        break
+                    }
+                }
+                result(crendentials)
+                break
+            case "setHttpAuthCredential":
+                let host = arguments!["host"] as! String
+                let urlProtocol = arguments!["protocol"] as? String
+                let urlPort = arguments!["port"] as? Int ?? 0
+                var realm = arguments!["realm"] as? String
+                if let r = realm, r.isEmpty { realm = nil }
+                let username = arguments!["username"] as! String
+                let password = arguments!["password"] as! String
+                let credential = URLCredential(user: username, password: password, persistence: .permanent)
+                CredentialDatabase.credentialStore.set(credential,
+                    for: URLProtectionSpace(host: host, port: urlPort, protocol: urlProtocol,
+                        realm: realm, authenticationMethod: NSURLAuthenticationMethodHTTPBasic))
+                result(true)
+                break
+            case "removeHttpAuthCredential":
+                let host = arguments!["host"] as! String
+                let urlProtocol = arguments!["protocol"] as? String
+                let urlPort = arguments!["port"] as? Int ?? 0
+                var realm = arguments!["realm"] as? String
+                if let r = realm, r.isEmpty { realm = nil }
+                let username = arguments!["username"] as! String
+                let password = arguments!["password"] as? String ?? ""
+                var credential: URLCredential? = nil
+                var protectionSpaceCredential: URLProtectionSpace? = nil
+                for (protectionSpace, credentials) in CredentialDatabase.credentialStore.allCredentials {
+                    if protectionSpace.host == host && protectionSpace.realm == realm &&
+                    protectionSpace.protocol == urlProtocol && protectionSpace.port == urlPort {
+                        for c in credentials {
+                            if c.value.user == username, c.value.password == password {
+                                credential = c.value
+                                protectionSpaceCredential = protectionSpace
+                                break
+                            }
+                        }
+                    }
+                    if credential != nil { break }
+                }
+                if let c = credential, let protectionSpace = protectionSpaceCredential {
+                    CredentialDatabase.credentialStore.remove(c, for: protectionSpace)
+                }
+                result(true)
+                break
+            case "removeHttpAuthCredentials":
+                let host = arguments!["host"] as! String
+                let urlProtocol = arguments!["protocol"] as? String
+                let urlPort = arguments!["port"] as? Int ?? 0
+                var realm = arguments!["realm"] as? String
+                if let r = realm, r.isEmpty { realm = nil }
+                var credentialsToRemove: [URLCredential] = []
+                var protectionSpaceCredential: URLProtectionSpace? = nil
+                for (protectionSpace, credentials) in CredentialDatabase.credentialStore.allCredentials {
+                    if protectionSpace.host == host && protectionSpace.realm == realm &&
+                    protectionSpace.protocol == urlProtocol && protectionSpace.port == urlPort {
+                        protectionSpaceCredential = protectionSpace
+                        for c in credentials {
+                            if let _ = c.value.user, let _ = c.value.password {
+                                credentialsToRemove.append(c.value)
+                            }
+                        }
+                        break
+                    }
+                }
+                if let protectionSpace = protectionSpaceCredential {
+                    for credential in credentialsToRemove {
+                        CredentialDatabase.credentialStore.remove(credential, for: protectionSpace)
+                    }
+                }
+                result(true)
+                break
+            case "clearAllAuthCredentials":
+                for (protectionSpace, credentials) in CredentialDatabase.credentialStore.allCredentials {
+                    for credential in credentials {
+                        CredentialDatabase.credentialStore.remove(credential.value, for: protectionSpace)
+                    }
+                }
+                result(true)
+                break
+            default:
+                result(FlutterMethodNotImplemented)
+                break
+        }
+    }
+
+    public override func dispose() {
+        super.dispose()
+        plugin = nil
+    }
+
+    deinit {
+        dispose()
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -10,6 +10,9 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     private var searchText: String?
     private var isDisposed = false
     public var settings: InAppWebViewSettings?
+    private static var sslCertificatesMap: [String: SslCertificate] = [:]
+    private static var credentialsProposed: [URLCredential] = []
+    var channelDelegate: WebViewChannelDelegate?
 
     init(
         registrar: FlutterPluginRegistrar, viewId: Any, arguments: Any?, channelName: String? = nil, plugin: InAppWebViewFlutterPlugin? = nil
@@ -72,6 +75,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         let finalChannelName = channelName ?? "dev.zuzu/zikzak_inappwebview_\(viewId)"
         channel = FlutterMethodChannel(name: finalChannelName, binaryMessenger: registrar.messenger)
         channel.setMethodCallHandler(self.handle)
+        channelDelegate = WebViewChannelDelegate(channel: channel)
 
         let findInteractionChannelName = "wtf.zikzak/zikzak_inappwebview_find_interaction_\(viewId)"
         findInteractionChannel = FlutterMethodChannel(
@@ -612,12 +616,14 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     }
 
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        InAppWebView.credentialsProposed = []
         channel?.invokeMethod("onLoadStop", arguments: ["url": webView.url?.absoluteString])
     }
 
     public func webView(
         _ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error
     ) {
+        InAppWebView.credentialsProposed = []
         onReceivedError(error: error)
     }
 
@@ -625,6 +631,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         _ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
+        InAppWebView.credentialsProposed = []
         onReceivedError(error: error)
     }
 
@@ -635,6 +642,277 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         arguments["message"] = error.localizedDescription
         channel?.invokeMethod("onReceivedError", arguments: arguments)
     }
+    public func webView(
+        _ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        var completionHandlerCalled = false
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPBasic
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodDefault
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodHTTPDigest
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNegotiate
+            || challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodNTLM
+        {
+            let host = challenge.protectionSpace.host
+            let prot = challenge.protectionSpace.protocol
+            let realm = challenge.protectionSpace.realm
+            let port = challenge.protectionSpace.port
+
+            let callback = WebViewChannelDelegate.ReceivedHttpAuthRequestCallback()
+            callback.nonNullSuccess = { (response: HttpAuthResponse) in
+                if let action = response.action {
+                    completionHandlerCalled = true
+                    switch action {
+                    case 0:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.performDefaultHandling, nil)
+                        break
+                    case 1:
+                        let username = response.username
+                        let password = response.password
+                        let permanentPersistence = response.permanentPersistence
+                        let persistence =
+                            (permanentPersistence)
+                            ? URLCredential.Persistence.permanent
+                            : URLCredential.Persistence.forSession
+                        let credential = URLCredential(
+                            user: username, password: password, persistence: persistence)
+                        completionHandler(.useCredential, credential)
+                        break
+                    case 2:
+                        if InAppWebView.credentialsProposed.count == 0 {
+                            for (protectionSpace, credentials) in CredentialDatabase.credentialStore
+                                .allCredentials
+                            {
+                                if protectionSpace.host == host && protectionSpace.realm == realm
+                                    && protectionSpace.protocol == prot
+                                    && protectionSpace.port == port
+                                {
+                                    for credential in credentials {
+                                        InAppWebView.credentialsProposed.append(credential.value)
+                                    }
+                                    break
+                                }
+                            }
+                        }
+                        if InAppWebView.credentialsProposed.count == 0,
+                            let credential = challenge.proposedCredential
+                        {
+                            InAppWebView.credentialsProposed.append(credential)
+                        }
+
+                        if let credential = InAppWebView.credentialsProposed.popLast() {
+                            completionHandler(.useCredential, credential)
+                        } else {
+                            completionHandler(.performDefaultHandling, nil)
+                        }
+                        break
+                    default:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.performDefaultHandling, nil)
+                    }
+                    return false
+                }
+                return true
+            }
+            callback.defaultBehaviour = { (response: HttpAuthResponse?) in
+                if !completionHandlerCalled {
+                    completionHandlerCalled = true
+                    completionHandler(.performDefaultHandling, nil)
+                }
+            }
+            callback.error = { [weak callback] (code: String, message: String?, details: Any?) in
+                print(code + ", " + (message ?? ""))
+                callback?.defaultBehaviour(nil)
+            }
+
+            let runCallback = {
+                if let channelDelegate = self.channelDelegate {
+                    channelDelegate.onReceivedHttpAuthRequest(
+                        challenge: HttpAuthenticationChallenge(fromChallenge: challenge),
+                        callback: callback)
+                } else {
+                    callback.defaultBehaviour(nil)
+                }
+            }
+
+            runCallback()
+        } else if challenge.protectionSpace.authenticationMethod
+            == NSURLAuthenticationMethodServerTrust
+        {
+            guard let serverTrust = challenge.protectionSpace.serverTrust else {
+                completionHandler(.performDefaultHandling, nil)
+                return
+            }
+
+            if let scheme = challenge.protectionSpace.protocol, scheme == "https" {
+                DispatchQueue.global(qos: .background).async {
+                    if let sslCertificate = challenge.protectionSpace.sslCertificate {
+                        DispatchQueue.main.async {
+                            InAppWebView.sslCertificatesMap[challenge.protectionSpace.host] =
+                                sslCertificate
+                        }
+                    }
+                }
+            }
+
+            let callback = WebViewChannelDelegate.ReceivedServerTrustAuthRequestCallback()
+            callback.nonNullSuccess = { (response: ServerTrustAuthResponse) in
+                if let action = response.action {
+                    completionHandlerCalled = true
+                    switch action {
+                    case 0:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    case 1:
+                        DispatchQueue.global(qos: .background).async {
+                            let exceptions = SecTrustCopyExceptions(serverTrust)
+                            SecTrustSetExceptions(serverTrust, exceptions)
+                            let credential = URLCredential(trust: serverTrust)
+                            completionHandler(.useCredential, credential)
+                        }
+                        break
+                    default:
+                        InAppWebView.credentialsProposed = []
+                        completionHandler(.performDefaultHandling, nil)
+                    }
+                    return false
+                }
+                return true
+            }
+            callback.defaultBehaviour = { (response: ServerTrustAuthResponse?) in
+                if !completionHandlerCalled {
+                    completionHandlerCalled = true
+                    completionHandler(.performDefaultHandling, nil)
+                }
+            }
+            callback.error = { [weak callback] (code: String, message: String?, details: Any?) in
+                print(code + ", " + (message ?? ""))
+                callback?.defaultBehaviour(nil)
+            }
+
+            let runCallback = {
+                if let channelDelegate = self.channelDelegate {
+                    channelDelegate.onReceivedServerTrustAuthRequest(
+                        challenge: ServerTrustChallenge(fromChallenge: challenge),
+                        callback: callback)
+                } else {
+                    callback.defaultBehaviour(nil)
+                }
+            }
+
+            runCallback()
+        } else if challenge.protectionSpace.authenticationMethod
+            == NSURLAuthenticationMethodClientCertificate
+        {
+            let callback = WebViewChannelDelegate.ReceivedClientCertRequestCallback()
+            callback.nonNullSuccess = { (response: ClientCertResponse) in
+                if let action = response.action {
+                    completionHandlerCalled = true
+                    switch action {
+                    case 0:
+                        completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    case 1:
+                        let certificatePath = response.certificatePath
+                        let certificatePassword = response.certificatePassword ?? ""
+
+                        var path: String = certificatePath
+                        do {
+                            if let plugin = self.plugin {
+                                path = try Util.getAbsPathAsset(
+                                    plugin: plugin, assetFilePath: certificatePath)
+                            }
+                        } catch {}
+
+                        if let PKCS12Data = NSData(contentsOfFile: path),
+                            let identityAndTrust: IdentityAndTrust = self.extractIdentity(
+                                PKCS12Data: PKCS12Data, password: certificatePassword)
+                        {
+                            let urlCredential: URLCredential = URLCredential(
+                                identity: identityAndTrust.identityRef,
+                                certificates: identityAndTrust.certArray as? [AnyObject],
+                                persistence: URLCredential.Persistence.forSession)
+                            completionHandler(.useCredential, urlCredential)
+                        } else {
+                            completionHandler(.performDefaultHandling, nil)
+                        }
+
+                        break
+                    case 2:
+                        completionHandler(.cancelAuthenticationChallenge, nil)
+                        break
+                    default:
+                        completionHandler(.performDefaultHandling, nil)
+                    }
+                    return false
+                }
+                return true
+            }
+            callback.defaultBehaviour = { (response: ClientCertResponse?) in
+                if !completionHandlerCalled {
+                    completionHandlerCalled = true
+                    completionHandler(.performDefaultHandling, nil)
+                }
+            }
+            callback.error = { [weak callback] (code: String, message: String?, details: Any?) in
+                print(code + ", " + (message ?? ""))
+                callback?.defaultBehaviour(nil)
+            }
+
+            let runCallback = {
+                if let channelDelegate = self.channelDelegate {
+                    channelDelegate.onReceivedClientCertRequest(
+                        challenge: ClientCertChallenge(fromChallenge: challenge), callback: callback
+                    )
+                } else {
+                    callback.defaultBehaviour(nil)
+                }
+            }
+
+            runCallback()
+        } else {
+            completionHandler(.performDefaultHandling, nil)
+        }
+    }
+
+    struct IdentityAndTrust {
+        var identityRef: SecIdentity
+        var trust: SecTrust
+        var certArray: AnyObject
+    }
+
+    func extractIdentity(PKCS12Data: NSData, password: String) -> IdentityAndTrust? {
+        var identityAndTrust: IdentityAndTrust?
+        var securityError: OSStatus = errSecSuccess
+
+        var importResult: CFArray?
+        securityError = SecPKCS12Import(
+            PKCS12Data as NSData,
+            [kSecImportExportPassphrase as String: password] as NSDictionary,
+            &importResult
+        )
+
+        if securityError == errSecSuccess {
+            let certItems: CFArray = importResult! as CFArray
+            let certItemsArray: Array = certItems as Array
+            let dict: AnyObject? = certItemsArray.first
+            if let certEntry: Dictionary = dict as? [String: AnyObject] {
+                let identityPointer: AnyObject? = certEntry["identity"]
+                let secIdentityRef: SecIdentity = (identityPointer as! SecIdentity?)!
+                let trustPointer: AnyObject? = certEntry["trust"]
+                let trustRef: SecTrust = trustPointer as! SecTrust
+                let chainPointer: AnyObject? = certEntry["chain"]
+                identityAndTrust = IdentityAndTrust(
+                    identityRef: secIdentityRef, trust: trustRef, certArray: chainPointer!)
+            }
+        } else {
+            print("Security Error: " + securityError.description)
+        }
+        return identityAndTrust
+    }
+
 
     public func userContentController(
         _ userContentController: WKUserContentController, didReceive message: WKScriptMessage

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
@@ -5,6 +5,7 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
     var headlessInAppWebViewManager: HeadlessInAppWebViewManager?
     var inAppBrowserManager: InAppBrowserManager?
     var myCookieManager: MyCookieManager?
+    var credentialDatabase: CredentialDatabase?
     var printJobManager: PrintJobManager?
     var registrar: FlutterPluginRegistrar?
     
@@ -20,6 +21,7 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
         instance.headlessInAppWebViewManager = HeadlessInAppWebViewManager(registrar: registrar)
         instance.inAppBrowserManager = InAppBrowserManager(registrar: registrar)
         instance.myCookieManager = MyCookieManager(registrar: registrar)
+        instance.credentialDatabase = CredentialDatabase(plugin: instance)
         instance.printJobManager = PrintJobManager(plugin: instance)
     }
 
@@ -31,6 +33,8 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
         headlessInAppWebViewManager = nil
         inAppBrowserManager = nil
         myCookieManager = nil
+        credentialDatabase?.dispose()
+        credentialDatabase = nil
         printJobManager?.dispose()
         printJobManager = nil
     }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/BaseCallbackResult.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/BaseCallbackResult.swift
@@ -1,0 +1,25 @@
+import FlutterMacOS
+
+public class BaseCallbackResult<T>: CallbackResult<T> {
+    
+    override init() {
+        super.init()
+        
+        self.success = { [weak self] (obj: Any?) in
+            let result: T? = self?.decodeResult(obj)
+            var shouldRunDefaultBehaviour = false
+            if let result = result {
+                shouldRunDefaultBehaviour = self?.nonNullSuccess(result) ?? shouldRunDefaultBehaviour
+            } else {
+                shouldRunDefaultBehaviour = self?.nullSuccess() ?? shouldRunDefaultBehaviour
+            }
+            if shouldRunDefaultBehaviour {
+                self?.defaultBehaviour(result)
+            }
+        }
+        
+        self.notImplemented = { [weak self] in
+            self?.defaultBehaviour(nil)
+        }
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/CallbackResult.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/CallbackResult.swift
@@ -1,0 +1,11 @@
+import FlutterMacOS
+
+public class CallbackResult<T>: MethodChannelResult {
+    public var notImplemented: () -> Void = {}
+    public var success: (Any?) -> Void = {_ in }
+    public var error: (String, String?, Any?) -> Void = {_,_,_ in }
+    public var nonNullSuccess: (T) -> Bool = {_ in true}
+    public var nullSuccess: () -> Bool = {true}
+    public var defaultBehaviour: (T?) -> Void = {_ in }
+    public var decodeResult: (Any?) -> T? = {_ in nil}
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ClientCertChallenge.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ClientCertChallenge.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public class ClientCertChallenge: NSObject {
+    var protectionSpace: URLProtectionSpace!
+    
+    public init(fromChallenge: URLAuthenticationChallenge) {
+        protectionSpace = fromChallenge.protectionSpace
+    }
+    
+    public func toMap () -> [String:Any?] {
+        return [
+            "protectionSpace": protectionSpace.toMap(),
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ClientCertResponse.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ClientCertResponse.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public class ClientCertResponse: NSObject {
+    var certificatePath: String
+    var certificatePassword: String?
+    var keyStoreType: String?
+    var action: Int?
+    
+    public init(certificatePath: String, certificatePassword: String? = nil, keyStoreType: String? = nil, action: Int? = nil) {
+        self.certificatePath = certificatePath
+        self.certificatePassword = certificatePassword
+        self.keyStoreType = keyStoreType
+        self.action = action
+    }
+    
+    public static func fromMap(map: [String:Any?]?) -> ClientCertResponse? {
+        guard let map = map else { return nil }
+        let certificatePath = map["certificatePath"] as! String
+        let certificatePassword = map["certificatePassword"] as? String
+        let keyStoreType = map["keyStoreType"] as? String
+        let action = map["action"] as? Int
+        return ClientCertResponse(certificatePath: certificatePath, certificatePassword: certificatePassword, keyStoreType: keyStoreType, action: action)
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/FlutterMethodCallDelegate.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/FlutterMethodCallDelegate.swift
@@ -1,0 +1,11 @@
+import FlutterMacOS
+
+public class FlutterMethodCallDelegate: NSObject {
+    public override init() {
+        super.init()
+    }
+    
+    public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/FlutterMethodChannel.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/FlutterMethodChannel.swift
@@ -1,0 +1,18 @@
+import FlutterMacOS
+
+extension FlutterMethodChannel {
+    public func invokeMethod(_ method: String, arguments: Any, callback: MethodChannelResult) {
+        invokeMethod(method, arguments: arguments) {(result) -> Void in
+            if result is FlutterError {
+                let error = result as! FlutterError
+                callback.error(error.code, error.message, error.details)
+            }
+            else if (result as? NSObject) == FlutterMethodNotImplemented {
+                callback.notImplemented()
+            }
+            else {
+                callback.success(result)
+            }
+        }
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/HttpAuthResponse.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/HttpAuthResponse.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+public class HttpAuthResponse: NSObject {
+    var username: String
+    var password: String
+    var permanentPersistence: Bool
+    var action: Int?
+    
+    public init(username: String, password: String, permanentPersistence: Bool, action: Int? = nil) {
+        self.username = username
+        self.password = password
+        self.permanentPersistence = permanentPersistence
+        self.action = action
+    }
+    
+    public static func fromMap(map: [String:Any?]?) -> HttpAuthResponse? {
+        guard let map = map else { return nil }
+        let username = map["username"] as! String
+        let password = map["password"] as! String
+        let permanentPersistence = map["permanentPersistence"] as! Bool
+        let action = map["action"] as? Int
+        return HttpAuthResponse(username: username, password: password, permanentPersistence: permanentPersistence, action: action)
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/HttpAuthenticationChallenge.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/HttpAuthenticationChallenge.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public class HttpAuthenticationChallenge: NSObject {
+    var protectionSpace: URLProtectionSpace!
+    var previousFailureCount: Int = 0
+    var failureResponse: URLResponse?
+    var error: Error?
+    var proposedCredential: URLCredential?
+    
+    public init(fromChallenge: URLAuthenticationChallenge) {
+        protectionSpace = fromChallenge.protectionSpace
+        previousFailureCount = fromChallenge.previousFailureCount
+        failureResponse = fromChallenge.failureResponse
+        error = fromChallenge.error
+        proposedCredential = fromChallenge.proposedCredential
+    }
+    
+    public func toMap () -> [String:Any?] {
+        return [
+            "protectionSpace": protectionSpace.toMap(),
+            "previousFailureCount": previousFailureCount,
+            "failureResponse": failureResponse?.toMap(),
+            "error": error?.localizedDescription,
+            "proposedCredential": proposedCredential?.toMap()
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/MethodChannelResult.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/MethodChannelResult.swift
@@ -1,0 +1,7 @@
+import FlutterMacOS
+
+public protocol MethodChannelResult {
+    var success: (_ obj: Any?) -> Void { get set }
+    var error: (_ code: String, _ message: String?, _ details: Any?) -> Void { get set }
+    var notImplemented: () -> Void { get set }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/SecCertificate.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/SecCertificate.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension SecCertificate {
+    var data: Data {
+        let serverCertificateCFData = SecCertificateCopyData(self)
+        return serverCertificateCFData as Data
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ServerTrustAuthResponse.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ServerTrustAuthResponse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public class ServerTrustAuthResponse: NSObject {
+    var action: Int?
+    
+    public init(action: Int? = nil) {
+        self.action = action
+    }
+    
+    public static func fromMap(map: [String:Any?]?) -> ServerTrustAuthResponse? {
+        guard let map = map else { return nil }
+        let action = map["action"] as? Int
+        return ServerTrustAuthResponse(action: action)
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ServerTrustChallenge.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/ServerTrustChallenge.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public class ServerTrustChallenge: NSObject {
+    var protectionSpace: URLProtectionSpace!
+    
+    public init(fromChallenge: URLAuthenticationChallenge) {
+        protectionSpace = fromChallenge.protectionSpace
+    }
+    
+    public func toMap () -> [String:Any?] {
+        return [
+            "protectionSpace": protectionSpace.toMap()
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/SslCertificate.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/SslCertificate.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+public class SslCertificate: NSObject {
+    var x509Certificate: Data
+    var issuedBy: Any?
+    var issuedTo: Any?
+    var validNotAfterDate: Any?
+    var validNotBeforeDate: Any?
+    
+    public init(x509Certificate: Data) {
+        self.x509Certificate = x509Certificate
+    }
+    
+    public func toMap () -> [String:Any?] {
+        return [
+            "x509Certificate": x509Certificate,
+            "issuedBy": issuedBy,
+            "issuedTo": issuedTo,
+            "validNotAfterDate": validNotAfterDate,
+            "validNotBeforeDate": validNotBeforeDate
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/SslError.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/SslError.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public class SslError: NSObject {
+    var errorType: SecTrustResultType?
+    var message: String?
+    
+    public init(errorType: SecTrustResultType?) {
+        self.errorType = errorType
+        var sslErrorMessage: String? = nil
+        switch errorType {
+            case .deny:
+                sslErrorMessage = "Indicates a user-configured deny; do not proceed."
+            case .fatalTrustFailure:
+                sslErrorMessage = "Indicates a trust failure which cannot be overridden by the user."
+            case .invalid:
+                sslErrorMessage = "Indicates an invalid setting or result."
+            case .otherError:
+                sslErrorMessage = "Indicates a failure other than that of trust evaluation."
+            case .recoverableTrustFailure:
+                sslErrorMessage = "Indicates a trust policy failure which can be overridden by the user."
+            case .unspecified:
+                sslErrorMessage = "Indicates the evaluation succeeded and the certificate is implicitly trusted, but user intent was not explicitly specified."
+            default:
+                sslErrorMessage = nil
+        }
+        self.message = sslErrorMessage
+    }
+    
+    public func toMap () -> [String:Any?] {
+        return [
+            "code": errorType?.rawValue,
+            "message": message
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLAuthenticationChallenge.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLAuthenticationChallenge.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension URLAuthenticationChallenge {
+    public func toMap () -> [String:Any?] {
+        return [
+            "protectionSpace": protectionSpace.toMap(),
+            "previousFailureCount": previousFailureCount,
+            "failureResponse": failureResponse?.toMap(),
+            "error": error?.localizedDescription,
+            "proposedCredential": proposedCredential?.toMap(),
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLCredential.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLCredential.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+extension URLCredential {
+    public func toMap () -> [String:Any?] {
+        var x509Certificates: [Data] = []
+        if certificates != nil {
+            for certificate in certificates {
+                x509Certificates.append((certificate as! SecCertificate).data)
+            }
+        }
+        return [
+            "password": password,
+            "username": user,
+            "certificates": x509Certificates,
+            "persistence": persistence.rawValue
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLProtectionSpace.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLProtectionSpace.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension URLProtectionSpace {
+    var x509Certificate: Data? {
+        guard let serverTrust = serverTrust else { return nil }
+        var secResult = SecTrustResultType.invalid
+        let secTrustEvaluateStatus = SecTrustEvaluate(serverTrust, &secResult)
+        if secTrustEvaluateStatus == errSecSuccess, let serverCertificate = SecTrustGetCertificateAtIndex(serverTrust, 0) {
+            return serverCertificate.data
+        }
+        return nil
+    }
+    var sslCertificate: SslCertificate? {
+        var sslCertificate: SslCertificate? = nil
+        if let x509Certificate = x509Certificate {
+            sslCertificate = SslCertificate(x509Certificate: x509Certificate)
+        }
+        return sslCertificate
+    }
+    var sslError: SslError? {
+        guard let serverTrust = serverTrust else { return nil }
+        var secResult = SecTrustResultType.invalid
+        SecTrustEvaluate(serverTrust, &secResult)
+        guard let sslErrorType = secResult != SecTrustResultType.proceed ? secResult : nil else { return nil }
+        return SslError(errorType: sslErrorType)
+    }
+    public func toMap () -> [String:Any?] {
+        return [
+            "host": host,
+            "protocol": self.protocol,
+            "realm": realm,
+            "port": port,
+            "sslCertificate": sslCertificate?.toMap(),
+            "sslError": sslError?.toMap(),
+            "authenticationMethod": authenticationMethod,
+            "distinguishedNames": distinguishedNames,
+            "receivesCredentialSecurely": receivesCredentialSecurely,
+            "proxyType": proxyType
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLResponse.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Types/URLResponse.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension URLResponse {
+    public func toMap () -> [String:Any?] {
+        let httpResponse: HTTPURLResponse? = self as? HTTPURLResponse
+        return [
+            "expectedContentLength": expectedContentLength,
+            "mimeType": mimeType,
+            "suggestedFilename": suggestedFilename,
+            "textEncodingName": textEncodingName,
+            "url": url?.absoluteString,
+            "headers": httpResponse?.allHeaderFields,
+            "statusCode": httpResponse?.statusCode
+        ]
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Util.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/Util.swift
@@ -1,0 +1,12 @@
+import FlutterMacOS
+import WebKit
+
+public class Util {
+    public static func getAbsPathAsset(plugin: InAppWebViewFlutterPlugin, assetFilePath: String) throws -> String {
+        guard let key = plugin.registrar?.lookupKey(forAsset: assetFilePath),
+              let assetAbsPath = Bundle.main.path(forResource: key, ofType: nil) else {
+            throw NSError(domain: assetFilePath + " asset file cannot be found!", code: 0)
+        }
+        return assetAbsPath
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/WebViewChannelDelegate.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/WebViewChannelDelegate.swift
@@ -1,0 +1,104 @@
+import FlutterMacOS
+
+public class WebViewChannelDelegate: ChannelDelegate {
+    
+    public init(channel: FlutterMethodChannel) {
+        super.init(channel: channel)
+    }
+    
+    public class ReceivedHttpAuthRequestCallback: BaseCallbackResult<HttpAuthResponse> {
+        override init() {
+            super.init()
+            self.decodeResult = { (obj: Any?) in
+                return HttpAuthResponse.fromMap(map: obj as? [String: Any?])
+            }
+        }
+        deinit {
+            self.defaultBehaviour(nil)
+        }
+    }
+    
+    public func onReceivedHttpAuthRequest(
+        challenge: HttpAuthenticationChallenge, callback: ReceivedHttpAuthRequestCallback
+    ) {
+        if channel == nil {
+            callback.defaultBehaviour(nil)
+            return
+        }
+        DispatchQueue.global(qos: .background).async {
+            let arguments = challenge.toMap()
+            DispatchQueue.main.async { [weak self] in
+                if self?.channel == nil {
+                    callback.defaultBehaviour(nil)
+                    return
+                }
+                self?.channel?.invokeMethod(
+                    "onReceivedHttpAuthRequest", arguments: arguments, callback: callback)
+            }
+        }
+    }
+    
+    public class ReceivedServerTrustAuthRequestCallback: BaseCallbackResult<ServerTrustAuthResponse> {
+        override init() {
+            super.init()
+            self.decodeResult = { (obj: Any?) in
+                return ServerTrustAuthResponse.fromMap(map: obj as? [String: Any?])
+            }
+        }
+        deinit {
+            self.defaultBehaviour(nil)
+        }
+    }
+    
+    public func onReceivedServerTrustAuthRequest(
+        challenge: ServerTrustChallenge, callback: ReceivedServerTrustAuthRequestCallback
+    ) {
+        if channel == nil {
+            callback.defaultBehaviour(nil)
+            return
+        }
+        DispatchQueue.global(qos: .background).async {
+            let arguments = challenge.toMap()
+            DispatchQueue.main.async { [weak self] in
+                if self?.channel == nil {
+                    callback.defaultBehaviour(nil)
+                    return
+                }
+                self?.channel?.invokeMethod(
+                    "onReceivedServerTrustAuthRequest", arguments: arguments, callback: callback)
+            }
+        }
+    }
+    
+    public class ReceivedClientCertRequestCallback: BaseCallbackResult<ClientCertResponse> {
+        override init() {
+            super.init()
+            self.decodeResult = { (obj: Any?) in
+                return ClientCertResponse.fromMap(map: obj as? [String: Any?])
+            }
+        }
+        deinit {
+            self.defaultBehaviour(nil)
+        }
+    }
+    
+    public func onReceivedClientCertRequest(
+        challenge: ClientCertChallenge, callback: ReceivedClientCertRequestCallback
+    ) {
+        if channel == nil {
+            callback.defaultBehaviour(nil)
+            return
+        }
+        DispatchQueue.global(qos: .background).async {
+            let arguments = challenge.toMap()
+            DispatchQueue.main.async { [weak self] in
+                if self?.channel == nil {
+                    callback.defaultBehaviour(nil)
+                    return
+                }
+                self?.channel?.invokeMethod(
+                    "onReceivedClientCertRequest", arguments: arguments, callback: callback)
+            }
+        }
+    }
+}

--- a/zikzak_inappwebview_macos/pubspec.lock
+++ b/zikzak_inappwebview_macos/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   vector_math:
     dependency: transitive
     description:
@@ -223,5 +223,5 @@ packages:
     source: path
     version: "4.6.3"
 sdks:
-  dart: ">=3.10.0-0 <4.0.0"
+  dart: ">=3.9.0-0 <4.0.0"
   flutter: ">=3.38.6"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added macOS WebView support for HTTP authentication, server trust decisions, and client certificate requests.
  * Added credential storage management, including viewing, saving, removing, and clearing credentials.
  * Added authentication challenge and SSL certificate information for Flutter callbacks.
  * Added support for resolving bundled Flutter asset paths on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->