### PR TITLE
fix(macos): avoid double-encoding JavaScript handler results

### DIFF
--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Unreleased
+
+### Fixes
+
+- [macOS] Prevent `addJavaScriptHandler` callbacks from crashing when their
+  JSON-encoded result is a top-level value such as `null`, a string, or a
+  number. The native bridge now consumes the JSON text already encoded by
+  Dart instead of passing it through `JSONSerialization` a second time.
+
 ## 5.0.0 - 2026-08-16
 
 

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -2133,7 +2133,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                     // Dart's callHandler implementation already returns the callback value
                     // encoded with jsonEncode. Re-encoding this String with
                     // JSONSerialization crashes for top-level fragments (for example
-                    // "null") and would also change the value's JavaScript semantics.
+                    // null) and would also change the value's JavaScript semantics.
                     let json = result as? String ?? "null"
 #if DEBUG
                     let resultType = result.map {

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -2130,17 +2130,21 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                             }
                         """, completionHandler: nil)
                 } else {
-                    var json: String
-                    if let resultData = try? JSONSerialization.data(
-                        withJSONObject: result ?? NSNull(), options: []),
-                        let resultString = String(data: resultData, encoding: .utf8)
-                    {
-                        json = resultString
-                    } else if let simpleResult = result {
-                        json = "\"\(simpleResult)\""
-                    } else {
-                        json = "null"
-                    }
+                    // Dart's callHandler implementation already returns the callback value
+                    // encoded with jsonEncode. Re-encoding this String with
+                    // JSONSerialization crashes for top-level fragments (for example
+                    // "null") and would also change the value's JavaScript semantics.
+                    let json = result as? String ?? "null"
+#if DEBUG
+                    let resultType = result.map {
+                        String(describing: type(of: $0))
+                    } ?? "nil"
+                    print(
+                        "[ZikzakInAppWebView][JSBridge] handler=\(handlerName) "
+                            + "resultType=\(resultType) jsonLength=\(json.utf8.count) "
+                            + "fallbackToNull=\(result != nil && !(result is String))"
+                    )
+#endif
                     self.evaluateJavaScript(
                         """
                             if(window.\(JAVASCRIPT_BRIDGE_NAME)[\(_callHandlerID)] != null) {

--- a/zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart
+++ b/zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart
@@ -63,6 +63,33 @@ void main() {
     });
   });
 
+  group('callHandler channel contract', () {
+    Future<dynamic> invokeHandler(dynamic callbackResult) {
+      controller.addJavaScriptHandler(
+        handlerName: 'channelContract',
+        callback: (args) async => callbackResult,
+      );
+      return controller.handleMethod(
+        const MethodCall('callHandler', {
+          'handlerName': 'channelContract',
+          'args': '[]',
+        }),
+      );
+    }
+
+    test('returns null as JSON text for the native bridge', () async {
+      expect(await invokeHandler(null), 'null');
+    });
+
+    test('returns strings as JSON text for the native bridge', () async {
+      expect(await invokeHandler('ready'), '"ready"');
+    });
+
+    test('returns objects as JSON text for the native bridge', () async {
+      expect(await invokeHandler({'ready': true}), '{"ready":true}');
+    });
+  });
+
   group('removeJavaScriptHandler', () {
     test('returns null when handler does not exist', () {
       final result = controller.removeJavaScriptHandler(


### PR DESCRIPTION
## Summary

- consume the JSON text already produced by Dart's macOS `callHandler` implementation
- avoid passing top-level JSON results such as `null`, strings, numbers, booleans, arrays, or objects through `JSONSerialization` a second time
- safely fall back to JavaScript `null` for unexpected native result types
- add debug-only bridge metadata without logging callback payloads
- add Dart-to-native channel contract coverage for null, string, and object results

## Root cause

The macOS Dart controller already returns:

```dart
jsonEncode(await _javaScriptHandlersMap[handlerName]!(args))
```

Therefore Swift receives valid JSON text as a `String`. The native bridge then tried to serialize that top-level string again:

```swift
JSONSerialization.data(withJSONObject: result ?? NSNull(), options: [])
```

Foundation raises an uncaught `NSInvalidArgumentException` because a string is not accepted as a top-level JSON object with those options. This terminates the macOS process and cannot be caught by Swift's `try?`.

Using `.fragmentsAllowed` alone would stop the exception but would still be incorrect: it would encode the JSON text a second time. For example, Dart's JSON text `null` would resolve in JavaScript as the string `"null"` instead of the value `null`.

## Fix

Use the already encoded JSON string directly, matching the current iOS bridge behavior:

```swift
let json = result as? String ?? "null"
```

The debug build logs only handler metadata, result type, JSON byte length, and whether the safe `null` fallback was used. It does not print callback data.

## Verification

- `flutter test test/in_app_webview_controller_test.dart`: 17 tests passed
- regression coverage verifies JSON text returned for `null`, strings, and objects
- Luotopia resolved commit `3a577a080d0aa41069644dc35e21456c478a35c4` through Dart pub's HTTPS Git cache
- Luotopia targeted Flutter tests passed
- Luotopia targeted `flutter analyze` passed
- Luotopia macOS Debug build succeeded using the remotely resolved fork commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed macOS JavaScript handler callbacks that could crash when returning top-level JSON values such as `null`, strings, or numbers.
  * Preserved handler results as valid JSON text for reliable communication between Dart and JavaScript.

* **Tests**
  * Added coverage for `null`, string, and object results returned through the macOS handler interface.

* **Documentation**
  * Documented the fix in the unreleased changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->