### PR TITLE
fix(macos): use WKWebpagePreferences.allowsContentJavaScript instead of deprecated WKPreferences.javaScriptEnabled (#200)

### DIFF
--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -449,7 +449,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         if newSettingsMap["javaScriptEnabled"] != nil
             && settings?.javaScriptEnabled != newSettings.javaScriptEnabled
         {
-            configuration.preferences.javaScriptEnabled = newSettings.javaScriptEnabled
+            configuration.defaultWebpagePreferences.allowsContentJavaScript = newSettings.javaScriptEnabled
         }
 
         if newSettingsMap["javaScriptCanOpenWindowsAutomatically"] != nil

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewSettings.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewSettings.swift
@@ -96,7 +96,7 @@ public class InAppWebViewSettings: ISettings<InAppWebView> {
                 configuration.suppressesIncrementalRendering
             realSettings["allowsBackForwardNavigationGestures"] =
                 webView.allowsBackForwardNavigationGestures
-            realSettings["javaScriptEnabled"] = configuration.preferences.javaScriptEnabled
+            realSettings["javaScriptEnabled"] = configuration.defaultWebpagePreferences.allowsContentJavaScript
             realSettings["allowUniversalAccessFromFileURLs"] = configuration.value(
                 forKey: "allowUniversalAccessFromFileURLs")
             realSettings["allowFileAccessFromFileURLs"] = configuration.preferences.value(


### PR DESCRIPTION
Closes #200

Switches the macOS `javaScriptEnabled` toggle from the **deprecated** `WKPreferences.javaScriptEnabled` (deprecated since macOS 11 / iOS 14) to the per-navigation `WKWebpagePreferences.allowsContentJavaScript`, matching the iOS port.

## Context

On macOS zikzak toggled JavaScript via `configuration.preferences.javaScriptEnabled`, which Apple deprecated in macOS 11 in favour of `WKWebpagePreferences.allowsContentJavaScript`. The iOS port already uses the modern API (`InAppWebView.swift:605` + `:1558`). `webview_flutter_wkwebview` also uses `WKWebpagePreferences.allowsContentJavaScript` on both platforms.

## Changes (macOS plugin only, 2 hunks)

1. `InAppWebView.swift` — `setSettings(...)` (single method applied at both init and runtime):
   `configuration.preferences.javaScriptEnabled = newSettings.javaScriptEnabled`
   → `configuration.defaultWebpagePreferences.allowsContentJavaScript = newSettings.javaScriptEnabled`

2. `InAppWebViewSettings.swift` — `getRealSettings(...)` read-back:
   `configuration.preferences.javaScriptEnabled`
   → `configuration.defaultWebpagePreferences.allowsContentJavaScript`

## Why no `#available` guard

zikzak's macOS deployment target is `.macOS("12.0")` (`Package.swift`), and `WKWebpagePreferences.allowsContentJavaScript` is available since macOS 11.0 — so the modern API is always available on every supported OS and the deprecated call can be dropped entirely. This also eliminates the deprecation warning (acceptance criterion #2).

## Acceptance criteria

- [x] macOS uses `defaultWebpagePreferences.allowsContentJavaScript` to enable/disable JavaScript.
- [x] No deprecation warning on the macOS build (deprecated `javaScriptEnabled` assignment removed).
- [x] Behaviour matches iOS (disabling JS via settings fully disables it).

## Verification

- `dart analyze` on `zikzak_inappwebview_macos`: clean (only a pre-existing, unrelated `invalid_dependency` path-dependency warning).
- `flutter test` on `zikzak_inappwebview_macos`: all 12 tests pass.
- `grep -rn 'configuration.preferences.javaScriptEnabled' zikzak_inappwebview_macos/` → no remaining deprecated assignments. (`javaScriptCanOpenWindowsAutomatically` is a different, non-deprecated property and is intentionally left untouched.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated JavaScript settings handling to use the current macOS WebView configuration.
  * Improved compatibility with newer macOS WebKit APIs.
  * Ensured JavaScript settings are accurately applied and reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->