### PR TITLE
fix(platform_interface): apply review findings (wire maps + AndroidResource factories)

### DIFF
--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/attributed_string_text_effect_style.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/attributed_string_text_effect_style.dart
@@ -5,7 +5,10 @@ enum AttributedStringTextEffectStyle {
 }
 
 ///AttributedStringTextEffectStyle wire values are strings — lookup by value.
-const _attributedStringTextEffectStyle_wire = ['NONE', 'LETTERPRESS_STYLE'];
+///
+///Wire value matches the pre-migration `@ExchangeableEnum` codegen
+///(`letterpressStyle`), not the Dart enum name.
+const _attributedStringTextEffectStyle_wire = ['letterpressStyle'];
 
 AttributedStringTextEffectStyle? attributedStringTextEffectStyleFromWire(
   Object? value,

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/proxy_scheme_filter.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/proxy_scheme_filter.dart
@@ -11,7 +11,11 @@ enum ProxySchemeFilter {
 }
 
 ///ProxySchemeFilter wire values are strings — lookup by value.
-const _proxySchemeFilter_wire = ['http', 'https', 'ws', 'wss'];
+///
+///Wire values match the pre-migration `@ExchangeableEnum` codegen: the
+///wildcard for [ProxySchemeFilter.MATCH_ALL_SCHEMES] is `*`, and [http]/[https]
+///use the scheme names the platform channels emit.
+const _proxySchemeFilter_wire = ['*', 'http', 'https'];
 
 ProxySchemeFilter? proxySchemeFilterFromWire(Object? value) {
   if (value is! String) return null;

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/website_data_type.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/website_data_type.dart
@@ -36,10 +36,20 @@ enum WebsiteDataType {
 }
 
 ///WebsiteDataType wire values are strings — lookup by value.
+///
+///Wire values match the `WKWebsiteDataType*` constants the platform channels
+///emit (same strings as the pre-migration `@ExchangeableEnum` codegen).
 const _websiteDataType_wire = [
+  'WKWebsiteDataTypeFetchCache',
+  'WKWebsiteDataTypeDiskCache',
+  'WKWebsiteDataTypeMemoryCache',
+  'WKWebsiteDataTypeOfflineWebApplicationCache',
+  'WKWebsiteDataTypeCookies',
   'WKWebsiteDataTypeSessionStorage',
+  'WKWebsiteDataTypeLocalStorage',
   'WKWebsiteDataTypeWebSQLDatabases',
   'WKWebsiteDataTypeIndexedDBDatabases',
+  'WKWebsiteDataTypeServiceWorkerRegistrations',
 ];
 
 WebsiteDataType? websiteDataTypeFromWire(Object? value) {

--- a/zikzak_inappwebview_platform_interface/lib/src/types/main.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/types/main.dart
@@ -19,7 +19,10 @@ export '../domain/entities/enums/ajax_request_ready_state.dart'
 export '../domain/entities/attributed_string/attributed_string.dart'
     show AttributedString, AttributedStringSerialization;
 export '../domain/entities/enums/attributed_string_text_effect_style.dart'
-    show AttributedStringTextEffectStyle;
+    show
+        AttributedStringTextEffectStyle,
+        attributedStringTextEffectStyleFromWire,
+        attributedStringTextEffectStyleToWire;
 export '../domain/entities/enums/cache_mode.dart'
     show CacheMode, cacheModeFromWire, cacheModeToWire;
 export '../domain/entities/call_async_javascript_result/call_async_javascript_result.dart'
@@ -219,7 +222,7 @@ export '../domain/entities/enums/print_job_state.dart'
 export '../domain/entities/proxy_rule/proxy_rule.dart'
     show ProxyRule, ProxyRuleSerialization;
 export '../domain/entities/enums/proxy_scheme_filter.dart'
-    show ProxySchemeFilter;
+    show ProxySchemeFilter, proxySchemeFilterFromWire, proxySchemeFilterToWire;
 export '../domain/entities/enums/pull_to_refresh_size.dart'
     show PullToRefreshSize, pullToRefreshSizeToWire;
 export '../domain/entities/enums/referrer_policy.dart' show ReferrerPolicy;

--- a/zikzak_inappwebview_platform_interface/test/types/wire_enum_maps_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/types/wire_enum_maps_test.dart
@@ -1,0 +1,129 @@
+// Wire-format regression tests for enum wire maps that the zorphy migration
+// (PR #226) broke, pinned by the kimi review of the migration branch:
+//  - WebsiteDataType / ProxySchemeFilter / AttributedStringTextEffectStyle
+//    wire maps must match the pre-migration @ExchangeableEnum codegen values.
+//  - AndroidResource static factories (anim/layout/id/drawable) must exist on
+//    the concrete class (restored post-merge in #230).
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+void main() {
+  group('WebsiteDataType wire map', () {
+    test('all values map to their WKWebsiteDataType* strings', () {
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeFetchCache),
+        'WKWebsiteDataTypeFetchCache',
+      );
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeDiskCache),
+        'WKWebsiteDataTypeDiskCache',
+      );
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeMemoryCache),
+        'WKWebsiteDataTypeMemoryCache',
+      );
+      expect(
+        websiteDataTypeToWire(
+          WebsiteDataType.WKWebsiteDataTypeOfflineWebApplicationCache,
+        ),
+        'WKWebsiteDataTypeOfflineWebApplicationCache',
+      );
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeCookies),
+        'WKWebsiteDataTypeCookies',
+      );
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeSessionStorage),
+        'WKWebsiteDataTypeSessionStorage',
+      );
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeLocalStorage),
+        'WKWebsiteDataTypeLocalStorage',
+      );
+      expect(
+        websiteDataTypeToWire(WebsiteDataType.WKWebsiteDataTypeWebSQLDatabases),
+        'WKWebsiteDataTypeWebSQLDatabases',
+      );
+      expect(
+        websiteDataTypeToWire(
+          WebsiteDataType.WKWebsiteDataTypeIndexedDBDatabases,
+        ),
+        'WKWebsiteDataTypeIndexedDBDatabases',
+      );
+      expect(
+        websiteDataTypeToWire(
+          WebsiteDataType.WKWebsiteDataTypeServiceWorkerRegistrations,
+        ),
+        'WKWebsiteDataTypeServiceWorkerRegistrations',
+      );
+    });
+
+    test('round-trips and rejects unknown wire strings', () {
+      for (final value in WebsiteDataType.values) {
+        expect(websiteDataTypeFromWire(websiteDataTypeToWire(value)), value);
+      }
+      expect(websiteDataTypeFromWire('WKWebsiteDataTypeUnknown'), isNull);
+    });
+  });
+
+  group('ProxySchemeFilter wire map', () {
+    test('values map to * / http / https', () {
+      expect(proxySchemeFilterToWire(ProxySchemeFilter.MATCH_ALL_SCHEMES), '*');
+      expect(proxySchemeFilterToWire(ProxySchemeFilter.MATCH_HTTP), 'http');
+      expect(proxySchemeFilterToWire(ProxySchemeFilter.MATCH_HTTPS), 'https');
+    });
+
+    test('round-trips and rejects unknown wire strings', () {
+      for (final value in ProxySchemeFilter.values) {
+        expect(
+          proxySchemeFilterFromWire(proxySchemeFilterToWire(value)),
+          value,
+        );
+      }
+      expect(proxySchemeFilterFromWire('ws'), isNull);
+      expect(proxySchemeFilterFromWire('wss'), isNull);
+    });
+  });
+
+  group('AttributedStringTextEffectStyle wire map', () {
+    test('LETTERPRESS_STYLE maps to letterpressStyle', () {
+      expect(
+        attributedStringTextEffectStyleToWire(
+          AttributedStringTextEffectStyle.LETTERPRESS_STYLE,
+        ),
+        'letterpressStyle',
+      );
+      expect(
+        attributedStringTextEffectStyleFromWire('letterpressStyle'),
+        AttributedStringTextEffectStyle.LETTERPRESS_STYLE,
+      );
+    });
+
+    test('rejects stale wire strings from the broken map', () {
+      expect(attributedStringTextEffectStyleFromWire('NONE'), isNull);
+      expect(
+        attributedStringTextEffectStyleFromWire('LETTERPRESS_STYLE'),
+        isNull,
+      );
+    });
+  });
+
+  group('AndroidResource static factories', () {
+    test('anim/layout/id/drawable factories exist on the concrete class', () {
+      expect(AndroidResource.anim(name: 'fade_in').defType, 'anim');
+      expect(AndroidResource.layout(name: 'activity_main').defType, 'layout');
+      expect(AndroidResource.id(name: 'webview').defType, 'id');
+      expect(AndroidResource.drawable(name: 'ic_launcher').defType, 'drawable');
+    });
+
+    test('factories forward defPackage', () {
+      expect(
+        AndroidResource.drawable(
+          name: 'abc',
+          defPackage: 'com.example.app',
+        ).defPackage,
+        'com.example.app',
+      );
+    });
+  });
+}

