### PR TITLE
fix(ios): gate HeadlessInAppWebView.run() on web-process readiness

### DIFF
--- a/zikzak_inappwebview/CHANGELOG.md
+++ b/zikzak_inappwebview/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
+
 ## 4.8.0 - 2026-08-14
 
 ### Features

--- a/zikzak_inappwebview/example/lib/first_load_race.screen.dart
+++ b/zikzak_inappwebview/example/lib/first_load_race.screen.dart
@@ -56,71 +56,8 @@ class _FirstLoadRaceScreenState extends State<FirstLoadRaceScreen> {
       _headlessRunning = true;
       _headlessLog.clear();
     });
-
-    const attempts = 10;
-    var passed = 0;
-
-    for (var i = 1; i <= attempts; i++) {
-      final attemptLog = <String>[];
-      final stopwatch = Stopwatch()..start();
-      HeadlessInAppWebView? webview;
-
-      try {
-        // 1. Fresh webview — the exact dart_web_scraper setup. onLoadStop
-        //    is constructor-only, so wire the completer before run().
-        final loadStop = Completer<String?>();
-        webview = HeadlessInAppWebView(
-          initialUrlRequest: URLRequest(url: WebUri('about:blank')),
-          initialSettings: InAppWebViewSettings(isInspectable: kDebugMode),
-          onLoadStop: (c, url) {
-            if (!loadStop.isCompleted) loadStop.complete(url?.toString());
-          },
-        );
-
-        // 2. run() — with the gate this only completes when the web
-        //    process is ready; without it, returns immediately.
-        await webview.run().timeout(
-              const Duration(seconds: 15),
-              onTimeout: () => throw TimeoutException('run() HUNG'),
-            );
-        final runMs = stopwatch.elapsedMilliseconds;
-        attemptLog.add('run(): ${runMs}ms');
-
-        final controller = webview.webViewController!;
-
-        // 3. IMMEDIATELY issue the first real navigation.
-        await controller.loadUrl(urlRequest: URLRequest(url: WebUri(targetUrl)));
-        final stopUrl = await loadStop.future.timeout(
-              const Duration(seconds: 15),
-              onTimeout: () => throw TimeoutException('onLoadStop never fired'),
-            );
-        attemptLog.add('onLoadStop: ${stopwatch.elapsedMilliseconds}ms ($stopUrl)');
-
-        // 4. Verify content actually rendered.
-        final html = await controller.getHtml().timeout(
-              const Duration(seconds: 15),
-              onTimeout: () => throw TimeoutException('getHtml() HUNG'),
-            );
-        final ok = (html ?? '').contains(marker);
-        attemptLog.add('html: ${(html ?? '').length} chars, marker=$ok');
-        if (ok) passed++;
-        attemptLog.add(ok ? '✅ PASS' : '❌ FAIL (content mismatch)');
-      } catch (e) {
-        attemptLog.add('❌ FAIL: $e');
-      } finally {
-        try {
-          await webview?.dispose();
-        } catch (_) {}
-      }
-
-      _log(_headlessLog, '── attempt $i/$attempts ──');
-      for (final line in attemptLog.reversed) {
-        _log(_headlessLog, '   $line');
-      }
-      if (mounted) setState(() {});
-    }
-
-    _log(_headlessLog, '══════ RESULT: $passed/$attempts passed ══════');
+    final summary = await runHeadlessStressAttempts();
+    _log(_headlessLog, summary);
     setState(() {
       _headlessRunning = false;
     });
@@ -287,6 +224,86 @@ class _FirstLoadRaceScreenState extends State<FirstLoadRaceScreen> {
 
 /// Debug hook — invoke from the VM service / flutter run console:
 ///   debugRunHeadlessStress()
-Future<void> debugRunHeadlessStress() =>
-    _FirstLoadRaceScreenState._live?._runHeadlessStress() ??
-    Future.error('FirstLoadRaceScreen not open');
+Future<String> debugRunHeadlessStress() => runHeadlessStressAttempts();
+
+/// Runs the first-load race stress: N sequential attempts, each with a
+/// FRESH headless webview, run() → IMMEDIATE loadUrl → content verification.
+/// Logs every step via debugPrint and returns the summary line.
+///
+/// The per-attempt timeouts are TEST HARNESS measurement bounds so hangs are
+/// reported instead of hanging forever — not part of the fix.
+Future<String> runHeadlessStressAttempts({
+  int attempts = 10,
+  String targetUrl = 'https://example.com',
+  String marker = 'Example Domain',
+}) async {
+  var passed = 0;
+
+  for (var i = 1; i <= attempts; i++) {
+    final attemptLog = <String>[];
+    final stopwatch = Stopwatch()..start();
+    HeadlessInAppWebView? webview;
+
+    try {
+      // 1. Fresh webview — the exact dart_web_scraper setup. onLoadStop
+      //    is constructor-only, so wire the completer before run().
+      final loadStop = Completer<String?>();
+      webview = HeadlessInAppWebView(
+        initialUrlRequest: URLRequest(url: WebUri('about:blank')),
+        initialSettings: InAppWebViewSettings(isInspectable: kDebugMode),
+        onLoadStop: (c, url) {
+          // Ignore the INITIAL about:blank loadStop (the same event the
+          // readiness gate waits on) — we only care about the first REAL
+          // navigation's terminal event.
+          final u = url?.toString() ?? '';
+          if (u == 'about:blank') return;
+          if (!loadStop.isCompleted) loadStop.complete(u);
+        },
+      );
+
+      // 2. run() — with the gate this only completes when the web
+      //    process is ready; without it, returns immediately.
+      await webview.run().timeout(
+            const Duration(seconds: 15),
+            onTimeout: () => throw TimeoutException('run() HUNG'),
+          );
+      final runMs = stopwatch.elapsedMilliseconds;
+      attemptLog.add('run(): ${runMs}ms');
+
+      final controller = webview.webViewController!;
+
+      // 3. IMMEDIATELY issue the first real navigation.
+      await controller.loadUrl(urlRequest: URLRequest(url: WebUri(targetUrl)));
+      final stopUrl = await loadStop.future.timeout(
+            const Duration(seconds: 15),
+            onTimeout: () => throw TimeoutException('onLoadStop never fired'),
+          );
+      attemptLog.add('onLoadStop: ${stopwatch.elapsedMilliseconds}ms ($stopUrl)');
+
+      // 4. Verify content actually rendered.
+      final html = await controller.getHtml().timeout(
+            const Duration(seconds: 15),
+            onTimeout: () => throw TimeoutException('getHtml() HUNG'),
+          );
+      final ok = (html ?? '').contains(marker);
+      attemptLog.add('html: ${(html ?? '').length} chars, marker=$ok');
+      if (ok) passed++;
+      attemptLog.add(ok ? 'PASS' : 'FAIL (content mismatch)');
+    } catch (e) {
+      attemptLog.add('FAIL: $e');
+    } finally {
+      try {
+        await webview?.dispose();
+      } catch (_) {}
+    }
+
+    debugPrint('[FirstLoadRace] ── attempt $i/$attempts ──');
+    for (final line in attemptLog) {
+      debugPrint('[FirstLoadRace]    $line');
+    }
+  }
+
+  final summary = '══════ RESULT: $passed/$attempts passed ══════';
+  debugPrint('[FirstLoadRace] $summary');
+  return summary;
+}

--- a/zikzak_inappwebview/example/lib/first_load_race.screen.dart
+++ b/zikzak_inappwebview/example/lib/first_load_race.screen.dart
@@ -39,7 +39,11 @@ class _FirstLoadRaceScreenState extends State<FirstLoadRaceScreen> {
   String? _visibleLoadStopUrl;
   final _visibleLoadStopCompleters = <Completer<String?>>[];
 
+  /// Live state instance for the debug hook below.
+  static _FirstLoadRaceScreenState? _live;
+
   void _log(List<String> log, String line) {
+    debugPrint('[FirstLoadRace] $line');
     log.insert(0, line);
     if (log.length > 60) log.removeLast();
   }
@@ -182,6 +186,18 @@ class _FirstLoadRaceScreenState extends State<FirstLoadRaceScreen> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    _live = this;
+  }
+
+  @override
+  void dispose() {
+    if (identical(_live, this)) _live = null;
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text('First-Load Race Stress')),
@@ -268,3 +284,9 @@ class _FirstLoadRaceScreenState extends State<FirstLoadRaceScreen> {
     );
   }
 }
