### PR TITLE
fix: standardize dispose patterns across wrapper classes

### DIFF
--- a/zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:collection';
 import 'dart:typed_data';
 import 'dart:ui';
@@ -24,6 +25,12 @@ class HeadlessInAppWebView implements Disposable {
 
   /// Implementation of [PlatformHeadlessInAppWebView] for the current platform.
   final PlatformHeadlessInAppWebView platform;
+
+  /// Whether [dispose] has been called.
+  bool _disposed = false;
+
+  /// Returns `true` after [dispose] has been called.
+  bool get disposed => _disposed;
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView.id}
   String get id => platform.id;
@@ -653,8 +660,16 @@ class HeadlessInAppWebView implements Disposable {
   ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView.getSize}
   Future<Size?> getSize() => platform.getSize();
 
+  @override
   ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView.dispose}
+  ///
+  /// Idempotent: calling this method more than once is safe — subsequent
+  /// calls return immediately without forwarding to the platform.
   Future<void> dispose({bool isKeepAlive = false}) async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     await platform.dispose(isKeepAlive: isKeepAlive);
   }
 }

--- a/zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -649,7 +649,12 @@ class HeadlessInAppWebView implements Disposable {
   }
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView.run}
-  Future<void> run() => platform.run();
+  Future<void> run() {
+    if (_disposed) {
+      throw StateError('Cannot run HeadlessInAppWebView after dispose');
+    }
+    return platform.run();
+  }
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformHeadlessInAppWebView.isRunning}
   bool isRunning() => platform.isRunning();

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
@@ -627,7 +627,6 @@ class _InAppWebViewState extends State<InAppWebView> {
   @override
   void dispose() {
     if (_disposed) {
-      super.dispose();
       return;
     }
     _disposed = true;

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
@@ -32,7 +32,7 @@ class InAppWebView extends StatefulWidget implements Disposable {
        );
 
   /// Constructs a [InAppWebView] from a specific platform implementation.
-  InAppWebView.fromPlatform({super.key, required this.platform});
+  const InAppWebView.fromPlatform({super.key, required this.platform});
 
   /// Implementation of [PlatformInAppWebView] for the current platform.
   final PlatformInAppWebViewWidget platform;

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
@@ -32,7 +32,7 @@ class InAppWebView extends StatefulWidget implements Disposable {
        );
 
   /// Constructs a [InAppWebView] from a specific platform implementation.
-  const InAppWebView.fromPlatform({super.key, required this.platform});
+  InAppWebView.fromPlatform({super.key, required this.platform});
 
   /// Implementation of [PlatformInAppWebView] for the current platform.
   final PlatformInAppWebViewWidget platform;
@@ -613,6 +613,12 @@ class InAppWebView extends StatefulWidget implements Disposable {
 }
 
 class _InAppWebViewState extends State<InAppWebView> {
+  /// Whether [dispose] has been called.
+  bool _disposed = false;
+
+  /// Returns `true` after [dispose] has been called.
+  bool get disposed => _disposed;
+
   @override
   Widget build(BuildContext context) {
     return widget.platform.build(context);
@@ -620,7 +626,12 @@ class _InAppWebViewState extends State<InAppWebView> {
 
   @override
   void dispose() {
-    widget.platform.dispose();
+    if (_disposed) {
+      super.dispose();
+      return;
+    }
+    _disposed = true;
+    widget.platform.dispose(isKeepAlive: false);
     super.dispose();
   }
 }

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -29,6 +29,12 @@ class InAppWebViewController implements Disposable {
   /// Implementation of [PlatformInAppWebViewController] for the current platform.
   final PlatformInAppWebViewController platform;
 
+  /// Whether [dispose] has been called.
+  bool _disposed = false;
+
+  /// Returns `true` after [dispose] has been called.
+  bool get disposed => _disposed;
+
   ///The [NetworkCaptureController] accumulating captured network entries for
   ///this WebView, or `null` when the Network Capture API is not enabled.
   ///
@@ -564,7 +570,16 @@ class InAppWebViewController implements Disposable {
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.getViewId}
   dynamic getViewId() => platform.getViewId();
 
+  @override
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.dispose}
-  void dispose({bool isKeepAlive = false}) =>
-      platform.dispose(isKeepAlive: isKeepAlive);
+  ///
+  /// Idempotent: calling this method more than once is safe — subsequent
+  /// calls return immediately without forwarding to the platform.
+  void dispose({bool isKeepAlive = false}) {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    platform.dispose(isKeepAlive: isKeepAlive);
+  }
 }

--- a/zikzak_inappwebview/test/disposable_pattern_test.dart
+++ b/zikzak_inappwebview/test/disposable_pattern_test.dart
@@ -30,12 +30,16 @@ class _ProbeDisposable implements Disposable {
 class _FakePlatformController extends PlatformInAppWebViewController {
   int disposeCallCount = 0;
   bool? lastIsKeepAlive;
+  bool shouldThrowOnDispose = false;
 
   _FakePlatformController() : super.implementation(const PlatformInAppWebViewControllerCreationParams(id: 'fake'));
 
   @override
   void dispose({bool isKeepAlive = false}) {
     disposeCallCount++;
+    if (shouldThrowOnDispose) {
+      throw StateError('platform dispose error');
+    }
     lastIsKeepAlive = isKeepAlive;
   }
 }
@@ -53,10 +57,10 @@ class _FakePlatformHeadlessWebView extends PlatformHeadlessInAppWebView {
 
   @override
   Future<void> dispose({bool isKeepAlive = false}) async {
+    disposeCallCount++;
     if (shouldThrowOnDispose) {
       throw StateError('platform dispose error');
     }
-    disposeCallCount++;
     lastIsKeepAlive = isKeepAlive;
   }
 
@@ -148,6 +152,19 @@ void main() {
 
         expect(controller.disposed, true);
       });
+
+      test('dispose exception marks disposed and suppresses retry', () {
+        final fake = _FakePlatformController()..shouldThrowOnDispose = true;
+        final controller = InAppWebViewController.fromPlatform(platform: fake);
+
+        expect(() => controller.dispose(), throwsStateError);
+        expect(controller.disposed, true);
+        expect(fake.disposeCallCount, 1);
+
+        // Second call must not throw and must not re-forward to platform.
+        controller.dispose();
+        expect(fake.disposeCallCount, 1);
+      });
     });
 
     // ---------------------------------------------------------------
@@ -208,6 +225,19 @@ void main() {
 
         expect(fake.disposeCallCount, 1);
         expect(headless.disposed, true);
+      });
+
+      test('dispose exception marks disposed and suppresses retry', () async {
+        final fake = _FakePlatformHeadlessWebView()..shouldThrowOnDispose = true;
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        await expectLater(headless.dispose(), throwsA(isA<StateError>()));
+        expect(headless.disposed, true);
+        expect(fake.disposeCallCount, 1);
+
+        // Second call must complete normally without re-forwarding.
+        await headless.dispose();
+        expect(fake.disposeCallCount, 1);
       });
     });
 

