### PR TITLE
fix(platform_interface): correct InAppWebViewSettings import path in PlatformSettingsDelegate

### DIFF
--- a/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_settings_delegate.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/in_app_webview/modules/platform_settings_delegate.dart
@@ -1,6 +1,6 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-import '../in_app_webview_settings.dart';
+import '../../domain/entities/in_app_webview_settings/in_app_webview_settings.dart';
 import '../platform_inappwebview_controller.dart';
 
 /// Delegate for reading and updating the WebView settings of a single


### PR DESCRIPTION
## Problem

The domain delegate split (#229 / #234) moved `in_app_webview_settings.dart` from `src/in_app_webview/` to `src/domain/entities/in_app_webview_settings/`, but the import in `platform_settings_delegate.dart` was not updated. It still points to the old relative path:

```dart
import '../in_app_webview_settings.dart';  // file no longer exists here
```

This causes a **compilation failure** in published 5.0.1 — any app depending on `zikzak_inappwebview: 5.0.1` gets:

```
Error: Error when reading .../in_app_webview/in_app_webview_settings.dart
```

## Fix

Update the import to the correct path, consistent with:
- The barrel export in `main.dart` (line 4): `export '../domain/entities/in_app_webview_settings/in_app_webview_settings.dart'`
- The import style used by sibling delegates (`platform_navigation_delegate.dart`, `platform_javascript_delegate.dart`, etc.)

```dart
import '../../domain/entities/in_app_webview_settings/in_app_webview_settings.dart';
```

## Scope

One-line change. No logic changes. No new files.

Closes #257 #255