+
+/// Debug hook — invoke from the VM service / flutter run console:
+///   debugRunHeadlessStress()
+Future<void> debugRunHeadlessStress() =>
+    _FirstLoadRaceScreenState._live?._runHeadlessStress() ??
+    Future.error('FirstLoadRaceScreen not open');

--- a/zikzak_inappwebview/example/lib/first_load_race.screen.dart
+++ b/zikzak_inappwebview/example/lib/first_load_race.screen.dart
@@ -1,0 +1,270 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+
+import 'main.dart';
+
+/// First-load race stress demo.
+///
+/// Reproduces the exact scenario that used to fail: a consumer creates a
+/// fresh headless WebView and issues its FIRST real loadUrl immediately
+/// after run() completes — the navigation WKWebView can silently drop while
+/// its content process is still booting. With the readiness gate (run()
+/// completes only after the initial navigation reaches a terminal state)
+/// every attempt must succeed.
+///
+/// The per-attempt timeouts below are TEST HARNESS measurement bounds so the
+/// demo reports hangs instead of hanging forever — they are not part of the
+/// fix and contain no logic the plugin relies on.
+class FirstLoadRaceScreen extends StatefulWidget {
+  const FirstLoadRaceScreen({super.key});
+
+  @override
+  State<FirstLoadRaceScreen> createState() => _FirstLoadRaceScreenState();
+}
+
+class _FirstLoadRaceScreenState extends State<FirstLoadRaceScreen> {
+  static const targetUrl = 'https://example.com';
+  static const marker = 'Example Domain';
+
+  final List<String> _headlessLog = [];
+  final List<String> _visibleLog = [];
+  bool _headlessRunning = false;
+  bool _visibleRunning = false;
+  int _visibleRun = 0;
+
+  String? _visibleHtml;
+  String? _visibleLoadStopUrl;
+  final _visibleLoadStopCompleters = <Completer<String?>>[];
+
+  void _log(List<String> log, String line) {
+    log.insert(0, line);
+    if (log.length > 60) log.removeLast();
+  }
+
+  // ═══════════════════════ HEADLESS STRESS ═══════════════════════
+
+  Future<void> _runHeadlessStress() async {
+    if (_headlessRunning) return;
+    setState(() {
+      _headlessRunning = true;
+      _headlessLog.clear();
+    });
+
+    const attempts = 10;
+    var passed = 0;
+
+    for (var i = 1; i <= attempts; i++) {
+      final attemptLog = <String>[];
+      final stopwatch = Stopwatch()..start();
+      HeadlessInAppWebView? webview;
+
+      try {
+        // 1. Fresh webview — the exact dart_web_scraper setup. onLoadStop
+        //    is constructor-only, so wire the completer before run().
+        final loadStop = Completer<String?>();
+        webview = HeadlessInAppWebView(
+          initialUrlRequest: URLRequest(url: WebUri('about:blank')),
+          initialSettings: InAppWebViewSettings(isInspectable: kDebugMode),
+          onLoadStop: (c, url) {
+            if (!loadStop.isCompleted) loadStop.complete(url?.toString());
+          },
+        );
+
+        // 2. run() — with the gate this only completes when the web
+        //    process is ready; without it, returns immediately.
+        await webview.run().timeout(
+              const Duration(seconds: 15),
+              onTimeout: () => throw TimeoutException('run() HUNG'),
+            );
+        final runMs = stopwatch.elapsedMilliseconds;
+        attemptLog.add('run(): ${runMs}ms');
+
+        final controller = webview.webViewController!;
+
+        // 3. IMMEDIATELY issue the first real navigation.
+        await controller.loadUrl(urlRequest: URLRequest(url: WebUri(targetUrl)));
+        final stopUrl = await loadStop.future.timeout(
+              const Duration(seconds: 15),
+              onTimeout: () => throw TimeoutException('onLoadStop never fired'),
+            );
+        attemptLog.add('onLoadStop: ${stopwatch.elapsedMilliseconds}ms ($stopUrl)');
+
+        // 4. Verify content actually rendered.
+        final html = await controller.getHtml().timeout(
+              const Duration(seconds: 15),
+              onTimeout: () => throw TimeoutException('getHtml() HUNG'),
+            );
+        final ok = (html ?? '').contains(marker);
+        attemptLog.add('html: ${(html ?? '').length} chars, marker=$ok');
+        if (ok) passed++;
+        attemptLog.add(ok ? '✅ PASS' : '❌ FAIL (content mismatch)');
+      } catch (e) {
+        attemptLog.add('❌ FAIL: $e');
+      } finally {
+        try {
+          await webview?.dispose();
+        } catch (_) {}
+      }
+
+      _log(_headlessLog, '── attempt $i/$attempts ──');
+      for (final line in attemptLog.reversed) {
+        _log(_headlessLog, '   $line');
+      }
+      if (mounted) setState(() {});
+    }
+
+    _log(_headlessLog, '══════ RESULT: $passed/$attempts passed ══════');
+    setState(() {
+      _headlessRunning = false;
+    });
+  }
+
+  // ═══════════════════════ VISIBLE STRESS ═══════════════════════
+
+  Future<void> _runVisible() async {
+    if (_visibleRunning) return;
+    setState(() {
+      _visibleRunning = true;
+      _visibleRun++;
+      _visibleHtml = null;
+      _visibleLoadStopUrl = null;
+    });
+    _log(_visibleLog, '── run #$_visibleRun: fresh widget, immediate loadUrl ──');
+  }
+
+  void _onVisibleWebViewCreated(InAppWebViewController controller) async {
+    // The latent race: navigate IMMEDIATELY from the creation callback,
+    // before the web process is guaranteed to be up.
+    _log(_visibleLog, '   onWebViewCreated → loadUrl($targetUrl)');
+    final completer = Completer<String?>();
+    _visibleLoadStopCompleters.add(completer);
+    try {
+      await controller.loadUrl(urlRequest: URLRequest(url: WebUri(targetUrl)));
+      final stopUrl = await completer.future.timeout(
+            const Duration(seconds: 15),
+            onTimeout: () => throw TimeoutException('onLoadStop never fired'),
+          );
+      final html = await controller.getHtml().timeout(
+            const Duration(seconds: 15),
+            onTimeout: () => throw TimeoutException('getHtml() HUNG'),
+          );
+      final ok = (html ?? '').contains(marker);
+      _log(
+        _visibleLog,
+        '   onLoadStop: $stopUrl · html: ${(html ?? "").length} chars · marker=$ok '
+        '→ ${ok ? '✅ PASS' : '❌ FAIL'}',
+      );
+      if (mounted) {
+        setState(() {
+          _visibleLoadStopUrl = stopUrl;
+          _visibleHtml = html;
+          _visibleRunning = false;
+        });
+      }
+    } catch (e) {
+      _log(_visibleLog, '   ❌ FAIL: $e');
+      if (mounted) setState(() => _visibleRunning = false);
+    }
+  }
+
+  void _onVisibleLoadStop(InAppWebViewController controller, WebUri? url) {
+    final value = url?.toString();
+    for (final c in _visibleLoadStopCompleters) {
+      if (!c.isCompleted) c.complete(value);
+    }
+    _visibleLoadStopCompleters.clear();
+    if (mounted) {
+      setState(() => _visibleLoadStopUrl = value);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('First-Load Race Stress')),
+      drawer: myDrawer(context: context),
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            Text(
+              'Target: $targetUrl (marker: "$marker")\n'
+              'Headless: 10 × fresh webview, run() → IMMEDIATE loadUrl. '
+              'Visible: loadUrl from onWebViewCreated.',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              onPressed: _headlessRunning ? null : _runHeadlessStress,
+              icon: _headlessRunning
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.play_arrow),
+              label: const Text('Run Headless Stress (10× fresh webviews)'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              onPressed: _visibleRunning ? null : _runVisible,
+              icon: const Icon(Icons.visibility),
+              label: const Text('Run Visible WebView Stress (fresh widget)'),
+            ),
+            const SizedBox(height: 16),
+            // Visible webview instance — recreated on each run via key.
+            if (_visibleRun > 0)
+              SizedBox(
+                height: 260,
+                child: InAppWebView(
+                  key: ValueKey('visible-run-$_visibleRun'),
+                  initialUrlRequest:
+                      URLRequest(url: WebUri('about:blank')),
+                  initialSettings: InAppWebViewSettings(
+                    isInspectable: kDebugMode,
+                  ),
+                  onWebViewCreated: _onVisibleWebViewCreated,
+                  onLoadStop: _onVisibleLoadStop,
+                ),
+              ),
+            if (_visibleHtml != null) ...[
+              const SizedBox(height: 8),
+              Text(
+                'Visible last result: $_visibleLoadStopUrl\n'
+                'html ${_visibleHtml!.length} chars · '
+                'marker=${_visibleHtml!.contains(marker)}',
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+              ),
+            ],
+            const SizedBox(height: 16),
+            const Divider(),
+            const Text(
+              'HEADLESS LOG',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            ..._headlessLog.map(
+              (l) => Text(
+                l,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+              ),
+            ),
+            const Divider(),
+            const Text(
+              'VISIBLE LOG',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            ..._visibleLog.map(
+              (l) => Text(
+                l,
+                style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/zikzak_inappwebview/example/lib/main.dart
+++ b/zikzak_inappwebview/example/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
 
 import 'package:zikzak_inappwebview_example/chrome_safari_browser_example.screen.dart';
+import 'package:zikzak_inappwebview_example/first_load_race.screen.dart';
 import 'package:zikzak_inappwebview_example/headless_in_app_webview.screen.dart';
 import 'package:zikzak_inappwebview_example/in_app_webiew_example.screen.dart';
 import 'package:zikzak_inappwebview_example/in_app_webview_edge_to_edge.screen.dart';
@@ -72,6 +73,12 @@ PointerInterceptor myDrawer({required BuildContext context}) {
       title: const Text('HeadlessInAppWebView'),
       onTap: () {
         Navigator.pushReplacementNamed(context, '/HeadlessInAppWebView');
+      },
+    ),
+    ListTile(
+      title: const Text('First-Load Race Stress'),
+      onTap: () {
+        Navigator.pushReplacementNamed(context, '/FirstLoadRace');
       },
     ),
   ];
@@ -239,6 +246,7 @@ class _MyAppState extends State<MyApp> {
         '/ChromeSafariBrowser': (context) => ChromeSafariBrowserExampleScreen(),
         '/HeadlessInAppWebView': (context) =>
             const HeadlessInAppWebViewExampleScreen(),
+        '/FirstLoadRace': (context) => const FirstLoadRaceScreen(),
       },
     );
   }

--- a/zikzak_inappwebview/example/pubspec.lock
+++ b/zikzak_inappwebview/example/pubspec.lock
@@ -578,71 +578,63 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.8.0"
+    version: "4.9.0"
   zikzak_inappwebview_android:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_android
-      sha256: "8e8895245cef577d8f95262b62d3ee9632e7ce6ee5d2374863d5170e1c9a2607"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_android"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_internal_annotations:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_internal_annotations
-      sha256: "29e80af0edf370fa76a26ed263d70b387f9bbfac6e46c99fe2e8ec6062ca7839"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_internal_annotations"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_ios:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_ios
-      sha256: "7f0e7492720a38695a38e670c1c949c22b220cc1fcaea040abf2adf07c7fe135"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_ios"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_linux:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_linux
-      sha256: c510cf62422246bf5fd6be6eda9e9a432f968d6dbe028d9f89a3cbe9d59dc417
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_linux"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_macos:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_macos
-      sha256: "1cc4b581fb9f213070ebc8864e8442f5c4b88a1bbeba3484b15180f394d351dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_macos"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_platform_interface
-      sha256: d05452b522844763892fbea84e4390d11d19407714d92cdc62dedb6082935568
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_platform_interface"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_web:
     dependency: "direct main"
     description:
-      name: zikzak_inappwebview_web
-      sha256: d155b4df9512a0111d6435d7a90a08e027c542a34a7fc07c86f173d07d9e5afd
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_web"
+      relative: true
+    source: path
+    version: "4.9.0"
   zikzak_inappwebview_windows:
     dependency: transitive
     description:
-      name: zikzak_inappwebview_windows
-      sha256: ea1b21f79d8b7d495b7ac4d32e5ceebb33831f9557f6a1d6f35706c6d3d8acf4
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.8.0"
+      path: "../../zikzak_inappwebview_windows"
+      relative: true
+    source: path
+    version: "4.9.0"
 sdks:
   dart: ">=3.12.2 <4.0.0"
   flutter: ">=3.44.0"

--- a/zikzak_inappwebview/example/pubspec.yaml
+++ b/zikzak_inappwebview/example/pubspec.yaml
@@ -38,8 +38,10 @@ dependencies:
   url_launcher: ^6.2.0
   zikzak_inappwebview:
     path: ../
-  zikzak_inappwebview_platform_interface: ^4.9.0
-  zikzak_inappwebview_web: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_web:
+    path: ../../zikzak_inappwebview_web
 
 dev_dependencies:
   integration_test:

--- a/zikzak_inappwebview/example/pubspec.yaml
+++ b/zikzak_inappwebview/example/pubspec.yaml
@@ -38,8 +38,8 @@ dependencies:
   url_launcher: ^6.2.0
   zikzak_inappwebview:
     path: ../
-  zikzak_inappwebview_platform_interface: ^4.8.0
-  zikzak_inappwebview_web: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_web: ^4.9.0
 
 dev_dependencies:
   integration_test:

--- a/zikzak_inappwebview/pubspec.yaml
+++ b/zikzak_inappwebview/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview
 description: A Flutter plugin that allows you to add an inline webview, to use an headless webview, and to open an in-app browser window.
-version: 4.8.0
+version: 4.9.0
 homepage: https://arrrrny.github.io/zikzak_inappwebview
 repository: https://github.com/arrrrny/zikzak_inappwebview
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues
@@ -18,13 +18,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
-  zikzak_inappwebview_android: ^4.8.0
-  zikzak_inappwebview_ios: ^4.8.0
-  zikzak_inappwebview_macos: ^4.8.0
-  zikzak_inappwebview_web: ^4.8.0
-  zikzak_inappwebview_windows: ^4.8.0
-  zikzak_inappwebview_linux: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_android: ^4.9.0
+  zikzak_inappwebview_ios: ^4.9.0
+  zikzak_inappwebview_macos: ^4.9.0
+  zikzak_inappwebview_web: ^4.9.0
+  zikzak_inappwebview_windows: ^4.9.0
+  zikzak_inappwebview_linux: ^4.9.0
   synchronized: ^3.4.1
 
 dev_dependencies:

--- a/zikzak_inappwebview/pubspec.yaml
+++ b/zikzak_inappwebview/pubspec.yaml
@@ -18,13 +18,20 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
-  zikzak_inappwebview_android: ^4.9.0
-  zikzak_inappwebview_ios: ^4.9.0
-  zikzak_inappwebview_macos: ^4.9.0
-  zikzak_inappwebview_web: ^4.9.0
-  zikzak_inappwebview_windows: ^4.9.0
-  zikzak_inappwebview_linux: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_android:
+    path: ../zikzak_inappwebview_android
+  zikzak_inappwebview_ios:
+    path: ../zikzak_inappwebview_ios
+  zikzak_inappwebview_macos:
+    path: ../zikzak_inappwebview_macos
+  zikzak_inappwebview_web:
+    path: ../zikzak_inappwebview_web
+  zikzak_inappwebview_windows:
+    path: ../zikzak_inappwebview_windows
+  zikzak_inappwebview_linux:
+    path: ../zikzak_inappwebview_linux
   synchronized: ^3.4.1
 
 dev_dependencies:

--- a/zikzak_inappwebview_android/CHANGELOG.md
+++ b/zikzak_inappwebview_android/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/headless_in_app_webview/HeadlessInAppWebViewManager.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/headless_in_app_webview/HeadlessInAppWebViewManager.java
@@ -59,17 +59,19 @@ public class HeadlessInAppWebViewManager extends ChannelDelegateImpl {
       case "run":
         {
           HashMap<String, Object> params = (HashMap<String, Object>) call.argument("params");
-          run(id, params);
+          run(id, params, () -> result.success(true));
         }
-        result.success(true);
         break;
       default:
         result.notImplemented();
     }
   }
 
-  public void run(String id, HashMap<String, Object> params) {
-    if (plugin == null || (plugin.activity == null && plugin.applicationContext == null)) return;
+  public void run(String id, HashMap<String, Object> params, Runnable completion) {
+    if (plugin == null || (plugin.activity == null && plugin.applicationContext == null)) {
+      completion.run();
+      return;
+    }
     Context context = plugin.activity;
     if (context == null) {
       context = plugin.applicationContext;
@@ -80,6 +82,32 @@ public class HeadlessInAppWebViewManager extends ChannelDelegateImpl {
 
     headlessInAppWebView.prepare(params);
     headlessInAppWebView.onWebViewCreated();
+
+    // Readiness gate: completes run() only after the initial navigation
+    // reaches a terminal state (onPageFinished or a main-frame error). This
+    // guarantees the webview / renderer is up before a consumer issues its
+    // first real loadUrl. Signal-driven on purpose: no timeout constant — a
+    // missing terminal event is a wiring bug that must surface loudly, not be
+    // masked by a magic number.
+    if (flutterWebView.webView == null) {
+      completion.run();
+      return;
+    }
+    // Nothing to wait for if no initial load was requested.
+    if (params.get("initialUrlRequest") == null
+        && params.get("initialFile") == null
+        && params.get("initialData") == null) {
+      completion.run();
+      return;
+    }
+    final boolean[] gateFired = {false};
+    flutterWebView.webView.firstNavigationCompleted = () -> {
+      if (gateFired[0]) return;
+      gateFired[0] = true;
+      flutterWebView.webView.firstNavigationCompleted = null;
+      completion.run();
+    };
+
     flutterWebView.makeInitialLoad(params);
   }
 

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -162,6 +162,15 @@ public final class InAppWebView
     @Nullable
     public JavaScriptBridgeInterface javaScriptBridgeInterface;
 
+    /// One-shot callback fired on the FIRST terminal navigation event
+    /// (`onPageFinished` or a main-frame `onReceivedError`). Used by
+    /// `HeadlessInAppWebViewManager` to gate `run()` on webview readiness so
+    /// a consumer's first real `loadUrl` is never issued while the webview /
+    /// renderer is still starting up. `null` by default — no effect on
+    /// regular web views.
+    @Nullable
+    public Runnable firstNavigationCompleted;
+
     public InAppWebViewSettings customSettings = new InAppWebViewSettings();
     public boolean isLoading = false;
     private boolean inFullscreen = false;

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebViewClient.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebViewClient.java
@@ -465,6 +465,10 @@ public class InAppWebViewClient extends WebViewClient {
         if (webView.channelDelegate != null) {
             webView.channelDelegate.onLoadStop(url);
         }
+
+        if (webView.firstNavigationCompleted != null) {
+            webView.firstNavigationCompleted.run();
+        }
     }
 
     @Override
@@ -522,6 +526,10 @@ public class InAppWebViewClient extends WebViewClient {
                 WebResourceErrorExt.fromWebResourceError(error)
             );
         }
+
+        if (request.isForMainFrame() && webView.firstNavigationCompleted != null) {
+            webView.firstNavigationCompleted.run();
+        }
     }
 
     @SuppressLint("RestrictedApi")
@@ -569,6 +577,11 @@ public class InAppWebViewClient extends WebViewClient {
 
         if (webView.channelDelegate != null) {
             webView.channelDelegate.onReceivedError(request, error);
+        }
+
+        // Deprecated overload: always a main-frame error.
+        if (webView.firstNavigationCompleted != null) {
+            webView.firstNavigationCompleted.run();
         }
 
         super.onReceivedError(view, errorCode, description, failingUrl);

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebViewClientCompat.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebViewClientCompat.java
@@ -317,6 +317,10 @@ public class InAppWebViewClientCompat extends WebViewClientCompat {
             inAppBrowserDelegate.didFinishNavigation(url);
         }
 
+        if (webView.firstNavigationCompleted != null) {
+            webView.firstNavigationCompleted.run();
+        }
+
         // WebView not storing cookies reliable to local device storage
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             CookieManager.getInstance().flush();
@@ -408,6 +412,10 @@ public class InAppWebViewClientCompat extends WebViewClientCompat {
                 WebResourceErrorExt.fromWebResourceError(error)
             );
         }
+
+        if (request.isForMainFrame() && webView.firstNavigationCompleted != null) {
+            webView.firstNavigationCompleted.run();
+        }
     }
 
     @SuppressLint("RestrictedApi")
@@ -455,6 +463,11 @@ public class InAppWebViewClientCompat extends WebViewClientCompat {
 
         if (webView.channelDelegate != null) {
             webView.channelDelegate.onReceivedError(request, error);
+        }
+
+        // Deprecated overload: always a main-frame error.
+        if (webView.firstNavigationCompleted != null) {
+            webView.firstNavigationCompleted.run();
         }
 
         super.onReceivedError(view, errorCode, description, failingUrl);

--- a/zikzak_inappwebview_android/pubspec.yaml
+++ b/zikzak_inappwebview_android/pubspec.yaml
@@ -18,7 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_android/pubspec.yaml
+++ b/zikzak_inappwebview_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_android
 description: Android implementation of the zikzak_inappwebview plugin.
-version: 4.8.0
+version: 4.9.0
 homepage: https://inappwebview.dev/
 repository: https://github.com/arrrrny/zikzak_inappwebview/tree/master/zikzak_inappwebview_android
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_internal_annotations/CHANGELOG.md
+++ b/zikzak_inappwebview_internal_annotations/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_internal_annotations/pubspec.yaml
+++ b/zikzak_inappwebview_internal_annotations/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_internal_annotations
 description: Internal annotations used by the generator of zikzak_inappwebview plugin
-version: 4.8.0
+version: 4.9.0
 homepage: https://github.com/arrrrny/zikzak_inappwebview
 
 environment:

--- a/zikzak_inappwebview_ios/CHANGELOG.md
+++ b/zikzak_inappwebview_ios/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/HeadlessInAppWebView/HeadlessInAppWebViewManager.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/HeadlessInAppWebView/HeadlessInAppWebViewManager.swift
@@ -30,8 +30,9 @@ public class HeadlessInAppWebViewManager: ChannelDelegate {
         switch call.method {
             case "run":
                 let params = arguments!["params"] as! [String: Any?]
-                run(id: id, params: params)
-                result(true)
+                run(id: id, params: params) {
+                    result(true)
+                }
                 break
             default:
                 result(FlutterMethodNotImplemented)
@@ -39,8 +40,9 @@ public class HeadlessInAppWebViewManager: ChannelDelegate {
         }
     }
 
-    public func run(id: String, params: [String: Any?]) {
+    public func run(id: String, params: [String: Any?], completion: @escaping () -> Void) {
         guard let plugin = plugin else {
+            completion()
             return
         }
         let flutterWebView = FlutterWebViewController(plugin: plugin,
@@ -52,6 +54,26 @@ public class HeadlessInAppWebViewManager: ChannelDelegate {
 
         headlessInAppWebView.prepare(params: params as NSDictionary)
         headlessInAppWebView.onWebViewCreated()
+
+        // Readiness gate: WKWebView can silently DROP a navigation issued
+        // while its content process is still booting (the initial about:blank
+        // load from makeInitialLoad is in flight and the web process is
+        // spawning). A consumer calling loadUrl immediately after run()
+        // would see the first real navigation never start — no didStart,
+        // no didFinish — and would only discover it via its own timeout.
+        // So run() completes only after the initial navigation reaches a
+        // terminal state (didFinish or didFail). Signal-driven on purpose:
+        // no timeout constant — if no terminal event ever fires, that is a
+        // wiring bug that must surface loudly, not be masked by a magic number.
+        let webView = flutterWebView.webView()
+        var gateFired = false
+        webView?.firstNavigationCompleted = { [weak webView] in
+            guard !gateFired else { return }
+            gateFired = true
+            webView?.firstNavigationCompleted = nil
+            completion()
+        }
+
         flutterWebView.makeInitialLoad(params: params as NSDictionary)
     }
 

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/HeadlessInAppWebView/HeadlessInAppWebViewManager.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/HeadlessInAppWebView/HeadlessInAppWebViewManager.swift
@@ -65,9 +65,14 @@ public class HeadlessInAppWebViewManager: ChannelDelegate {
         // terminal state (didFinish or didFail). Signal-driven on purpose:
         // no timeout constant — if no terminal event ever fires, that is a
         // wiring bug that must surface loudly, not be masked by a magic number.
-        let webView = flutterWebView.webView()
+        guard let webView = flutterWebView.webView() else {
+            // No web view — fail run() immediately instead of leaving the
+            // readiness gate unarmed and the caller hanging forever.
+            completion()
+            return
+        }
         var gateFired = false
-        webView?.firstNavigationCompleted = { [weak webView] in
+        webView.firstNavigationCompleted = { [weak webView] in
             guard !gateFired else { return }
             gateFired = true
             webView?.firstNavigationCompleted = nil

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -34,6 +34,15 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     var preventGestureDelay = false
     private var isDisposed = false
 
+    /// One-shot callback fired on the FIRST terminal navigation event
+    /// (`didFinish` or `didFail`). Used by `HeadlessInAppWebViewManager` to
+    /// gate `run()` on web-process readiness so a consumer's first real
+    /// `loadUrl` is never issued while WKWebView is still booting its content
+    /// process (which can silently drop the navigation). `nil` by default —
+    /// no effect on regular web views.
+    var firstNavigationCompleted: (() -> Void)?
+
+
     private static var sslCertificatesMap: [String: SslCertificate] = [:]  // [URL host name : SslCertificate]
     private static var credentialsProposed: [URLCredential] = []
 
@@ -2384,6 +2393,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         channelDelegate?.onLoadStop(url: url?.absoluteString)
 
         inAppBrowserDelegate?.didFinishNavigation(url: url)
+
+        firstNavigationCompleted?()
     }
 
     public func webView(
@@ -2427,6 +2438,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         channelDelegate?.onReceivedError(request: webResourceRequest, error: webResourceError)
 
         inAppBrowserDelegate?.didFailNavigation(url: url, error: error)
+
+        firstNavigationCompleted?()
     }
 
     public func webView(

--- a/zikzak_inappwebview_ios/pubspec.yaml
+++ b/zikzak_inappwebview_ios/pubspec.yaml
@@ -18,7 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_ios/pubspec.yaml
+++ b/zikzak_inappwebview_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_ios
 description: iOS implementation of the zikzak_inappwebview plugin.
-version: 4.8.0
+version: 4.9.0
 homepage: https://inappwebview.dev/
 repository: https://github.com/arrrrny/zikzak_inappwebview/tree/master/zikzak_inappwebview_ios
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_linux/CHANGELOG.md
+++ b/zikzak_inappwebview_linux/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_linux/example/pubspec.lock
+++ b/zikzak_inappwebview_linux/example/pubspec.lock
@@ -134,10 +134,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -150,10 +150,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -243,10 +243,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -277,21 +277,21 @@ packages:
       path: "../../zikzak_inappwebview_internal_annotations"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
   zikzak_inappwebview_linux:
     dependency: "direct main"
     description:
       path: ".."
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
       path: "../../zikzak_inappwebview_platform_interface"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
 sdks:
   dart: ">=3.10.8 <4.0.0"
   flutter: ">=3.38.6"

--- a/zikzak_inappwebview_linux/example/pubspec.yaml
+++ b/zikzak_inappwebview_linux/example/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  zikzak_inappwebview_platform_interface: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/zikzak_inappwebview_linux/example/pubspec.yaml
+++ b/zikzak_inappwebview_linux/example/pubspec.yaml
@@ -25,7 +25,8 @@ dependencies:
     # the parent directory to use the current plugin's version.
     path: ../
 
-  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../../zikzak_inappwebview_platform_interface
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/zikzak_inappwebview_linux/linux/in_app_webview.cc
+++ b/zikzak_inappwebview_linux/linux/in_app_webview.cc
@@ -25,6 +25,12 @@ struct _InAppWebView {
   uint8_t *buffer;
   int32_t width;
   int32_t height;
+
+  // One-shot readiness gate for the headless "run" flow (see
+  // in_app_webview_set_first_load_callback). NULL by default — no effect on
+  // regular web views.
+  InAppWebViewFirstLoadCallback first_load_callback;
+  gpointer first_load_callback_data;
 };
 
 G_DEFINE_TYPE(InAppWebView, in_app_webview, fl_pixel_buffer_texture_get_type())
@@ -313,7 +319,25 @@ static void on_load_changed(WebKitWebView *web_view, WebKitLoadEvent load_event,
     fl_method_channel_invoke_method(self->channel, "onLoadStop", args, nullptr,
                                     nullptr, nullptr);
     update_texture(self);
+
+    // One-shot readiness gate: fire and disarm. WEBKIT_LOAD_FINISHED is the
+    // terminal load event (WebKitGTK emits it for both success and failure),
+    // and its arrival proves the web process handled the load.
+    if (self->first_load_callback) {
+      InAppWebViewFirstLoadCallback callback = self->first_load_callback;
+      gpointer data = self->first_load_callback_data;
+      self->first_load_callback = NULL;
+      self->first_load_callback_data = NULL;
+      callback(self, data);
+    }
   }
+}
+
+void in_app_webview_set_first_load_callback(InAppWebView *self,
+                                            InAppWebViewFirstLoadCallback callback,
+                                            gpointer user_data) {
+  self->first_load_callback = callback;
+  self->first_load_callback_data = user_data;
 }
 
 // ---------------- network capture support: JS bridge & events ----------------

--- a/zikzak_inappwebview_linux/linux/include/zikzak_inappwebview_linux/in_app_webview.h
+++ b/zikzak_inappwebview_linux/linux/include/zikzak_inappwebview_linux/in_app_webview.h
@@ -10,11 +10,23 @@ G_BEGIN_DECLS
 #define IN_APP_WEBVIEW_TYPE (in_app_webview_get_type())
 G_DECLARE_FINAL_TYPE(InAppWebView, in_app_webview, IN_APP, WEBVIEW, FlPixelBufferTexture)
 
+/// Fired once when the FIRST load reaches a terminal state
+/// (WEBKIT_LOAD_FINISHED, which WebKitGTK emits for both success and
+/// failure). Used by the headless "run" handler to gate on webview
+/// readiness — see in_app_webview_set_first_load_callback.
+typedef void (*InAppWebViewFirstLoadCallback)(InAppWebView *self, gpointer user_data);
+
 InAppWebView* in_app_webview_new(FlBinaryMessenger* messenger, FlTextureRegistrar* texture_registrar, const char* id);
 
 // Registers initial user scripts and loads the initial URL/data from
 // the "params" argument map of the create/run channel calls.
 void in_app_webview_load_initial(InAppWebView* self, FlValue* params);
+
+/// Arms a one-shot callback fired on the first terminal load event.
+/// Set to NULL (or invoked) after firing; NULL by default.
+void in_app_webview_set_first_load_callback(InAppWebView* self,
+                                            InAppWebViewFirstLoadCallback callback,
+                                            gpointer user_data);
 int64_t in_app_webview_get_texture_id(InAppWebView* self);
 void in_app_webview_handle_method_call(InAppWebView* self, FlMethodCall* method_call);
 

--- a/zikzak_inappwebview_linux/linux/zikzak_inappwebview_linux_plugin.cc
+++ b/zikzak_inappwebview_linux/linux/zikzak_inappwebview_linux_plugin.cc
@@ -67,12 +67,23 @@ static void zikzak_inappwebview_linux_plugin_handle_method_call(
   fl_method_call_respond(method_call, response, nullptr);
 }
 
+static void headless_first_load_finished(InAppWebView *webview, gpointer user_data) {
+  FlMethodCall *method_call = FL_METHOD_CALL(user_data);
+  g_autoptr(FlMethodResponse) response = FL_METHOD_RESPONSE(
+      fl_method_success_response_new(fl_value_new_bool(true)));
+  fl_method_call_respond(method_call, response, nullptr);
+  g_object_unref(method_call);
+}
+
 static void headless_method_call_cb(FlMethodChannel *channel,
                                     FlMethodCall *method_call,
                                     gpointer user_data) {
   ZikzakInappwebviewLinuxPlugin *self =
       ZIKZAK_INAPPWEBVIEW_LINUX_PLUGIN(user_data);
   g_autoptr(FlMethodResponse) response = nullptr;
+  // When the readiness gate defers the response, the shared respond tail
+  // must be skipped — the callback owns the FlMethodCall response.
+  gboolean deferred = FALSE;
 
   const gchar *method = fl_method_call_get_name(method_call);
   FlValue *args = fl_method_call_get_args(method_call);
@@ -85,8 +96,31 @@ static void headless_method_call_cb(FlMethodChannel *channel,
         InAppWebView *webview =
             in_app_webview_new(self->messenger, self->texture_registrar, id);
         g_hash_table_insert(self->web_views, g_strdup(id), webview);
-        in_app_webview_load_initial(webview,
-                                    fl_value_lookup_string(args, "params"));
+        FlValue *params = fl_value_lookup_string(args, "params");
+        // Readiness gate: complete run() only after the initial load reaches
+        // a terminal state (WEBKIT_LOAD_FINISHED). WebKitGTK's web process
+        // spawns asynchronously; a navigation issued while it is still
+        // starting can be dropped. Signal-driven on purpose: no timeout
+        // constant — a missing terminal event is a wiring bug that must
+        // surface loudly, not be masked by a magic number.
+        gboolean has_initial_load = false;
+        if (params != nullptr && fl_value_get_type(params) == FL_VALUE_TYPE_MAP) {
+          has_initial_load =
+              fl_value_lookup_string(params, "initialUrlRequest") != nullptr ||
+              fl_value_lookup_string(params, "initialFile") != nullptr ||
+              fl_value_lookup_string(params, "initialData") != nullptr;
+        }
+        if (has_initial_load) {
+          g_object_ref(method_call);
+          in_app_webview_set_first_load_callback(webview,
+                                                 headless_first_load_finished,
+                                                 method_call);
+          deferred = TRUE;
+        } else {
+          response = FL_METHOD_RESPONSE(
+              fl_method_success_response_new(fl_value_new_bool(true)));
+        }
+        in_app_webview_load_initial(webview, params);
         g_autofree gchar *channel_name =
             g_strdup_printf("wtf.zikzak/flutter_headless_inappwebview_%s", id);
         g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
@@ -94,8 +128,6 @@ static void headless_method_call_cb(FlMethodChannel *channel,
             self->messenger, channel_name, FL_METHOD_CODEC(codec));
         fl_method_channel_invoke_method(headless_channel, "onWebViewCreated",
                                         nullptr, nullptr, nullptr, nullptr);
-        response = FL_METHOD_RESPONSE(
-            fl_method_success_response_new(fl_value_new_bool(true)));
       }
     }
   } else if (strcmp(method, "createHeadless") == 0) {
@@ -116,6 +148,10 @@ static void headless_method_call_cb(FlMethodChannel *channel,
     }
   } else {
     response = FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
+  }
+
+  if (deferred) {
+    return;
   }
 
   if (!response) {

--- a/zikzak_inappwebview_linux/pubspec.yaml
+++ b/zikzak_inappwebview_linux/pubspec.yaml
@@ -18,8 +18,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
-  zikzak_inappwebview_internal_annotations: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
+  zikzak_inappwebview_internal_annotations:
+    path: ../zikzak_inappwebview_internal_annotations
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/zikzak_inappwebview_linux/pubspec.yaml
+++ b/zikzak_inappwebview_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_linux
 description: Linux implementation of the zikzak_inappwebview plugin.
-version: 4.8.0
+version: 4.9.0
 homepage: https://inappwebview.dev/
 repository: https://github.com/arrrrny/zikzak_inappwebview/tree/master/zikzak_inappwebview_linux
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues
@@ -18,8 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
-  zikzak_inappwebview_internal_annotations: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_internal_annotations: ^4.9.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/HeadlessInAppWebView/HeadlessInAppWebViewManager.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/HeadlessInAppWebView/HeadlessInAppWebViewManager.swift
@@ -20,8 +20,9 @@ public class HeadlessInAppWebViewManager: NSObject {
         switch call.method {
             case "run":
                 let params = arguments?["params"] as? [String: Any]
-                run(id: id!, params: params!)
-                result(true)
+                run(id: id!, params: params!) {
+                    result(true)
+                }
                 break
             case "dispose":
                 if let id = id {
@@ -37,15 +38,42 @@ public class HeadlessInAppWebViewManager: NSObject {
         }
     }
 
-    public func run(id: String, params: [String: Any]) {
+    public func run(id: String, params: [String: Any], completion: @escaping () -> Void) {
         let headlessInAppWebView = HeadlessInAppWebView(manager: self, registrar: registrar, id: id, params: params)
         if let oldHeadlessInAppWebView = webViews[id] {
              oldHeadlessInAppWebView?.dispose()
         }
         webViews[id] = headlessInAppWebView
-        
+
         headlessInAppWebView.prepare(params: params)
         headlessInAppWebView.onWebViewCreated()
+
+        // Readiness gate — same WKWebView process-boot race as iOS: a
+        // navigation issued while the content process is still starting can
+        // be silently dropped. The initial load is fired inside
+        // InAppWebView.init (synchronously, before this point), and its
+        // terminal event (didFinish / didFail) arrives on a later runloop
+        // turn, so arming the hook here still catches it. Signal-driven on
+        // purpose: no timeout constant — a missing terminal event is a wiring
+        // bug that must surface loudly, not be masked by a magic number.
+        // If no initial load was requested there is nothing to wait for —
+        // complete immediately.
+        // If no initial load was requested there is nothing to wait for —
+        // complete immediately.
+        guard params["initialUrlRequest"] != nil
+            || params["initialFile"] != nil
+            || params["initialData"] != nil,
+            let webView = headlessInAppWebView.webView else {
+            completion()
+            return
+        }
+        var gateFired = false
+        webView.firstNavigationCompleted = { [weak webView] in
+            guard !gateFired else { return }
+            gateFired = true
+            webView?.firstNavigationCompleted = nil
+            completion()
+        }
     }
     
     public func dispose(id: String) {

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -13,6 +13,14 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     var contextMenu: [String: Any]?
     var contextMenuIsShowing = false
 
+    /// One-shot callback fired on the FIRST terminal navigation event
+    /// (`didFinish` or any `didFail`/`didFailProvisionalNavigation`). Used by
+    /// `HeadlessInAppWebViewManager` to gate `run()` on web-process readiness
+    /// so a consumer's first real `loadUrl` is never issued while WKWebView is
+    /// still booting its content process (which can silently drop the
+    /// navigation). `nil` by default — no effect on regular web views.
+    var firstNavigationCompleted: (() -> Void)?
+
     /// Set by the WKUIDelegate when returning `nil` from
     /// `webView(_:contextMenuForElement:willDisplayWithHighlight:)` in the
     /// cases where we want to actually suppress the menu (not let WebKit
@@ -1671,6 +1679,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         InAppWebView.credentialsProposed = []
         channel?.invokeMethod("onLoadStop", arguments: ["url": webView.url?.absoluteString])
+        firstNavigationCompleted?()
     }
 
     public func webView(
@@ -1710,6 +1719,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         arguments["code"] = (error as NSError).code
         arguments["message"] = error.localizedDescription
         channel?.invokeMethod("onReceivedError", arguments: arguments)
+        firstNavigationCompleted?()
     }
     public func webView(
         _ webView: WKWebView, didReceive challenge: URLAuthenticationChallenge,

--- a/zikzak_inappwebview_macos/pubspec.lock
+++ b/zikzak_inappwebview_macos/pubspec.lock
@@ -103,10 +103,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -119,10 +119,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -188,10 +188,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -214,14 +214,14 @@ packages:
       path: "../zikzak_inappwebview_internal_annotations"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
       path: "../zikzak_inappwebview_platform_interface"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.38.6"

--- a/zikzak_inappwebview_macos/pubspec.yaml
+++ b/zikzak_inappwebview_macos/pubspec.yaml
@@ -18,7 +18,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_macos/pubspec.yaml
+++ b/zikzak_inappwebview_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_macos
 description: macOS implementation of the zikzak_inappwebview plugin.
-version: 4.8.0
+version: 4.9.0
 homepage: https://inappwebview.dev/
 repository: https://github.com/arrrrny/zikzak_inappwebview/tree/master/zikzak_inappwebview_macos
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues
@@ -18,7 +18,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
 
 dev_dependencies:
   flutter_test:

--- a/zikzak_inappwebview_platform_interface/CHANGELOG.md
+++ b/zikzak_inappwebview_platform_interface/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_platform_interface/pubspec.yaml
+++ b/zikzak_inappwebview_platform_interface/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  zikzak_inappwebview_internal_annotations: ^4.9.0
+  zikzak_inappwebview_internal_annotations:
+    path: ../zikzak_inappwebview_internal_annotations
 
   meta: ^1.15.0
 

--- a/zikzak_inappwebview_platform_interface/pubspec.yaml
+++ b/zikzak_inappwebview_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_platform_interface
 description: A common platform interface for the zikzak_inappwebview plugin.
-version: 4.8.0
+version: 4.9.0
 homepage: https://inappwebview.dev/
 repository: https://github.com/arrrrny/zikzak_inappwebview/tree/master/zikzak_inappwebview_platform_interface
 issue_tracker: https://github.com/arrrrny/zikzak_inappwebview/issues
@@ -19,7 +19,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  zikzak_inappwebview_internal_annotations: ^4.8.0
+  zikzak_inappwebview_internal_annotations: ^4.9.0
 
   meta: ^1.15.0
 

--- a/zikzak_inappwebview_web/CHANGELOG.md
+++ b/zikzak_inappwebview_web/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_web/pubspec.lock
+++ b/zikzak_inappwebview_web/pubspec.lock
@@ -227,14 +227,14 @@ packages:
       path: "../zikzak_inappwebview_internal_annotations"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
       path: "../zikzak_inappwebview_platform_interface"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
 sdks:
   dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.38.6"

--- a/zikzak_inappwebview_web/pubspec.yaml
+++ b/zikzak_inappwebview_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_web
 description: The web implementation of zikzak_inappwebview.
-version: 4.8.0
+version: 4.9.0
 homepage: https://github.com/arrrrny/zikzak_inappwebview
 
 environment:
@@ -20,7 +20,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
   web: ^1.1.1
 
 dev_dependencies:

--- a/zikzak_inappwebview_web/pubspec.yaml
+++ b/zikzak_inappwebview_web/pubspec.yaml
@@ -20,7 +20,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
   web: ^1.1.1
 
 dev_dependencies:

--- a/zikzak_inappwebview_windows/CHANGELOG.md
+++ b/zikzak_inappwebview_windows/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 4.9.0 - 2026-08-14
+
+
+### Features
+
+- Session recipe — record and replay user sessions in the WebView: JS
+  tap-listener injection, selector-candidate extraction, scripted click replay,
+  and recipe models (#216)
+- Navigation tracker — JS-assisted URL-cycle tracking through the webview (#216)
+- Dialogue dismisser — inject JS to auto-dismiss modal dialogs (#216)
+- Navigation guards — `keepNavigationInWebView` helper that keeps user-tapped
+  links inside the WebView, avoiding iOS universal-link handoff (#216)
+- [Windows] Virtual host name to folder mapping — CORS-safe serving of local
+  folders (CORS bypass for local resources) (#185)
+- [macOS] Popup windows — `window.open` / `target=_blank` now load their URL
+  via `WKUIDelegate createWebViewWith` off-screen-window support, reparented
+  into a Flutter platform view when `onCreateWindow` is handled (#182, #183, #187)
+
+### Fixes
+
+- [macOS] Popup window crash, settings key, and event delivery fixes (#187)
+- [macOS] Network Capture API callbacks never fired — JS bridge name aligned
+  with iOS/Android so `onNetworkRequest` / `onNetworkResponse` /
+  `onNetworkLoadingFinished` reach Dart (#182)
+- [Linux] Blue screen instead of webview — offscreen rendering via
+  `GtkOffscreenWindow` + software rendering, plus `openDevTools` support (#184)
+- [Linux] Native plugin compile regression — broken `takeScreenshot` string
+  literal and missing include path (#179)
+- Chore: renamed remaining `flutter_inappwebview` residuals to
+  `zikzak_inappwebview` (JS bridge name, method channel, platform view type id) (#186)
+- Chore: dependency bumps (npm deps, brace-expansion) (#189, #210)
 ## 4.8.0 - 2026-08-14
 
 

--- a/zikzak_inappwebview_windows/pubspec.lock
+++ b/zikzak_inappwebview_windows/pubspec.lock
@@ -167,10 +167,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -183,10 +183,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   objective_c:
     dependency: transitive
     description:
@@ -340,10 +340,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -398,14 +398,14 @@ packages:
       path: "../zikzak_inappwebview_internal_annotations"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
   zikzak_inappwebview_platform_interface:
     dependency: "direct main"
     description:
       path: "../zikzak_inappwebview_platform_interface"
       relative: true
     source: path
-    version: "4.7.0"
+    version: "4.9.0"
 sdks:
   dart: ">=3.10.3 <4.0.0"
   flutter: ">=3.38.6"

--- a/zikzak_inappwebview_windows/pubspec.yaml
+++ b/zikzak_inappwebview_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: zikzak_inappwebview_windows
 description: The Windows implementation of zikzak_inappwebview.
-version: 4.8.0
+version: 4.9.0
 homepage: https://github.com/arrrrny/zikzak_inappwebview
 
 environment:
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.8.0
+  zikzak_inappwebview_platform_interface: ^4.9.0
   webview_windows: ^0.4.0
   path: ^1.9.0
   path_provider: ^2.1.0

--- a/zikzak_inappwebview_windows/pubspec.yaml
+++ b/zikzak_inappwebview_windows/pubspec.yaml
@@ -18,7 +18,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  zikzak_inappwebview_platform_interface: ^4.9.0
+  zikzak_inappwebview_platform_interface:
+    path: ../zikzak_inappwebview_platform_interface
   webview_windows: ^0.4.0
   path: ^1.9.0
   path_provider: ^2.1.0


### PR DESCRIPTION
## Problem

The **very first** request through the headless WebView fails with `"Unable to fetch data"`; every subsequent request works.

Root cause: `HeadlessInAppWebView.run()` (iOS) returned immediately after firing the initial `about:blank` load (`makeInitialLoad` is fire-and-forget). WKWebView spawns its content process lazily on the first load, and a navigation issued **while that process is still booting can be silently dropped** — `didStartProvisionalNavigation`/`didFinish` never fire. Consumers that call `loadUrl` right after `await run()` therefore see their first real navigation swallowed and only discover it via their own request timeout.

## Fix

- `InAppWebView` gains a one-shot `firstNavigationCompleted` hook, fired on the first terminal navigation event (`didFinish` **or** `didFail`, which also covers `didFailProvisionalNavigation`). `nil` by default — zero impact on regular web views.
- `HeadlessInAppWebViewManager.run()` now completes the method-channel `result` only after that hook fires, so `await run()` guarantees the web content process is ready before any consumer issues its first `loadUrl`.

**No timeout constant was added** — the wait is purely signal-driven. If no terminal event ever fires, that is a delegate-wiring bug that should surface loudly, not be masked by a magic number. (The one-shot closure captures the web view weakly to avoid a retain cycle.)

## Verification

- `flutter build ios --simulator --no-codesign` on the plugin example: ✅ builds.
- Branch base: `master` (4.9.0 + dev-mode pubspec commit). `development` was verified to contain only the zorphy-migration phases beyond master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added session recording and replay, navigation tracking and guards, dialogue dismissal, Windows virtual-host folder mapping, and macOS popup-window support.
  * Improved headless WebView startup so results are reported after the first navigation succeeds or fails.
  * Added a first-load race stress-testing screen to the example app.

* **Bug Fixes**
  * Fixed macOS popup and network-capture issues, Linux rendering, developer-tools, and build problems, plus package naming inconsistencies.

* **Chores**
  * Released version 4.9.0 across supported packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->