### PR TITLE
fix(android): bump toolchain — androidx.webkit 1.15.0, AGP 8.13.1, JVM target 17 (closes #201)

### DIFF
--- a/zikzak_inappwebview/example/pubspec.lock
+++ b/zikzak_inappwebview/example/pubspec.lock
@@ -585,7 +585,7 @@ packages:
       path: "../../zikzak_inappwebview_android"
       relative: true
     source: path
-    version: "4.6.3"
+    version: "4.6.4"
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:

--- a/zikzak_inappwebview_android/CHANGELOG.md
+++ b/zikzak_inappwebview_android/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Android toolchain bump (closes #201): `androidx.webkit:webkit` 1.14.0 -> 1.15.0, AGP 8.5.2 -> 8.13.1 (current stable 8.x, matches webview_flutter_android reference), JVM target 11 -> 17. Reflection-based `SUPPRESS_ERROR_PAGE` guards in `InAppWebViewSettings` and `ZikZakSecurityManager` remain forward-compatible (feature available since webkit 1.13.0). 16KB page size alignment retained.
 - Added iOS proxy support (iOS 17.0+) — set process-wide proxy for WKWebView
 
 

--- a/zikzak_inappwebview_android/android/build.gradle
+++ b/zikzak_inappwebview_android/android/build.gradle
@@ -8,9 +8,11 @@ buildscript {
     }
 
     dependencies {
-        // AGP 8.5.2 automatically enables 16KB page size alignment (requires >= 8.5.1)
-        // This ensures compatibility with Android 15+ devices using 16KB memory pages
-        classpath 'com.android.tools.build:gradle:8.5.2'
+        // AGP 8.13.1 — current stable 8.x (matches webview_flutter_android reference).
+        // 16KB page size alignment is enabled automatically (requires AGP >= 8.5.1).
+        // This ensures compatibility with Android 15+ devices using 16KB memory pages.
+        // See #70 for the planned AGP 9.0 / built-in Kotlin migration.
+        classpath 'com.android.tools.build:gradle:8.13.1'
     }
 }
 
@@ -31,8 +33,8 @@ android {
     compileSdkVersion 36
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     defaultConfig {
@@ -56,7 +58,7 @@ android {
         }
     }
     dependencies {
-        implementation 'androidx.webkit:webkit:1.14.0'
+        implementation 'androidx.webkit:webkit:1.15.0'
         implementation 'androidx.browser:browser:1.8.0'
         implementation 'androidx.appcompat:appcompat:1.7.0'
         implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0'

--- a/zikzak_inappwebview_android/pubspec.yaml
+++ b/zikzak_inappwebview_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_android
 description: Android implementation of the zikzak_inappwebview plugin.
-version: 4.6.3
+version: 4.6.4
 homepage: https://inappwebview.dev/
 repository: https://github.com/arrrrny/zikzak_inappwebview/tree/master/zikzak_inappwebview_android
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues


### PR DESCRIPTION
Closes #201

Bump the Android plugin toolchain to align with the current webview_flutter_android reference, as requested in #201.

Changes (zikzak_inappwebview_android/android/build.gradle):
- androidx.webkit:webkit 1.14.0 -> 1.15.0 (latest stable; picks up WebKitCompat additions)
- AGP 8.5.2 -> 8.13.1 (current stable 8.x; matches webview_flutter_android reference. AGP 9.0 / built-in Kotlin is tracked separately in #70)
- JavaVersion source/target 11 -> 17 (aligns with modern AGP/Gradle/Kotlin toolchains and the example app which already targets 17)

Also:
- pubspec.yaml: 4.6.3 -> 4.6.4 (patch bump for the toolchain chore; matches repo convention)
- example/pubspec.lock: recorded android plugin version synced to 4.6.4
- CHANGELOG.md: Unreleased entry

Reflection-based SUPPRESS_ERROR_PAGE guards in InAppWebViewSettings and ZikZakSecurityManager are forward-compatible (feature available since webkit 1.13.0; 1.15.0 > 1.13.0) — no source changes needed. 16KB page size alignment retained (AGP >= 8.5.1).

compileSdkVersion 36 is kept (current; flutter.compileSdkVersion is a 'consider' in the issue, not an acceptance criterion, and the flutter ext is not wired into the legacy Groovy plugin build.gradle).

Verification:
- dart pub get + dart analyze on zikzak_inappwebview_android: clean (2 pre-existing warnings unrelated to this change)
- Example app / main package could not be fully exercised — they require Dart 3.12.2 while the sandbox has 3.11.0 (pre-existing env gap)
- Android Gradle build could not run in the sandbox (no Android SDK/Java); all version strings reference verified Maven artifacts

Base: development (repo lags master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Android compatibility with updated platform tooling and WebKit support.
  * Added support for Java 17 and retained compatibility with devices using 16KB page sizes.

* **Bug Fixes**
  * Strengthened compatibility safeguards for Android WebKit reflection behavior.

* **Chores**
  * Updated the Android package version to 4.6.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->