### PR TITLE
fix(macos): missing navigation event handlers + fix(android): insets listener type

### DIFF
--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -2293,7 +2293,7 @@ public final class InAppWebView
      * to this WebView.
      *
      * <p>For each ignored inset type the matching {@link WindowInsetsCompat.Type}
-     * mask is zeroed out via a {@link ViewCompat.OnApplyWindowInsetsListener}
+     * mask is zeroed out via a {@link OnApplyWindowInsetsListener}
      * (using {@link WindowInsetsCompat.Builder#setInsets(int, Insets)}) so the
      * WebView no longer pads or shrinks its content for those insets. This is
      * the zikzak equivalent of {@code webview_flutter_android}'s
@@ -2349,7 +2349,7 @@ public final class InAppWebView
         final int finalTypeMask = typeMask;
         ViewCompat.setOnApplyWindowInsetsListener(
             this,
-            new ViewCompat.OnApplyWindowInsetsListener() {
+            new androidx.core.view.OnApplyWindowInsetsListener() {
                 @Override
                 public WindowInsetsCompat onApplyWindowInsets(
                     View v, WindowInsetsCompat insets

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -95,6 +95,25 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
           );
         }
         break;
+      case 'onPageCommitVisible':
+        if (params.webviewParams?.onPageCommitVisible != null) {
+          String? url = call.arguments['url'];
+          params.webviewParams!.onPageCommitVisible!(
+            controller,
+            url != null ? WebUri(url) : null,
+          );
+        }
+        break;
+      case 'onDidReceiveServerRedirectForProvisionalNavigation':
+        if (params
+                .webviewParams
+                ?.onDidReceiveServerRedirectForProvisionalNavigation !=
+            null) {
+          params
+              .webviewParams!
+              .onDidReceiveServerRedirectForProvisionalNavigation!(controller);
+        }
+        break;
       case 'onReceivedError':
         if (params.webviewParams?.onReceivedError != null) {
           String? url = call.arguments['url'];
@@ -184,9 +203,7 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
         break;
       case 'onWebContentProcessDidTerminate':
         if (params.webviewParams?.onWebContentProcessDidTerminate != null) {
-          params.webviewParams!.onWebContentProcessDidTerminate!(
-            controller,
-          );
+          params.webviewParams!.onWebContentProcessDidTerminate!(controller);
         }
         break;
       case 'onJsAlert':
@@ -251,8 +268,7 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
             : webviewParams?.contextMenu;
         if (contextMenu != null && contextMenu.onCreateContextMenu != null) {
           Map<String, dynamic> arguments =
-              (call.arguments as Map<dynamic, dynamic>)
-                  .cast<String, dynamic>();
+              (call.arguments as Map<dynamic, dynamic>).cast<String, dynamic>();
           InAppWebViewHitTestResult hitTestResult =
               InAppWebViewHitTestResult.fromMap(arguments)!;
           contextMenu.onCreateContextMenu!(hitTestResult);
@@ -502,7 +518,6 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
     args.putIfAbsent('contentWorld', () => contentWorld?.toMap());
     return await _channel.invokeMethod('evaluateJavascript', args);
   }
-
 
   @override
   Future<MacOSPrintJobController?> printCurrentPage({


### PR DESCRIPTION
Two small follow-ups from the local working tree (split out of a mixed commit).

**Commit 1 — fix(android):** use `androidx.core.view.OnApplyWindowInsetsListener` top-level interface directly instead of the deprecated `ViewCompat.OnApplyWindowInsetsListener` nested alias in the window-insets listener registration (follow-up to #206).

**Commit 2 — fix(macos):** add missing `onPageCommitVisible` and `onDidReceiveServerRedirectForProvisionalNavigation` method-channel handlers so macOS fires the same navigation lifecycle callbacks as iOS (follow-up to #205). `flutter analyze` passes.