--- a/zikzak_inappwebview_platform_interface/test/types/wire_enum_maps_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/types/wire_enum_maps_test.dart
@@ -73,15 +73,23 @@ void main() {
       expect(proxySchemeFilterToWire(ProxySchemeFilter.MATCH_HTTPS), 'https');
     });
 
-    test('round-trips and rejects unknown wire strings', () {
-      for (final value in ProxySchemeFilter.values) {
+    test('round-trips values with a wire representation', () {
+      for (final value in [
+        ProxySchemeFilter.MATCH_ALL_SCHEMES,
+        ProxySchemeFilter.MATCH_HTTP,
+        ProxySchemeFilter.MATCH_HTTPS,
+      ]) {
         expect(
           proxySchemeFilterFromWire(proxySchemeFilterToWire(value)),
           value,
         );
       }
+    });
+
+    test('rejects unknown wire strings', () {
       expect(proxySchemeFilterFromWire('ws'), isNull);
       expect(proxySchemeFilterFromWire('wss'), isNull);
+      expect(proxySchemeFilterFromWire('ftp'), isNull);
     });
   });
 
@@ -105,6 +113,10 @@ void main() {
         attributedStringTextEffectStyleFromWire('LETTERPRESS_STYLE'),
         isNull,
       );
+    });
+
+    test('toWire returns null for the default (NONE/null) value', () {
+      expect(attributedStringTextEffectStyleToWire(null), isNull);
     });
   });
 