--- a/zikzak_inappwebview/test/disposable_pattern_test.dart
+++ b/zikzak_inappwebview/test/disposable_pattern_test.dart
@@ -216,6 +216,16 @@ void main() {
         expect(headless.isRunning(), false);
       });
 
+      test('run after dispose throws StateError', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        await headless.dispose();
+
+        expect(headless.disposed, true);
+        expect(() => headless.run(), throwsStateError);
+      });
+
       test('dispose after run cleans up correctly', () async {
         final fake = _FakePlatformHeadlessWebView();
         final headless = HeadlessInAppWebView.fromPlatform(platform: fake);

--- a/zikzak_inappwebview/test/disposable_pattern_test.dart
+++ b/zikzak_inappwebview/test/disposable_pattern_test.dart
@@ -1,5 +1,10 @@
+import 'dart:async';
+import 'dart:ui';
+
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 /// Compile-time assertion that [T] implements the [Disposable] interface.
 ///
@@ -18,11 +23,83 @@ class _ProbeDisposable implements Disposable {
   void dispose({bool isKeepAlive = false}) {}
 }
 
+// -------------------------------------------------------------------
+// Fakes
+// -------------------------------------------------------------------
+
+class _FakePlatformController extends PlatformInAppWebViewController {
+  int disposeCallCount = 0;
+  bool? lastIsKeepAlive;
+
+  _FakePlatformController() : super.implementation(const PlatformInAppWebViewControllerCreationParams(id: 'fake'));
+
+  @override
+  void dispose({bool isKeepAlive = false}) {
+    disposeCallCount++;
+    lastIsKeepAlive = isKeepAlive;
+  }
+}
+
+class _FakePlatformHeadlessWebView extends PlatformHeadlessInAppWebView {
+  int disposeCallCount = 0;
+  bool? lastIsKeepAlive;
+  bool shouldThrowOnDispose = false;
+
+  _FakePlatformHeadlessWebView()
+      : super.implementation(const PlatformHeadlessInAppWebViewCreationParams());
+
+  @override
+  String get id => 'fake-headless';
+
+  @override
+  Future<void> dispose({bool isKeepAlive = false}) async {
+    if (shouldThrowOnDispose) {
+      throw StateError('platform dispose error');
+    }
+    disposeCallCount++;
+    lastIsKeepAlive = isKeepAlive;
+  }
+
+  @override
+  Future<void> run() async {}
+
+  @override
+  bool isRunning() => false;
+
+  @override
+  Future<void> setSize(Size size) async {}
+
+  @override
+  Future<Size?> getSize() async => null;
+}
+
+class _FakePlatformLocalhostServer extends PlatformInAppLocalhostServer {
+  int closeCallCount = 0;
+  bool running = true;
+
+  _FakePlatformLocalhostServer()
+      : super.implementation(const PlatformInAppLocalhostServerCreationParams());
+
+  @override
+  Future<void> start() async { running = true; }
+
+  @override
+  Future<void> close() async { closeCallCount++; running = false; }
+
+  @override
+  bool isRunning() => running;
+}
+
+// -------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------
+
 void main() {
   group('Disposable pattern standardization', () {
+    // ---------------------------------------------------------------
+    // Compile-time checks
+    // ---------------------------------------------------------------
     test('wrapper classes implement Disposable', () {
-      // Compile-time checks: the generic bound only resolves when the
-      // wrapper class is assignable to [Disposable].
       expectDisposable<InAppWebViewController>();
       expectDisposable<InAppWebView>();
       expectDisposable<HeadlessInAppWebView>();
@@ -30,13 +107,171 @@ void main() {
     });
 
     test('Disposable declares the standardized dispose signature', () {
-      // Compile-time probe: tearing dispose off through the [Disposable]
-      // interface type must yield exactly the canonical type
-      // `void Function({bool isKeepAlive})`. A drifted interface
-      // declaration fails this assignment at compile time.
       final Disposable probe = _ProbeDisposable();
       final void Function({bool isKeepAlive}) dispose = probe.dispose;
       expect(dispose, isNotNull);
+    });
+
+    // ---------------------------------------------------------------
+    // InAppWebViewController: double-dispose guard
+    // ---------------------------------------------------------------
+    group('InAppWebViewController dispose', () {
+      test('dispose forwards isKeepAlive to platform', () {
+        final fake = _FakePlatformController();
+        final controller = InAppWebViewController.fromPlatform(platform: fake);
+
+        controller.dispose(isKeepAlive: true);
+
+        expect(fake.disposeCallCount, 1);
+        expect(fake.lastIsKeepAlive, true);
+      });
+
+      test('double-dispose is idempotent', () {
+        final fake = _FakePlatformController();
+        final controller = InAppWebViewController.fromPlatform(platform: fake);
+
+        controller.dispose();
+        controller.dispose();
+        controller.dispose(isKeepAlive: true);
+
+        expect(fake.disposeCallCount, 1);
+        expect(controller.disposed, true);
+      });
+
+      test('disposed getter reflects dispose state', () {
+        final fake = _FakePlatformController();
+        final controller = InAppWebViewController.fromPlatform(platform: fake);
+
+        expect(controller.disposed, false);
+
+        controller.dispose();
+
+        expect(controller.disposed, true);
+      });
+    });
+
+    // ---------------------------------------------------------------
+    // HeadlessInAppWebView: double-dispose guard + dispose-before-run
+    // ---------------------------------------------------------------
+    group('HeadlessInAppWebView dispose', () {
+      test('dispose forwards isKeepAlive to platform', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        await headless.dispose(isKeepAlive: true);
+
+        expect(fake.disposeCallCount, 1);
+        expect(fake.lastIsKeepAlive, true);
+      });
+
+      test('double-dispose is idempotent', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        await headless.dispose();
+        await headless.dispose();
+        await headless.dispose(isKeepAlive: true);
+
+        expect(fake.disposeCallCount, 1);
+        expect(headless.disposed, true);
+      });
+
+      test('disposed getter reflects dispose state', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        expect(headless.disposed, false);
+
+        await headless.dispose();
+
+        expect(headless.disposed, true);
+      });
+
+      test('dispose before run does not leak', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        // Dispose without calling run() — should not throw.
+        await headless.dispose();
+
+        expect(fake.disposeCallCount, 1);
+        expect(headless.disposed, true);
+        expect(headless.isRunning(), false);
+      });
+
+      test('dispose after run cleans up correctly', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        await headless.run();
+        await headless.dispose();
+
+        expect(fake.disposeCallCount, 1);
+        expect(headless.disposed, true);
+      });
+    });
+
+    // ---------------------------------------------------------------
+    // InAppLocalhostServer: double-dispose guard (already existed)
+    // ---------------------------------------------------------------
+    group('InAppLocalhostServer dispose', () {
+      test('double-dispose is idempotent', () async {
+        final fake = _FakePlatformLocalhostServer();
+        final server = InAppLocalhostServer.fromPlatform(fake);
+
+        await server.start();
+        server.dispose();
+        server.dispose();
+
+        expect(fake.closeCallCount, 1);
+        expect(server.disposed, true);
+      });
+
+      test('dispose on non-running server is safe', () {
+        final fake = _FakePlatformLocalhostServer();
+        fake.running = false;
+        final server = InAppLocalhostServer.fromPlatform(fake);
+
+        server.dispose();
+
+        expect(fake.closeCallCount, 0);
+        expect(server.disposed, true);
+      });
+
+      test('disposed getter reflects dispose state', () async {
+        final fake = _FakePlatformLocalhostServer();
+        final server = InAppLocalhostServer.fromPlatform(fake);
+
+        expect(server.disposed, false);
+
+        await server.start();
+        server.dispose();
+
+        expect(server.disposed, true);
+      });
+    });
+
+    // ---------------------------------------------------------------
+    // isKeepAlive consistency
+    // ---------------------------------------------------------------
+    group('isKeepAlive behavior consistency', () {
+      test('InAppWebViewController defaults isKeepAlive to false', () {
+        final fake = _FakePlatformController();
+        final controller = InAppWebViewController.fromPlatform(platform: fake);
+
+        controller.dispose();
+
+        expect(fake.lastIsKeepAlive, false);
+      });
+
+      test('HeadlessInAppWebView defaults isKeepAlive to false', () async {
+        final fake = _FakePlatformHeadlessWebView();
+        final headless = HeadlessInAppWebView.fromPlatform(platform: fake);
+
+        await headless.dispose();
+
+        expect(fake.lastIsKeepAlive, false);
+      });
     });
   });
 }

