### PR TITLE
fix(windows): forward additionalBrowserArguments to WebView2 (closes #178)

### DIFF
--- a/zikzak_inappwebview_windows/CHANGELOG.md
+++ b/zikzak_inappwebview_windows/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 4.6.4 - 2026-08-09
+
+
+- Fixed: Windows — `WebViewEnvironmentSettings.additionalBrowserArguments`
+  and `browserExecutableFolder` are now forwarded to
+  `WebviewController.initializeEnvironment` (previously only `userDataFolder`
+  was honored). Chromium flags such as `--disable-web-security` now actually
+  reach the WebView2 runtime via `ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments`,
+  so local CORS can be disabled for development (issue #178).
+- Test: added `resolveEnvironmentInitArgs` unit tests covering the issue #178
+  repro (`--disable-web-security --allow-running-insecure-content
+  --use-fake-ui-for-media-stream --use-fake-device-for-media-stream`) and the
+  full/null/partial settings matrix.
+
 ## 4.6.3 - 2026-07-21
 
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -80,17 +80,24 @@ class _InAppWebViewWindowsWidgetStateImpl
 
   Future<void> initPlatformState() async {
     try {
-      // Determine user data folder from WebViewEnvironmentSettings or use default
-      String userDataPath;
+      // Resolve the WebView2 environment arguments from the user-supplied
+      // [WebViewEnvironmentSettings] (or platform defaults). Previously only
+      // `userDataFolder` was honored, which silently dropped
+      // `additionalBrowserArguments` — so Chromium flags such as
+      // `--disable-web-security` never reached WebView2 (issue #178).
       final settings = widget.params.webViewEnvironment?.settings;
-      if (settings?.userDataFolder != null) {
-        userDataPath = settings!.userDataFolder!;
-      } else {
-        userDataPath = await _getDefaultUserDataFolder();
-      }
+      final defaultUserDataFolder = await _getDefaultUserDataFolder();
+      final args = resolveEnvironmentInitArgs(
+        settings: settings,
+        defaultUserDataFolder: () => defaultUserDataFolder,
+      );
 
-      // Initialize the shared WebView2 environment with the user data folder
-      await WebviewController.initializeEnvironment(userDataPath: userDataPath);
+      // Initialize the shared WebView2 environment with the resolved args.
+      await WebviewController.initializeEnvironment(
+        userDataPath: args.userDataPath,
+        browserExePath: args.browserExePath,
+        additionalArguments: args.additionalArguments,
+      );
 
       await _controller.initialize();
 
@@ -152,4 +159,62 @@ class _InAppWebViewWindowsWidgetStateImpl
     _controller.dispose();
     super.dispose();
   }
+}
+
+/// Arguments forwarded to [WebviewController.initializeEnvironment] when
+/// bringing up the shared WebView2 environment.
+///
+/// Exposed as a typed record so the mapping from
+/// [WebViewEnvironmentSettings] to the underlying `webview_windows` API
+/// can be unit-tested without a live WebView2 runtime.
+class WebViewEnvironmentInitArgs {
+  const WebViewEnvironmentInitArgs({
+    required this.userDataPath,
+    this.browserExePath,
+    this.additionalArguments,
+  });
+
+  /// User-data folder to use for the WebView2 runtime. Always non-null —
+  /// falls back to the platform default when the caller did not supply one.
+  final String userDataPath;
+
+  /// Path to a fixed-version WebView2 runtime, or `null` to use the
+  /// installed runtime.
+  final String? browserExePath;
+
+  /// Raw Chromium command-line switches forwarded to WebView2's
+  /// `ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments`.
+  ///
+  /// Example: `"--disable-web-security --allow-running-insecure-content"`.
+  final String? additionalArguments;
+}
+
+/// Maps a [WebViewEnvironmentSettings] into the parameters accepted by
+/// [WebviewController.initializeEnvironment].
+///
+/// This is the single source of truth for which Windows-only settings are
+/// forwarded to the WebView2 runtime. Before this helper existed, only
+/// [WebViewEnvironmentSettings.userDataFolder] was honored, silently
+/// dropping `additionalBrowserArguments` — so Chromium flags such as
+/// `--disable-web-security` never reached WebView2 and local CORS could
+/// not be disabled (issue #178).
+///
+/// Pure and synchronous so it can be unit-tested without a live WebView2
+/// runtime; the caller supplies the default user-data folder via
+/// [defaultUserDataFolder] (which is only invoked when [settings] is `null`
+/// or does not specify `userDataFolder`).
+WebViewEnvironmentInitArgs resolveEnvironmentInitArgs({
+  required WebViewEnvironmentSettings? settings,
+  required String Function() defaultUserDataFolder,
+}) {
+  if (settings == null) {
+    return WebViewEnvironmentInitArgs(
+      userDataPath: defaultUserDataFolder(),
+    );
+  }
+  return WebViewEnvironmentInitArgs(
+    userDataPath: settings.userDataFolder ?? defaultUserDataFolder(),
+    browserExePath: settings.browserExecutableFolder,
+    additionalArguments: settings.additionalBrowserArguments,
+  );
 }

--- a/zikzak_inappwebview_windows/pubspec.lock
+++ b/zikzak_inappwebview_windows/pubspec.lock
@@ -167,10 +167,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -183,10 +183,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   objective_c:
     dependency: transitive
     description:
@@ -340,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/zikzak_inappwebview_windows/pubspec.yaml
+++ b/zikzak_inappwebview_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_windows
 description: The Windows implementation of zikzak_inappwebview.
-version: 4.6.3
+version: 4.6.4
 homepage: https://github.com/arrrrny/zikzak_inappwebview
 
 environment:

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
+
+void main() {
+  const defaultFolder = '/tmp/default-zikzak-webview2-data';
+
+  group('resolveEnvironmentInitArgs', () {
+    group('issue #178 regression — additionalBrowserArguments', () {
+      test(
+        'forwards --disable-web-security and friends to additionalArguments',
+        () {
+          // The exact symptom reported in issue #178: the user supplied
+          // `--disable-web-security --allow-running-insecure-content
+          // --use-fake-ui-for-media-stream
+          // --use-fake-device-for-media-stream` via
+          // `WebViewEnvironmentSettings.additionalBrowserArguments`, but
+          // CORS stayed on because the flag was silently dropped before
+          // reaching WebView2. The resolver must surface the value on
+          // `WebViewEnvironmentInitArgs.additionalArguments` so the
+          // caller can forward it to
+          // `WebviewController.initializeEnvironment(additionalArguments:)`.
+          const args = '--disable-web-security '
+              '--allow-running-insecure-content '
+              '--use-fake-ui-for-media-stream '
+              '--use-fake-device-for-media-stream';
+          final resolved = resolveEnvironmentInitArgs(
+            settings: WebViewEnvironmentSettings(
+              userDataFolder: '/tmp/cors-disabled',
+              additionalBrowserArguments: args,
+            ),
+            defaultUserDataFolder: () => defaultFolder,
+          );
+
+          expect(resolved.additionalArguments, args);
+          expect(resolved.userDataPath, '/tmp/cors-disabled');
+          expect(resolved.browserExePath, isNull);
+        },
+      );
+    });
+
+    test('null settings → only userDataPath, defaults invoked', () {
+      var defaultInvoked = 0;
+      final resolved = resolveEnvironmentInitArgs(
+        settings: null,
+        defaultUserDataFolder: () {
+          defaultInvoked++;
+          return defaultFolder;
+        },
+      );
+
+      expect(resolved.userDataPath, defaultFolder);
+      expect(resolved.browserExePath, isNull);
+      expect(resolved.additionalArguments, isNull);
+      expect(defaultInvoked, 1);
+    });
+
+    test('settings without userDataFolder → falls back to default', () {
+      var defaultInvoked = 0;
+      final resolved = resolveEnvironmentInitArgs(
+        settings: WebViewEnvironmentSettings(
+          additionalBrowserArguments: '--disable-web-security',
+        ),
+        defaultUserDataFolder: () {
+          defaultInvoked++;
+          return defaultFolder;
+        },
+      );
+
+      expect(resolved.userDataPath, defaultFolder);
+      expect(resolved.additionalArguments, '--disable-web-security');
+      expect(defaultInvoked, 1);
+    });
+
+    test('settings with all fields → all fields forwarded', () {
+      final resolved = resolveEnvironmentInitArgs(
+        settings: WebViewEnvironmentSettings(
+          browserExecutableFolder: 'C:/wbv2/fixed',
+          userDataFolder: 'D:/appdata/wbv2',
+          additionalBrowserArguments: '--disable-web-security --flag2',
+        ),
+        defaultUserDataFolder: () => defaultFolder,
+      );
+
+      expect(resolved.userDataPath, 'D:/appdata/wbv2');
+      expect(resolved.browserExePath, 'C:/wbv2/fixed');
+      expect(resolved.additionalArguments, '--disable-web-security --flag2');
+    });
+
+    test('settings with only userDataFolder → null browser/args', () {
+      final resolved = resolveEnvironmentInitArgs(
+        settings: WebViewEnvironmentSettings(
+          userDataFolder: '/tmp/custom-folder',
+        ),
+        defaultUserDataFolder: () => defaultFolder,
+      );
+
+      expect(resolved.userDataPath, '/tmp/custom-folder');
+      expect(resolved.browserExePath, isNull);
+      expect(resolved.additionalArguments, isNull);
+    });
+
+    test('defaultUserDataFolder is NOT invoked when settings.userDataFolder is set', () {
+      var defaultInvoked = 0;
+      resolveEnvironmentInitArgs(
+        settings: WebViewEnvironmentSettings(
+          userDataFolder: '/tmp/explicit',
+          additionalBrowserArguments: '--disable-web-security',
+        ),
+        defaultUserDataFolder: () {
+          defaultInvoked++;
+          return defaultFolder;
+        },
+      );
+
+      expect(defaultInvoked, 0);
+    });
+  });
+}


### PR DESCRIPTION
Closes #178

The Windows implementation of WebViewEnvironmentSettings only forwarded userDataFolder to WebviewController.initializeEnvironment, silently dropping additionalBrowserArguments (and browserExecutableFolder). Chromium flags such as --disable-web-security therefore never reached the WebView2 runtime, and local CORS could not be disabled for development (issue #178).

Root cause: zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart only read settings.userDataFolder before calling WebviewController.initializeEnvironment(userDataPath: ...). The upstream webview_windows package already accepts additionalArguments and browserExePath and the native C++ side already plumbs them to ICoreWebView2EnvironmentOptions::put_AdditionalBrowserArguments → CreateCoreWebView2EnvironmentWithOptions.

Fix:
- Extract a pure, testable helper resolveEnvironmentInitArgs({settings, defaultUserDataFolder}) → WebViewEnvironmentInitArgs that maps WebViewEnvironmentSettings to the three parameters accepted by WebviewController.initializeEnvironment (userDataPath, browserExePath, additionalArguments). This is the single source of truth for which Windows-only settings are forwarded to WebView2.
- initPlatformState() now calls the helper and forwards all three args.
- Added regression tests (test/in_app_webview_windows_environment_args_test.dart) covering the exact issue #178 repro (--disable-web-security --allow-running-insecure-content --use-fake-ui-for-media-stream --use-fake-device-for-media-stream) plus null/partial/full settings matrices and the default-folder-not-invoked-when-userDataFolder-set guarantee.
- Bumped zikzak_inappwebview_windows 4.6.3 → 4.6.4 with CHANGELOG entry.

Verification:
- dart analyze on changed files: No issues found.
- flutter test (whole Windows package): All 13 tests passed (7 pre-existing + 6 new).