### PR DESCRIPTION
Kimi review findings (PR #224 review) applied on master post-#226 merge:

- **WebsiteDataType wire map** — was a 3-entry list for a 10-value enum, so toWire/fromWire were broken for 7 values and returned scrambled types. Restored the full 10 `WKWebsiteDataType*` wire strings matching the pre-migration `@ExchangeableEnum` codegen.
- **ProxySchemeFilter wire map** — was `['http','https','ws','wss']` (4 entries, 3 values, no wildcard). Restored `['*','http','https']` per the old codegen (`MATCH_ALL_SCHEMES` = `*`).
- **AttributedStringTextEffectStyle wire map** — was `['NONE','LETTERPRESS_STYLE']`. Restored `['letterpressStyle']` per the old codegen.
- **AndroidResource static factories** — already restored on master by #230 (`anim`/`layout`/`id`/`drawable`); pinned by regression tests here.

Also re-exports the wire helpers for the two enums whose `show` clauses dropped them (matching the website_data_type / print_job convention), and adds `test/types/wire_enum_maps_test.dart` asserting exact wire strings + round-trips + factory presence.

Verified: `flutter analyze` clean for touched files (0 new issues), full platform_interface suite 146/146 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected text effect and proxy filtering values used when communicating with web view platforms.
  - Expanded website data coverage to include caches, cookies, local storage, and service worker data.
  - Improved handling of null and unsupported values during data conversion.

- **Reliability**
  - Added validation for enum conversions and round-trip behavior.
  - Improved consistency when creating Android resource objects and forwarding package information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->