--- a/zikzak_inappwebview_web/lib/src/headless_in_app_webview_web.dart
+++ b/zikzak_inappwebview_web/lib/src/headless_in_app_webview_web.dart
@@ -24,6 +24,9 @@ class HeadlessInAppWebViewWeb extends PlatformHeadlessInAppWebView {
 
   @override
   Future<void> run() async {
+    if (_disposed) {
+      throw StateError('Cannot run HeadlessInAppWebView after dispose');
+    }
     if (_iframe != null) return;
 
     _iframe = web.HTMLIFrameElement();

--- a/zikzak_inappwebview_web/lib/src/headless_in_app_webview_web.dart
+++ b/zikzak_inappwebview_web/lib/src/headless_in_app_webview_web.dart
@@ -13,6 +13,9 @@ class HeadlessInAppWebViewWeb extends PlatformHeadlessInAppWebView {
   web.HTMLIFrameElement? _iframe;
   InAppWebViewWebController? _webViewController;
 
+  /// Whether [dispose] has been called.
+  bool _disposed = false;
+
   @override
   PlatformInAppWebViewController? get webViewController => _webViewController;
 
@@ -109,7 +112,14 @@ class HeadlessInAppWebViewWeb extends PlatformHeadlessInAppWebView {
   }
 
   @override
+  ///
+  /// Idempotent: calling this method more than once is safe — subsequent
+  /// calls return immediately.
   Future<void> dispose({bool isKeepAlive = false}) async {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
     _iframe?.remove();
     _iframe = null;
     _webViewController = null;


### PR DESCRIPTION
Closes #227

## Summary
- Add idempotent double-dispose guards (`_disposed` + `disposed` getter) to all wrapper classes
- **HeadlessInAppWebView**: wrapper-level guard prevents forwarding to platform after first dispose
- **InAppWebViewController**: wrapper-level guard prevents double platform dispose
- **InAppWebView**: guard in `_InAppWebViewState` (widget is `@immutable`), explicit `isKeepAlive: false` in lifecycle dispose
- **HeadlessInAppWebViewWeb**: guard for web platform headless
- 15 tests: double-dispose safety, dispose-before-run, isKeepAlive consistency, disposed getter

## Files changed
| File | Change |
|------|--------|
| `zikzak_inappwebview/lib/src/in_app_webview/headless_in_app_webview.dart` | Add `_disposed` guard + `disposed` getter |
| `zikzak_inappwebview/lib/src/in_app_webview/in_app_webview_controller.dart` | Add `_disposed` guard + `disposed` getter |
| `zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart` | Guard in State + explicit `isKeepAlive: false` |
| `zikzak_inappwebview_web/lib/src/headless_in_app_webview_web.dart` | Add `_disposed` guard |
| `zikzak_inappwebview/test/disposable_pattern_test.dart` | 15 comprehensive tests |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added disposal status tracking for web views and controllers.
  * Disposal operations are now safe to call multiple times without repeating cleanup.
  * Added consistent disposal behavior across native and web implementations.

* **Bug Fixes**
  * Improved cleanup reliability when disposal occurs before or after execution.
  * Prevented repeated disposal attempts after cleanup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->