### PR TITLE
test(platform_interface): add relative-import integrity guard for issue #257

### DIFF
--- a/zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guard for issue #257.
+///
+/// `zikzak_inappwebview_platform_interface` 5.0.1 shipped
+/// `lib/src/in_app_webview/modules/platform_settings_delegate.dart` with
+///
+///     import '../in_app_webview_settings.dart';
+///
+/// — a file that did not exist (the class lives under
+/// `lib/src/domain/entities/in_app_webview_settings/`). Every consumer of
+/// the published package failed to compile with
+///
+///     Error: Error when reading '.../in_app_webview_settings.dart':
+///     No such file or directory
+///     Type 'InAppWebViewSettings' not found.
+///
+/// The analyzer reports `uri_does_not_exist` for such directives, but no
+/// test surface caught it before the package was published, because the
+/// broken file is only reachable through the consumer's build.
+///
+/// This test walks every `.dart` file under `lib/` and asserts that every
+/// relative `import`/`export`/`part` URI resolves to a real file, so a
+/// dangling relative import can never ship to pub.dev again.
+void main() {
+  test(
+    'every relative import/export/part URI in lib/ resolves to a real file',
+    () {
+      final libDir = Directory.fromUri(Directory.current.uri.resolve('lib'));
+      expect(
+        libDir.existsSync(),
+        isTrue,
+        reason:
+            'lib/ not found under ${Directory.current.path} — the test must '
+            'run from the package root (flutter test does this by default).',
+      );
+
+      final dangling = <String>[];
+      var filesScanned = 0;
+      var directivesChecked = 0;
+
+      // Matches `import '...'`, `export '...'`, `part '...'` (also with
+      // double quotes) at the start of a line, allowing leading whitespace.
+      // `part of '...'` is intentionally not matched: after `part ` the
+      // regex requires a quote, and a `part of` directive targets the
+      // owning library, which exists by construction.
+      final directivePattern = RegExp(
+        r"""^\s*(?:import|export|part)\s+['"]([^'"]+)['"]""",
+        multiLine: true,
+      );
+
+      for (final entity in libDir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        filesScanned++;
+        final content = entity.readAsStringSync();
+        for (final match in directivePattern.allMatches(content)) {
+          final uri = match.group(1)!;
+          // `dart:` and `package:` URIs are resolved by the SDK / pub, not
+          // by the filesystem layout checked here.
+          if (uri.startsWith('dart:') || uri.startsWith('package:')) continue;
+          directivesChecked++;
+          final targetPath = entity.uri.resolve(uri).toFilePath();
+          if (!File(targetPath).existsSync()) {
+            dangling.add(
+              '${entity.path}: $uri -> $targetPath (missing)',
+            );
+          }
+        }
+      }
+
+      // Sanity: the walker must actually have scanned the package sources.
+      // If this fires, the test was run from an unexpected working directory
+      // and checked nothing (a silent pass would be worse than a failure).
+      expect(filesScanned, greaterThan(100));
+
+      expect(
+        dangling,
+        isEmpty,
+        reason:
+            'Found ${dangling.length} dangling relative URI(s) while checking '
+            '$directivesChecked directives in $filesScanned Dart files under '
+            'lib/. The analyzer would report "Target of URI doesn\'t exist" '
+            '(issue #257 regression — a broken import previously shipped to '
+            'pub.dev in 5.0.1). Offending directives:\n'
+            '${dangling.join('\n')}',
+      );
+    },
+  );
+}


### PR DESCRIPTION
Closes #257

## Root cause

`zikzak_inappwebview_platform_interface` **5.0.1** shipped `lib/src/in_app_webview/modules/platform_settings_delegate.dart` with a dangling relative import:

```dart
import '../in_app_webview_settings.dart';
```

That URI resolves to `lib/src/in_app_webview/in_app_webview_settings.dart`, which does not exist — `InAppWebViewSettings` actually lives at `lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart` (moved there by the delegate split in #229/#234, commit d87f7050). Every consumer of the published package failed to compile with:

```
Error: Error when reading '.../in_app_webview_settings.dart': No such file or directory
Type 'InAppWebViewSettings' not found.
```

Reproduced on the `5.0.1` tag with `dart analyze`:

```
error - platform_settings_delegate.dart:3:8 - Target of URI doesn't exist: '../in_app_webview_settings.dart'. - uri_does_not_exist
error - platform_settings_delegate.dart:22:38 - Undefined class 'InAppWebViewSettings'. - undefined_class
error - platform_settings_delegate.dart:29:10 - The name 'InAppWebViewSettings' isn't a type... - non_type_as_type_argument
```

## State of the code fix

The import itself was already corrected on master (in 5.1.0, commit 8a37ab4b) to:

```dart
import '../../domain/entities/in_app_webview_settings/in_app_webview_settings.dart';
```

`dart analyze` on the current `zikzak_inappwebview_platform_interface` reports **0 errors**, so consumers on 5.1.0+ are unaffected. Upgrading past 5.0.1 is the workaround for affected users.

## What this PR adds

The bug class that let #257 happen is still unguarded: nothing in the repo verifies that relative import/export/part URIs resolve to real files, so a refactor can reintroduce a dangling import and it only surfaces in *consumers'* builds (the repo has no CI workflows running analyze either). This PR adds a regression guard:

**`zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart`** — walks all 449 `.dart` files under `lib/`, resolves each of the 893 relative `import`/`export`/`part` URIs against the importing file, and fails with an issue-#257-specific message listing every dangling directive. Includes a sanity floor (files scanned > 100) so it can never silently pass from a wrong working directory.

## Verification

- Regression test reintroduces the exact 5.0.1 broken import in a scratch copy → test **fails**, naming the offending file, directive, and missing target:
  ```
  lib/src/in_app_webview/modules/platform_settings_delegate.dart: ../in_app_webview_settings.dart
    -> .../lib/src/in_app_webview/in_app_webview_settings.dart (missing)
  ```
- On master: test passes; full `flutter test` suite → **151/151 passed**; `dart analyze` → **0 errors**.
