### PR TITLE
refactor(platform_interface+android+ios): complete InAppWebViewController domain delegate split (#229)

### DIFF
--- a/zikzak_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -17,6 +17,10 @@ import '../web_storage/web_storage.dart';
 
 import 'headless_in_app_webview.dart';
 import '_static_channel.dart';
+import 'modules/android_navigation_delegate.dart';
+import 'modules/android_javascript_delegate.dart';
+import 'modules/android_cookie_delegate.dart';
+import 'modules/android_settings_delegate.dart';
 
 import '../print_job/main.dart';
 
@@ -95,6 +99,30 @@ class AndroidInAppWebViewController extends PlatformInAppWebViewController
 
   @override
   late AndroidWebStorage webStorage;
+
+  // Domain-specific delegate singletons (issue #229, P3). Lazily
+  // instantiated on first access; forwarding facades over the existing
+  // controller methods — behavior is identical to calling the controller.
+  AndroidNavigationDelegate? _navigationDelegate;
+  AndroidJavaScriptDelegate? _javaScriptDelegate;
+  AndroidCookieDelegate? _cookieDelegate;
+  AndroidSettingsDelegate? _settingsDelegate;
+
+  @override
+  AndroidNavigationDelegate? get navigationDelegate =>
+      _navigationDelegate ??= AndroidNavigationDelegate(this);
+
+  @override
+  AndroidJavaScriptDelegate? get javaScriptDelegate =>
+      _javaScriptDelegate ??= AndroidJavaScriptDelegate(this);
+
+  @override
+  AndroidCookieDelegate? get cookieDelegate =>
+      _cookieDelegate ??= AndroidCookieDelegate(this);
+
+  @override
+  AndroidSettingsDelegate? get settingsDelegate =>
+      _settingsDelegate ??= AndroidSettingsDelegate(this);
 
   AndroidInAppWebViewController(
     PlatformInAppWebViewControllerCreationParams params,

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_cookie_delegate.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_cookie_delegate.dart
@@ -1,0 +1,100 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+import '../cookie_manager.dart';
+
+/// Android implementation of [PlatformCookieDelegate].
+///
+/// Forwards every call to the shared [AndroidCookieManager] singleton,
+/// passing the parent [AndroidInAppWebViewController] as
+/// `webViewController` so per-WebView session cookies are honored.
+/// Global operations ([getAllCookies], [deleteAllCookies],
+/// [removeSessionCookies]) do not require the controller and are forwarded
+/// directly. Part of the domain-controller split (issue #229, P3).
+class AndroidCookieDelegate extends PlatformCookieDelegate {
+  /// Creates a new [AndroidCookieDelegate] bound to [_controller].
+  AndroidCookieDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final AndroidInAppWebViewController _controller;
+
+  @override
+  Future<bool> setCookie({
+    required WebUri url,
+    required String name,
+    required String value,
+    String path = "/",
+    String? domain,
+    int? expiresDate,
+    int? maxAge,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) => AndroidCookieManager.instance().setCookie(
+    url: url,
+    name: name,
+    value: value,
+    path: path,
+    domain: domain,
+    expiresDate: expiresDate,
+    maxAge: maxAge,
+    isSecure: isSecure,
+    isHttpOnly: isHttpOnly,
+    sameSite: sameSite,
+    webViewController: _controller,
+  );
+
+  @override
+  Future<List<Cookie>> getCookies({required WebUri url}) =>
+      AndroidCookieManager.instance().getCookies(
+        url: url,
+        webViewController: _controller,
+      );
+
+  @override
+  Future<Cookie?> getCookie({required WebUri url, required String name}) =>
+      AndroidCookieManager.instance().getCookie(
+        url: url,
+        name: name,
+        webViewController: _controller,
+      );
+
+  @override
+  Future<bool> deleteCookie({
+    required WebUri url,
+    required String name,
+    String path = "/",
+    String? domain,
+  }) => AndroidCookieManager.instance().deleteCookie(
+    url: url,
+    name: name,
+    path: path,
+    domain: domain,
+    webViewController: _controller,
+  );
+
+  @override
+  Future<bool> deleteCookies({
+    required WebUri url,
+    String path = "/",
+    String? domain,
+  }) => AndroidCookieManager.instance().deleteCookies(
+    url: url,
+    path: path,
+    domain: domain,
+    webViewController: _controller,
+  );
+
+  @override
+  Future<List<Cookie>> getAllCookies() =>
+      AndroidCookieManager.instance().getAllCookies();
+
+  @override
+  Future<bool> deleteAllCookies() =>
+      AndroidCookieManager.instance().deleteAllCookies();
+
+  @override
+  Future<bool> removeSessionCookies() =>
+      AndroidCookieManager.instance().removeSessionCookies();
+}

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_cookie_delegate.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_cookie_delegate.dart
@@ -1,7 +1,7 @@
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 import '../in_app_webview_controller.dart';
-import '../cookie_manager.dart';
+import '../../cookie_manager.dart';
 
 /// Android implementation of [PlatformCookieDelegate].
 ///

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_javascript_delegate.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_javascript_delegate.dart
@@ -21,7 +21,7 @@ class AndroidJavaScriptDelegate extends PlatformJavaScriptDelegate {
       _controller.evaluateJavascript(source: source);
 
   @override
-  Future<String?> callAsyncJavaScript({
+  Future<CallAsyncJavaScriptResult?> callAsyncJavaScript({
     required String functionBody,
     Map<String, dynamic> arguments = const <String, dynamic>{},
     ContentWorld? contentWorld,
@@ -71,7 +71,7 @@ class AndroidJavaScriptDelegate extends PlatformJavaScriptDelegate {
   );
 
   @override
-  Future<JavaScriptHandlerCallback?> removeJavaScriptHandler({
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
     required String handlerName,
   }) => _controller.removeJavaScriptHandler(handlerName: handlerName);
 }

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_javascript_delegate.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_javascript_delegate.dart
@@ -1,0 +1,77 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+/// Android implementation of [PlatformJavaScriptDelegate].
+///
+/// Forwards every call to the parent [AndroidInAppWebViewController].
+/// Behavior is identical to calling the controller directly — this is a
+/// focused facade, not a separate implementation. Part of the
+/// domain-controller split (issue #229, P3).
+class AndroidJavaScriptDelegate extends PlatformJavaScriptDelegate {
+  /// Creates a new [AndroidJavaScriptDelegate] bound to [_controller].
+  AndroidJavaScriptDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final AndroidInAppWebViewController _controller;
+
+  @override
+  Future<dynamic> evaluateJavascript({required String source}) =>
+      _controller.evaluateJavascript(source: source);
+
+  @override
+  Future<String?> callAsyncJavaScript({
+    required String functionBody,
+    Map<String, dynamic> arguments = const <String, dynamic>{},
+    ContentWorld? contentWorld,
+  }) => _controller.callAsyncJavaScript(
+    functionBody: functionBody,
+    arguments: arguments,
+    contentWorld: contentWorld,
+  );
+
+  @override
+  Future<void> injectJavascriptFileFromUrl({
+    required WebUri urlFile,
+    ScriptHtmlTagAttributes? scriptHtmlTagAttributes,
+  }) => _controller.injectJavascriptFileFromUrl(
+    urlFile: urlFile,
+    scriptHtmlTagAttributes: scriptHtmlTagAttributes,
+  );
+
+  @override
+  Future<void> injectJavascriptFileFromAsset({required String assetFilePath}) =>
+      _controller.injectJavascriptFileFromAsset(assetFilePath: assetFilePath);
+
+  @override
+  Future<void> injectCSSFileFromUrl({
+    required WebUri urlFile,
+    CSSLinkHtmlTagAttributes? cssLinkHtmlTagAttributes,
+  }) => _controller.injectCSSFileFromUrl(
+    urlFile: urlFile,
+    cssLinkHtmlTagAttributes: cssLinkHtmlTagAttributes,
+  );
+
+  @override
+  Future<void> injectCSSFileFromAsset({required String assetFilePath}) =>
+      _controller.injectCSSFileFromAsset(assetFilePath: assetFilePath);
+
+  @override
+  Future<void> injectCSSCode({required String source}) =>
+      _controller.injectCSSCode(source: source);
+
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) => _controller.addJavaScriptHandler(
+    handlerName: handlerName,
+    callback: callback,
+  );
+
+  @override
+  Future<JavaScriptHandlerCallback?> removeJavaScriptHandler({
+    required String handlerName,
+  }) => _controller.removeJavaScriptHandler(handlerName: handlerName);
+}

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_navigation_delegate.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_navigation_delegate.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+/// Android implementation of [PlatformNavigationDelegate].
+///
+/// Forwards every call to the parent [AndroidInAppWebViewController].
+/// Behavior is identical to calling the controller directly — this is a
+/// focused facade, not a separate implementation. Part of the
+/// domain-controller split (issue #229, P3).
+class AndroidNavigationDelegate extends PlatformNavigationDelegate {
+  /// Creates a new [AndroidNavigationDelegate] bound to [_controller].
+  AndroidNavigationDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final AndroidInAppWebViewController _controller;
+
+  @override
+  Future<WebUri?> getUrl() => _controller.getUrl();
+
+  @override
+  Future<String?> getTitle() => _controller.getTitle();
+
+  @override
+  Future<int?> getProgress() => _controller.getProgress();
+
+  @override
+  Future<void> loadUrl({
+    required URLRequest urlRequest,
+    WebUri? allowingReadAccessTo,
+  }) => _controller.loadUrl(
+    urlRequest: urlRequest,
+    allowingReadAccessTo: allowingReadAccessTo,
+  );
+
+  @override
+  Future<void> postUrl({required WebUri url, required Uint8List postData}) =>
+      _controller.postUrl(url: url, postData: postData);
+
+  @override
+  Future<void> loadData({
+    required String data,
+    String mimeType = "text/html",
+    String encoding = "utf8",
+    WebUri? baseUrl,
+    WebUri? historyUrl,
+    WebUri? allowingReadAccessTo,
+  }) => _controller.loadData(
+    data: data,
+    mimeType: mimeType,
+    encoding: encoding,
+    baseUrl: baseUrl,
+    historyUrl: historyUrl,
+    allowingReadAccessTo: allowingReadAccessTo,
+  );
+
+  @override
+  Future<void> loadFile({required String assetFilePath}) =>
+      _controller.loadFile(assetFilePath: assetFilePath);
+
+  @override
+  Future<void> reload() => _controller.reload();
+
+  @override
+  Future<void> goBack() => _controller.goBack();
+
+  @override
+  Future<bool> canGoBack() => _controller.canGoBack();
+
+  @override
+  Future<void> goForward() => _controller.goForward();
+
+  @override
+  Future<bool> canGoForward() => _controller.canGoForward();
+
+  @override
+  Future<void> goBackOrForward({required int steps}) =>
+      _controller.goBackOrForward(steps: steps);
+
+  @override
+  Future<bool> canGoBackOrForward({required int steps}) =>
+      _controller.canGoBackOrForward(steps: steps);
+
+  @override
+  Future<void> goTo({required WebHistoryItem historyItem}) =>
+      _controller.goTo(historyItem: historyItem);
+
+  @override
+  Future<bool> isLoading() => _controller.isLoading();
+
+  @override
+  Future<void> stopLoading() => _controller.stopLoading();
+}

--- a/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_settings_delegate.dart
+++ b/zikzak_inappwebview_android/lib/src/in_app_webview/modules/android_settings_delegate.dart
@@ -1,0 +1,25 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+/// Android implementation of [PlatformSettingsDelegate].
+///
+/// Forwards every call to the parent [AndroidInAppWebViewController].
+/// Behavior is identical to calling the controller directly — this is a
+/// focused facade, not a separate implementation. Part of the
+/// domain-controller split (issue #229, P3).
+class AndroidSettingsDelegate extends PlatformSettingsDelegate {
+  /// Creates a new [AndroidSettingsDelegate] bound to [_controller].
+  AndroidSettingsDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final AndroidInAppWebViewController _controller;
+
+  @override
+  Future<void> setSettings({required InAppWebViewSettings settings}) =>
+      _controller.setSettings(settings: settings);
+
+  @override
+  Future<InAppWebViewSettings?> getSettings() => _controller.getSettings();
+}

--- a/zikzak_inappwebview_android/test/in_app_webview/modules/android_delegates_test.dart
+++ b/zikzak_inappwebview_android/test/in_app_webview/modules/android_delegates_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_android/src/in_app_webview/modules/android_navigation_delegate.dart';
+import 'package:zikzak_inappwebview_android/src/in_app_webview/modules/android_javascript_delegate.dart';
+import 'package:zikzak_inappwebview_android/src/in_app_webview/modules/android_cookie_delegate.dart';
+import 'package:zikzak_inappwebview_android/src/in_app_webview/modules/android_settings_delegate.dart';
+
+/// Compile-time probes for the Android domain delegates.
+///
+/// Importing and referencing each concrete delegate forces the analyzer to
+/// resolve the class and its overrides against the platform interface. If any
+/// delegate signature drifts from its [PlatformInterface] base, this file stops
+/// compiling — which is exactly how a brittle override (e.g. a return-type
+/// mismatch) would be caught before shipping.
+void main() {
+  group('Android delegate compile-time checks', () {
+    test('AndroidNavigationDelegate compiles', () {
+      expect(AndroidNavigationDelegate, isNotNull);
+    });
+    test('AndroidJavaScriptDelegate compiles', () {
+      expect(AndroidJavaScriptDelegate, isNotNull);
+    });
+    test('AndroidCookieDelegate compiles', () {
+      expect(AndroidCookieDelegate, isNotNull);
+    });
+    test('AndroidSettingsDelegate compiles', () {
+      expect(AndroidSettingsDelegate, isNotNull);
+    });
+  });
+}

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -17,6 +17,10 @@ import '../web_storage/web_storage.dart';
 
 import 'headless_in_app_webview.dart';
 import '_static_channel.dart';
+import 'modules/ios_navigation_delegate.dart';
+import 'modules/ios_javascript_delegate.dart';
+import 'modules/ios_cookie_delegate.dart';
+import 'modules/ios_settings_delegate.dart';
 
 import '../print_job/main.dart';
 
@@ -95,6 +99,30 @@ class IOSInAppWebViewController extends PlatformInAppWebViewController
 
   @override
   late IOSWebStorage webStorage;
+
+  // Domain-specific delegate singletons (issue #229, P3). Lazily
+  // instantiated on first access; forwarding facades over the existing
+  // controller methods — behavior is identical to calling the controller.
+  IOSNavigationDelegate? _navigationDelegate;
+  IOSJavaScriptDelegate? _javaScriptDelegate;
+  IOSCookieDelegate? _cookieDelegate;
+  IOSSettingsDelegate? _settingsDelegate;
+
+  @override
+  IOSNavigationDelegate? get navigationDelegate =>
+      _navigationDelegate ??= IOSNavigationDelegate(this);
+
+  @override
+  IOSJavaScriptDelegate? get javaScriptDelegate =>
+      _javaScriptDelegate ??= IOSJavaScriptDelegate(this);
+
+  @override
+  IOSCookieDelegate? get cookieDelegate =>
+      _cookieDelegate ??= IOSCookieDelegate(this);
+
+  @override
+  IOSSettingsDelegate? get settingsDelegate =>
+      _settingsDelegate ??= IOSSettingsDelegate(this);
 
   IOSInAppWebViewController(PlatformInAppWebViewControllerCreationParams params)
     : super.implementation(

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_cookie_delegate.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_cookie_delegate.dart
@@ -1,7 +1,7 @@
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 import '../in_app_webview_controller.dart';
-import '../cookie_manager.dart';
+import '../../cookie_manager.dart';
 
 /// iOS implementation of [PlatformCookieDelegate].
 ///

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_cookie_delegate.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_cookie_delegate.dart
@@ -1,0 +1,100 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+import '../cookie_manager.dart';
+
+/// iOS implementation of [PlatformCookieDelegate].
+///
+/// Forwards every call to the shared [IOSCookieManager] singleton,
+/// passing the parent [IOSInAppWebViewController] as `webViewController`
+/// so per-WebView session cookies are honored. Global operations
+/// ([getAllCookies], [deleteAllCookies], [removeSessionCookies]) do not
+/// require the controller and are forwarded directly. Part of the
+/// domain-controller split (issue #229, P3).
+class IOSCookieDelegate extends PlatformCookieDelegate {
+  /// Creates a new [IOSCookieDelegate] bound to [_controller].
+  IOSCookieDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final IOSInAppWebViewController _controller;
+
+  @override
+  Future<bool> setCookie({
+    required WebUri url,
+    required String name,
+    required String value,
+    String path = "/",
+    String? domain,
+    int? expiresDate,
+    int? maxAge,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) => IOSCookieManager.instance().setCookie(
+    url: url,
+    name: name,
+    value: value,
+    path: path,
+    domain: domain,
+    expiresDate: expiresDate,
+    maxAge: maxAge,
+    isSecure: isSecure,
+    isHttpOnly: isHttpOnly,
+    sameSite: sameSite,
+    webViewController: _controller,
+  );
+
+  @override
+  Future<List<Cookie>> getCookies({required WebUri url}) =>
+      IOSCookieManager.instance().getCookies(
+        url: url,
+        webViewController: _controller,
+      );
+
+  @override
+  Future<Cookie?> getCookie({required WebUri url, required String name}) =>
+      IOSCookieManager.instance().getCookie(
+        url: url,
+        name: name,
+        webViewController: _controller,
+      );
+
+  @override
+  Future<bool> deleteCookie({
+    required WebUri url,
+    required String name,
+    String path = "/",
+    String? domain,
+  }) => IOSCookieManager.instance().deleteCookie(
+    url: url,
+    name: name,
+    path: path,
+    domain: domain,
+    webViewController: _controller,
+  );
+
+  @override
+  Future<bool> deleteCookies({
+    required WebUri url,
+    String path = "/",
+    String? domain,
+  }) => IOSCookieManager.instance().deleteCookies(
+    url: url,
+    path: path,
+    domain: domain,
+    webViewController: _controller,
+  );
+
+  @override
+  Future<List<Cookie>> getAllCookies() =>
+      IOSCookieManager.instance().getAllCookies();
+
+  @override
+  Future<bool> deleteAllCookies() =>
+      IOSCookieManager.instance().deleteAllCookies();
+
+  @override
+  Future<bool> removeSessionCookies() =>
+      IOSCookieManager.instance().removeSessionCookies();
+}

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_javascript_delegate.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_javascript_delegate.dart
@@ -1,0 +1,78 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+/// iOS implementation of [PlatformJavaScriptDelegate].
+///
+/// Forwards every call to the parent [IOSInAppWebViewController].
+/// Behavior is identical to calling the controller directly — this is a
+/// focused facade, not a separate implementation. Part of the
+/// domain-controller split (issue #229, P3).
+class IOSJavaScriptDelegate extends PlatformJavaScriptDelegate {
+  /// Creates a new [IOSJavaScriptDelegate] bound to [_controller].
+  IOSJavaScriptDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final IOSInAppWebViewController _controller;
+
+  @override
+  Future<dynamic> evaluateJavascript({required String source}) =>
+      _controller.evaluateJavascript(source: source);
+
+  @override
+  Future<CallAsyncJavaScriptResult?> callAsyncJavaScript({
+    required String functionBody,
+    Map<String, dynamic> arguments = const <String, dynamic>{},
+    ContentWorld? contentWorld,
+  }) => _controller.callAsyncJavaScript(
+    functionBody: functionBody,
+    arguments: arguments,
+    contentWorld: contentWorld,
+  );
+
+  @override
+  Future<void> injectJavascriptFileFromUrl({
+    required WebUri urlFile,
+    ScriptHtmlTagAttributes? scriptHtmlTagAttributes,
+  }) => _controller.injectJavascriptFileFromUrl(
+    urlFile: urlFile,
+    scriptHtmlTagAttributes: scriptHtmlTagAttributes,
+  );
+
+  @override
+  Future<dynamic> injectJavascriptFileFromAsset({
+    required String assetFilePath,
+  }) => _controller.injectJavascriptFileFromAsset(assetFilePath: assetFilePath);
+
+  @override
+  Future<void> injectCSSFileFromUrl({
+    required WebUri urlFile,
+    CSSLinkHtmlTagAttributes? cssLinkHtmlTagAttributes,
+  }) => _controller.injectCSSFileFromUrl(
+    urlFile: urlFile,
+    cssLinkHtmlTagAttributes: cssLinkHtmlTagAttributes,
+  );
+
+  @override
+  Future<void> injectCSSFileFromAsset({required String assetFilePath}) =>
+      _controller.injectCSSFileFromAsset(assetFilePath: assetFilePath);
+
+  @override
+  Future<void> injectCSSCode({required String source}) =>
+      _controller.injectCSSCode(source: source);
+
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) => _controller.addJavaScriptHandler(
+    handlerName: handlerName,
+    callback: callback,
+  );
+
+  @override
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
+    required String handlerName,
+  }) => _controller.removeJavaScriptHandler(handlerName: handlerName);
+}

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_navigation_delegate.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_navigation_delegate.dart
@@ -1,0 +1,96 @@
+import 'dart:typed_data';
+
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+/// iOS implementation of [PlatformNavigationDelegate].
+///
+/// Forwards every call to the parent [IOSInAppWebViewController].
+/// Behavior is identical to calling the controller directly — this is a
+/// focused facade, not a separate implementation. Part of the
+/// domain-controller split (issue #229, P3).
+class IOSNavigationDelegate extends PlatformNavigationDelegate {
+  /// Creates a new [IOSNavigationDelegate] bound to [_controller].
+  IOSNavigationDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final IOSInAppWebViewController _controller;
+
+  @override
+  Future<WebUri?> getUrl() => _controller.getUrl();
+
+  @override
+  Future<String?> getTitle() => _controller.getTitle();
+
+  @override
+  Future<int?> getProgress() => _controller.getProgress();
+
+  @override
+  Future<void> loadUrl({
+    required URLRequest urlRequest,
+    WebUri? allowingReadAccessTo,
+  }) => _controller.loadUrl(
+    urlRequest: urlRequest,
+    allowingReadAccessTo: allowingReadAccessTo,
+  );
+
+  @override
+  Future<void> postUrl({required WebUri url, required Uint8List postData}) =>
+      _controller.postUrl(url: url, postData: postData);
+
+  @override
+  Future<void> loadData({
+    required String data,
+    String mimeType = "text/html",
+    String encoding = "utf8",
+    WebUri? baseUrl,
+    WebUri? historyUrl,
+    WebUri? allowingReadAccessTo,
+  }) => _controller.loadData(
+    data: data,
+    mimeType: mimeType,
+    encoding: encoding,
+    baseUrl: baseUrl,
+    historyUrl: historyUrl,
+    allowingReadAccessTo: allowingReadAccessTo,
+  );
+
+  @override
+  Future<void> loadFile({required String assetFilePath}) =>
+      _controller.loadFile(assetFilePath: assetFilePath);
+
+  @override
+  Future<void> reload() => _controller.reload();
+
+  @override
+  Future<void> goBack() => _controller.goBack();
+
+  @override
+  Future<bool> canGoBack() => _controller.canGoBack();
+
+  @override
+  Future<void> goForward() => _controller.goForward();
+
+  @override
+  Future<bool> canGoForward() => _controller.canGoForward();
+
+  @override
+  Future<void> goBackOrForward({required int steps}) =>
+      _controller.goBackOrForward(steps: steps);
+
+  @override
+  Future<bool> canGoBackOrForward({required int steps}) =>
+      _controller.canGoBackOrForward(steps: steps);
+
+  @override
+  Future<void> goTo({required WebHistoryItem historyItem}) =>
+      _controller.goTo(historyItem: historyItem);
+
+  @override
+  Future<bool> isLoading() => _controller.isLoading();
+
+  @override
+  Future<void> stopLoading() => _controller.stopLoading();
+}

--- a/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_settings_delegate.dart
+++ b/zikzak_inappwebview_ios/lib/src/in_app_webview/modules/ios_settings_delegate.dart
@@ -1,0 +1,25 @@
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import '../in_app_webview_controller.dart';
+
+/// iOS implementation of [PlatformSettingsDelegate].
+///
+/// Forwards every call to the parent [IOSInAppWebViewController].
+/// Behavior is identical to calling the controller directly — this is a
+/// focused facade, not a separate implementation. Part of the
+/// domain-controller split (issue #229, P3).
+class IOSSettingsDelegate extends PlatformSettingsDelegate {
+  /// Creates a new [IOSSettingsDelegate] bound to [_controller].
+  IOSSettingsDelegate(this._controller) : super(token: _token);
+
+  static final Object _token = Object();
+
+  final IOSInAppWebViewController _controller;
+
+  @override
+  Future<void> setSettings({required InAppWebViewSettings settings}) =>
+      _controller.setSettings(settings: settings);
+
+  @override
+  Future<InAppWebViewSettings?> getSettings() => _controller.getSettings();
+}

--- a/zikzak_inappwebview_ios/test/in_app_webview/modules/ios_delegates_test.dart
+++ b/zikzak_inappwebview_ios/test/in_app_webview/modules/ios_delegates_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_ios/src/in_app_webview/modules/ios_navigation_delegate.dart';
+import 'package:zikzak_inappwebview_ios/src/in_app_webview/modules/ios_javascript_delegate.dart';
+import 'package:zikzak_inappwebview_ios/src/in_app_webview/modules/ios_cookie_delegate.dart';
+import 'package:zikzak_inappwebview_ios/src/in_app_webview/modules/ios_settings_delegate.dart';
+
+/// Compile-time probes for the iOS domain delegates.
+///
+/// Importing and referencing each concrete delegate forces the analyzer to
+/// resolve the class and its overrides against the platform interface. If any
+/// delegate signature drifts from its [PlatformInterface] base, this file stops
+/// compiling — which is exactly how a brittle override (e.g. a return-type
+/// mismatch) would be caught before shipping.
+void main() {
+  group('iOS delegate compile-time checks', () {
+    test('IOSNavigationDelegate compiles', () {
+      expect(IOSNavigationDelegate, isNotNull);
+    });
+    test('IOSJavaScriptDelegate compiles', () {
+      expect(IOSJavaScriptDelegate, isNotNull);
+    });
+    test('IOSCookieDelegate compiles', () {
+      expect(IOSCookieDelegate, isNotNull);
+    });
+    test('IOSSettingsDelegate compiles', () {
+      expect(IOSSettingsDelegate, isNotNull);
+    });
+  });
+}

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/main.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/main.dart
@@ -4,3 +4,7 @@ export 'platform_webview.dart';
 export 'in_app_webview_settings.dart' show InAppWebViewSettings;
 export 'platform_headless_in_app_webview.dart';
 export 'in_app_webview_keep_alive.dart';
+export 'modules/platform_navigation_delegate.dart';
+export 'modules/platform_javascript_delegate.dart';
+export 'modules/platform_cookie_delegate.dart';
+export 'modules/platform_settings_delegate.dart';

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_cookie_delegate.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_cookie_delegate.dart
@@ -1,0 +1,101 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import '../../web_uri.dart';
+import '../../types/main.dart';
+import '../platform_inappwebview_controller.dart';
+
+/// Delegate for cookie-management methods scoped to a single
+/// [PlatformInAppWebViewController].
+///
+/// Part of the domain-controller split (issue #229, P3): cookie operations
+/// that operate on the WebView's current context are grouped behind this
+/// focused facade so the main [PlatformInAppWebViewController] stays easy to
+/// reason about. The shared [PlatformCookieManager] remains the source of
+/// truth for cross-WebView global operations; this delegate exposes the
+/// per-controller subset that takes a [PlatformInAppWebViewController] as
+/// context.
+///
+/// Platform implementations override the [PlatformInAppWebViewController.cookieDelegate]
+/// getter to return a concrete instance. The default getter returns `null`,
+/// preserving backward compatibility for implementations that have not yet
+/// been migrated.
+abstract class PlatformCookieDelegate extends PlatformInterface {
+  /// Creates a new [PlatformCookieDelegate].
+  PlatformCookieDelegate({required Object token}) : super(token: token);
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.setCookie}
+  Future<bool> setCookie({
+    required WebUri url,
+    required String name,
+    required String value,
+    String path = "/",
+    String? domain,
+    int? expiresDate,
+    int? maxAge,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) {
+    throw UnimplementedError(
+      'setCookie is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.getCookies}
+  Future<List<Cookie>> getCookies({required WebUri url}) {
+    throw UnimplementedError(
+      'getCookies is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.getCookie}
+  Future<Cookie?> getCookie({required WebUri url, required String name}) {
+    throw UnimplementedError(
+      'getCookie is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.deleteCookie}
+  Future<bool> deleteCookie({
+    required WebUri url,
+    required String name,
+    String path = "/",
+    String? domain,
+  }) {
+    throw UnimplementedError(
+      'deleteCookie is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.deleteCookies}
+  Future<bool> deleteCookies({
+    required WebUri url,
+    String path = "/",
+    String? domain,
+  }) {
+    throw UnimplementedError(
+      'deleteCookies is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.getAllCookies}
+  Future<List<Cookie>> getAllCookies() {
+    throw UnimplementedError(
+      'getAllCookies is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.deleteAllCookies}
+  Future<bool> deleteAllCookies() {
+    throw UnimplementedError(
+      'deleteAllCookies is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformCookieManager.removeSessionCookies}
+  Future<bool> removeSessionCookies() {
+    throw UnimplementedError(
+      'removeSessionCookies is not implemented on the current platform',
+    );
+  }
+}

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_javascript_delegate.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_javascript_delegate.dart
@@ -4,8 +4,18 @@ import '../../web_uri.dart';
 import '../../types/main.dart';
 
 /// Delegate for JavaScript-related methods of [PlatformInAppWebViewController].
+///
+/// Part of the domain-controller split (issue #229, P3): JavaScript
+/// evaluation, handler management and asset injection are grouped behind
+/// this focused facade so the main [PlatformInAppWebViewController] stays
+/// easy to reason about.
+///
+/// Platform implementations override the [PlatformInAppWebViewController.javaScriptDelegate]
+/// getter to return a concrete instance. The default getter returns `null`,
+/// preserving backward compatibility for implementations that have not yet
+/// been migrated.
 abstract class PlatformJavaScriptDelegate extends PlatformInterface {
-  /// Creates a new [PlatformJavaScriptDelegate]
+  /// Creates a new [PlatformJavaScriptDelegate].
   PlatformJavaScriptDelegate({required Object token}) : super(token: token);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.evaluateJavascript}
@@ -16,7 +26,7 @@ abstract class PlatformJavaScriptDelegate extends PlatformInterface {
   }
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.callAsyncJavaScript}
-  Future<String?> callAsyncJavaScript({
+  Future<CallAsyncJavaScriptResult?> callAsyncJavaScript({
     required String functionBody,
     Map<String, dynamic> arguments = const <String, dynamic>{},
     ContentWorld? contentWorld,
@@ -37,7 +47,9 @@ abstract class PlatformJavaScriptDelegate extends PlatformInterface {
   }
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.injectJavascriptFileFromAsset}
-  Future<void> injectJavascriptFileFromAsset({required String assetFilePath}) {
+  Future<dynamic> injectJavascriptFileFromAsset({
+    required String assetFilePath,
+  }) {
     throw UnimplementedError(
       'injectJavascriptFileFromAsset is not implemented on the current platform',
     );
@@ -78,7 +90,7 @@ abstract class PlatformJavaScriptDelegate extends PlatformInterface {
   }
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.removeJavaScriptHandler}
-  Future<JavaScriptHandlerCallback?> removeJavaScriptHandler({
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
     required String handlerName,
   }) {
     throw UnimplementedError(

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_navigation_delegate.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_navigation_delegate.dart
@@ -1,14 +1,24 @@
 import 'dart:typed_data';
 
-import 'package:flutter/foundation.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import '../../web_uri.dart';
 import '../../types/main.dart';
+import '../platform_inappwebview_controller.dart';
 
 /// Delegate for navigation-related methods of [PlatformInAppWebViewController].
+///
+/// Part of the domain-controller split (issue #229, P3): page loading,
+/// history management and navigation are grouped behind this focused
+/// facade so the main [PlatformInAppWebViewController] stays easy to
+/// reason about.
+///
+/// Platform implementations override the [PlatformInAppWebViewController.navigationDelegate]
+/// getter to return a concrete instance. The default getter returns `null`,
+/// preserving backward compatibility for implementations that have not yet
+/// been migrated.
 abstract class PlatformNavigationDelegate extends PlatformInterface {
-  /// Creates a new [PlatformNavigationDelegate]
+  /// Creates a new [PlatformNavigationDelegate].
   PlatformNavigationDelegate({required Object token}) : super(token: token);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.getUrl}

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_settings_delegate.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_settings_delegate.dart
@@ -1,0 +1,34 @@
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+
+import '../in_app_webview_settings.dart';
+import '../platform_inappwebview_controller.dart';
+
+/// Delegate for reading and updating the WebView settings of a single
+/// [PlatformInAppWebViewController].
+///
+/// Part of the domain-controller split (issue #229, P3). Exposes the
+/// settings subset of [PlatformInAppWebViewController] behind a focused
+/// facade so the main controller stays easy to reason about.
+///
+/// Platform implementations override the [PlatformInAppWebViewController.settingsDelegate]
+/// getter to return a concrete instance. The default getter returns `null`,
+/// preserving backward compatibility for implementations that have not yet
+/// been migrated.
+abstract class PlatformSettingsDelegate extends PlatformInterface {
+  /// Creates a new [PlatformSettingsDelegate].
+  PlatformSettingsDelegate({required Object token}) : super(token: token);
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.setSettings}
+  Future<void> setSettings({required InAppWebViewSettings settings}) {
+    throw UnimplementedError(
+      'setSettings is not implemented on the current platform',
+    );
+  }
+
+  ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.getSettings}
+  Future<InAppWebViewSettings?> getSettings() {
+    throw UnimplementedError(
+      'getSettings is not implemented on the current platform',
+    );
+  }
+}

--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/platform_inappwebview_controller.dart
@@ -24,6 +24,8 @@ import 'in_app_webview_keep_alive.dart';
 import 'in_app_webview_settings.dart';
 import 'modules/platform_navigation_delegate.dart';
 import 'modules/platform_javascript_delegate.dart';
+import 'modules/platform_cookie_delegate.dart';
+import 'modules/platform_settings_delegate.dart';
 
 import '../print_job/main.dart';
 
@@ -126,6 +128,20 @@ abstract class PlatformInAppWebViewController extends PlatformInterface
 
   /// Delegate for JavaScript-related methods.
   PlatformJavaScriptDelegate? get javaScriptDelegate => null;
+
+  /// Delegate for cookie-management methods scoped to this WebView.
+  ///
+  /// Returns `null` by default; platform implementations override
+  /// this to return a concrete [PlatformCookieDelegate] that wraps the
+  /// controller's cookie operations.
+  PlatformCookieDelegate? get cookieDelegate => null;
+
+  /// Delegate for reading and updating the WebView settings.
+  ///
+  /// Returns `null` by default; platform implementations override
+  /// this to return a concrete [PlatformSettingsDelegate] that wraps the
+  /// controller's settings operations.
+  PlatformSettingsDelegate? get settingsDelegate => null;
 
   ///{@template zikzak_inappwebview_platform_interface.PlatformInAppWebViewController.webStorage}
   ///Provides access to the JavaScript [Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API): `window.sessionStorage` and `window.localStorage`.

--- a/zikzak_inappwebview_platform_interface/test/in_app_webview_controller_delegates_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/in_app_webview_controller_delegates_test.dart
@@ -1,0 +1,190 @@
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+/// Compile-time probes for the platform-interface domain delegate split
+/// (issue #229, P3).
+///
+/// The platform interface exposes four focused delegates —
+/// [PlatformNavigationDelegate], [PlatformJavaScriptDelegate],
+/// [PlatformCookieDelegate], [PlatformSettingsDelegate] — and the main
+/// [PlatformInAppWebViewController] exposes a getter for each. If a
+/// delegate, getter or method drifts, this file stops compiling, so
+/// `flutter analyze` and `flutter test` both fail.
+
+// --- Compile-time bound checks: each delegate extends PlatformInterface ---
+
+class _ProbeNavigation extends PlatformNavigationDelegate {
+  _ProbeNavigation() : super(token: Object());
+  @override
+  Future<WebUri?> getUrl() async => null;
+  @override
+  Future<void> loadUrl({
+    required URLRequest urlRequest,
+    WebUri? allowingReadAccessTo,
+  }) async {}
+  @override
+  Future<void> postUrl({
+    required WebUri url,
+    required Uint8List postData,
+  }) async {}
+  @override
+  Future<void> loadData({
+    required String data,
+    String mimeType = "text/html",
+    String encoding = "utf8",
+    WebUri? baseUrl,
+    WebUri? historyUrl,
+    WebUri? allowingReadAccessTo,
+  }) async {}
+  @override
+  Future<void> loadFile({required String assetFilePath}) async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  Future<void> goBack() async {}
+  @override
+  Future<bool> canGoBack() async => false;
+  @override
+  Future<void> goForward() async {}
+  @override
+  Future<bool> canGoForward() async => false;
+  @override
+  Future<void> goBackOrForward({required int steps}) async {}
+  @override
+  Future<bool> canGoBackOrForward({required int steps}) async => false;
+  @override
+  Future<void> goTo({required WebHistoryItem historyItem}) async {}
+  @override
+  Future<bool> isLoading() async => false;
+  @override
+  Future<void> stopLoading() async {}
+}
+
+class _ProbeJavaScript extends PlatformJavaScriptDelegate {
+  _ProbeJavaScript() : super(token: Object());
+  @override
+  Future<dynamic> evaluateJavascript({required String source}) async => null;
+  @override
+  Future<CallAsyncJavaScriptResult?> callAsyncJavaScript({
+    required String functionBody,
+    Map<String, dynamic> arguments = const <String, dynamic>{},
+    ContentWorld? contentWorld,
+  }) async => null;
+  @override
+  Future<void> injectJavascriptFileFromUrl({
+    required WebUri urlFile,
+    ScriptHtmlTagAttributes? scriptHtmlTagAttributes,
+  }) async {}
+  @override
+  Future<dynamic> injectJavascriptFileFromAsset({
+    required String assetFilePath,
+  }) async => null;
+  @override
+  Future<void> injectCSSFileFromUrl({
+    required WebUri urlFile,
+    CSSLinkHtmlTagAttributes? cssLinkHtmlTagAttributes,
+  }) async {}
+  @override
+  Future<void> injectCSSFileFromAsset({required String assetFilePath}) async {}
+  @override
+  Future<void> injectCSSCode({required String source}) async {}
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) {}
+  @override
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
+    required String handlerName,
+  }) => null;
+}
+
+class _ProbeCookie extends PlatformCookieDelegate {
+  _ProbeCookie() : super(token: Object());
+  @override
+  Future<bool> setCookie({
+    required WebUri url,
+    required String name,
+    required String value,
+    String path = "/",
+    String? domain,
+    int? expiresDate,
+    int? maxAge,
+    bool? isSecure,
+    bool? isHttpOnly,
+    HTTPCookieSameSitePolicy? sameSite,
+  }) async => false;
+  @override
+  Future<List<Cookie>> getCookies({required WebUri url}) async => [];
+  @override
+  Future<Cookie?> getCookie({
+    required WebUri url,
+    required String name,
+  }) async => null;
+  @override
+  Future<bool> deleteCookie({
+    required WebUri url,
+    required String name,
+    String path = "/",
+    String? domain,
+  }) async => false;
+  @override
+  Future<bool> deleteCookies({
+    required WebUri url,
+    String path = "/",
+    String? domain,
+  }) async => false;
+  @override
+  Future<List<Cookie>> getAllCookies() async => [];
+  @override
+  Future<bool> deleteAllCookies() async => false;
+  @override
+  Future<bool> removeSessionCookies() async => false;
+}
+
+class _ProbeSettings extends PlatformSettingsDelegate {
+  _ProbeSettings() : super(token: Object());
+  @override
+  Future<void> setSettings({required InAppWebViewSettings settings}) async {}
+  @override
+  Future<InAppWebViewSettings?> getSettings() async => null;
+}
+
+// --- Compile-time bound checks: the main controller exposes all four
+// delegate getters. The getters return nullable delegates (null by default
+// on the abstract base); the platform implementations override them.
+
+PlatformNavigationDelegate? _nav(PlatformInAppWebViewController c) =>
+    c.navigationDelegate;
+PlatformJavaScriptDelegate? _js(PlatformInAppWebViewController c) =>
+    c.javaScriptDelegate;
+PlatformCookieDelegate? _ck(PlatformInAppWebViewController c) =>
+    c.cookieDelegate;
+PlatformSettingsDelegate? _st(PlatformInAppWebViewController c) =>
+    c.settingsDelegate;
+
+void main() {
+  group('PlatformInAppWebViewController delegate split (issue #229 P3)', () {
+    test(
+      'the four domain delegate types are exported from the platform interface',
+      () {
+        expect(_ProbeNavigation, isNotNull);
+        expect(_ProbeJavaScript, isNotNull);
+        expect(_ProbeCookie, isNotNull);
+        expect(_ProbeSettings, isNotNull);
+      },
+    );
+
+    test(
+      'PlatformInAppWebViewController declares all four delegate getters',
+      () {
+        expect(_nav, isNotNull);
+        expect(_js, isNotNull);
+        expect(_ck, isNotNull);
+        expect(_st, isNotNull);
+      },
+    );
+  });
+}


### PR DESCRIPTION
Closes #229

Completes issue #229 (P3): split PlatformInAppWebViewController into four domain-specific delegates — Navigation, JavaScript, Cookie, Settings.

## What

Platform interface (zikzak_inappwebview_platform_interface):
- Add PlatformCookieDelegate + PlatformSettingsDelegate abstract classes (mirroring the existing PlatformNavigationDelegate / PlatformJavaScriptDelegate stubs).
- Add cookieDelegate + settingsDelegate getters on PlatformInAppWebViewController (return null by default — same backward-compat pattern as the existing two getters).
- Export all four delegates from in_app_webview/main.dart.
- Fix three pre-existing signature bugs in the PlatformJavaScriptDelegate stub so concrete overrides can compile (callAsyncJavaScript return type, injectJavascriptFileFromAsset return type, removeJavaScriptHandler sync vs async).

Android (zikzak_inappwebview_android) + iOS (zikzak_inappwebview_ios):
- Add concrete delegate implementations (Android{Navigation,JavaScript,Cookie,Settings}Delegate / IOS{...}Delegate) that forward every call to the parent controller — pure facade, zero behavior change.
- Wire the four delegate getters on AndroidInAppWebViewController / IOSInAppWebViewController to return lazy singleton delegates bound to this controller.
- Cookie delegate: forwards to the shared AndroidCookieManager / IOSCookieManager singleton, passing the bound controller as webViewController.

Tests:
- New zikzak_inappwebview_platform_interface/test/in_app_webview_controller_delegates_test.dart — compile-time probes verifying all four delegate types and all four getters exist with the expected signatures.

## Why

The monolithic PlatformInAppWebViewController (~2.5k LOC) and its Android/iOS implementations (~2.7k LOC each) are hard to reason about. The app-facing layer was already split into NavigationController / JavaScriptController / CookieController / SettingsController facades by PR #176, but the platform-interface layer only had two inert stubs (PlatformNavigationDelegate, PlatformJavaScriptDelegate) with no concrete wiring. This PR completes the platform-interface split and wires up Android and iOS.

## Backward compatibility

100% additive. Every existing method on PlatformInAppWebViewController and on the Android/iOS controllers stays unchanged. The delegates are ADDITIONAL entry points that forward to the existing methods — behavior is identical. Existing callers that do not use the new delegate getters continue to work.

## Verification

- flutter pub get on all 6 packages (platform_interface, android, ios, macos, app-facing, example) — clean.
- flutter analyze on all 6 packages — 0 errors, 0 warnings in changed files (only pre-existing info-level lints).
- flutter test on platform_interface — 100/100 passed (includes 2 new delegate-split tests).
- flutter test on app-facing — 95/95 passed (existing domain_controllers_test.dart from PR #176 still green).

## Out of scope (follow-up)

- macOS / Linux / Windows / Web platform implementations are intentionally NOT modified. They keep the default null-returning getters, which is the documented backward-compatible fallback. A follow-up PR can wire those up using the same forwarding pattern.
- The delegates are forwarding facades, not separate implementations. A larger follow-up could physically move method bodies into the delegate classes if that proves valuable.

Closes #229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated navigation, JavaScript, cookie, and settings delegates for Android and iOS WebViews.
  * WebView controllers now provide access to navigation, scripting, cookie management, and settings operations.
  * Added cross-platform interfaces for managing cookies and WebView settings.
  * JavaScript calls now support structured asynchronous results.

* **Tests**
  * Added coverage confirming delegate availability and platform-controller integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->