### PR TITLE
fix(macos): replace deprecated javaScriptEnabled read in getSelectedText (follow-up to #212)

### DIFF
--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -847,7 +847,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             self.resumeTimers()
             result(true)
         case "getSelectedText":
-            if self.configuration.preferences.javaScriptEnabled {
+            if self.configuration.defaultWebpagePreferences.allowsContentJavaScript {
                 self.evaluateJavaScript(PluginScriptsUtil.GET_SELECTED_TEXT_JS_SOURCE) { (value, _) in
                     result(value ?? "")
                 }


### PR DESCRIPTION
Follow-up to #212 — eliminates the last remaining deprecated `WKPreferences.javaScriptEnabled` read on the macOS plugin.

## Context

PR #212 swapped the macOS `javaScriptEnabled` toggle from the deprecated `WKPreferences.javaScriptEnabled` to `WKWebpagePreferences.allowsContentJavaScript`, and at merge time the author verified with `grep -rn 'configuration.preferences.javaScriptEnabled' zikzak_inappwebview_macos/` that no deprecated usages remained.

A later commit (`bdec3219`, PR #197/#205 "method-channel parity for ~50 iOS controller methods") re-introduced a deprecated read in the newly-added `getSelectedText` handler:

`InAppWebView.swift:850` (before)
```swift
case "getSelectedText":
    if self.configuration.preferences.javaScriptEnabled {   // ← deprecated
        self.evaluateJavaScript(PluginScriptsUtil.GET_SELECTED_TEXT_JS_SOURCE) { (value, _) in
            result(value ?? "")
        }
    } else {
        result("")
    }
```

This restored the deprecation warning that #212 had removed, breaking #212's acceptance criterion #2 ("No deprecation warning on the macOS build").

## Change

One-line, `Bool` → `Bool` swap with identical semantics, matching what #212 already did for the write path and the read-back path:

`InAppWebView.swift:850` (after)
```swift
if self.configuration.defaultWebpagePreferences.allowsContentJavaScript {
```

`defaultWebpagePreferences.allowsContentJavaScript` is available since macOS 11.0 and the deployment target is `.macOS("12.0")`, so no `#available` guard is required (same reasoning as #212).

## Verification

- `grep -rn 'configuration.preferences.javaScriptEnabled' zikzak_inappwebview_macos/` → no remaining deprecated usages.
- The macOS plugin now has zero `configuration.preferences.javaScriptEnabled` references (write + read-back + `getSelectedText` all use `defaultWebpagePreferences.allowsContentJavaScript`), restoring parity with #212's end state.
- Behaviourally identical: both properties are `Bool`; `getSelectedText` only gates whether to run `evaluateJavaScript` for the selection, so the swap is semantically equivalent.

Refs #212, #200.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selected-text retrieval in macOS web views by correctly respecting the current JavaScript setting.
  * Replaced use of a deprecated configuration check to improve compatibility with newer platform APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->