### PR TITLE
fix(macos): dispatch onScrollChanged/onContentSizeChanged/onOverScrolled to callbacks

### DIFF
--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -364,6 +364,43 @@ class MacOSInAppWebViewController extends PlatformInAppWebViewController {
           ))?.toJson();
         }
         break;
+      case 'onScrollChanged':
+        if (params.webviewParams?.onScrollChanged != null) {
+          params.webviewParams!.onScrollChanged!(
+            controller,
+            call.arguments['x'] as int? ?? 0,
+            call.arguments['y'] as int? ?? 0,
+          );
+        }
+        break;
+      case 'onContentSizeChanged':
+        if (params.webviewParams?.onContentSizeChanged != null) {
+          final old = call.arguments['oldContentSize'] as Map? ?? {};
+          final neu = call.arguments['newContentSize'] as Map? ?? {};
+          params.webviewParams!.onContentSizeChanged!(
+            controller,
+            Size(
+              (old['width'] as num? ?? 0).toDouble(),
+              (old['height'] as num? ?? 0).toDouble(),
+            ),
+            Size(
+              (neu['width'] as num? ?? 0).toDouble(),
+              (neu['height'] as num? ?? 0).toDouble(),
+            ),
+          );
+        }
+        break;
+      case 'onOverScrolled':
+        if (params.webviewParams?.onOverScrolled != null) {
+          params.webviewParams!.onOverScrolled!(
+            controller,
+            call.arguments['x'] as int? ?? 0,
+            call.arguments['y'] as int? ?? 0,
+            call.arguments['clampedX'] as bool? ?? false,
+            call.arguments['clampedY'] as bool? ?? false,
+          );
+        }
+        break;
       default:
         throw UnimplementedError("Unimplemented ${call.method} method");
     }

--- a/zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart
+++ b/zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart
@@ -294,4 +294,124 @@ void main() {
       },
     );
   });
+
+  // Regression test for issue #197 / macOS scroll callbacks:
+  // the native side emits onScrollChanged / onContentSizeChanged /
+  // onOverScrolled, but the Dart dispatcher previously had no case arms and
+  // fell through to `default:` throwing UnimplementedError. These tests pin the
+  // Dart-side channel contract so a future refactor cannot silently re-break it.
+  group('scroll callbacks (issue #197)', () {
+    test('onScrollChanged invokes the callback with decoded x/y', () async {
+      int? receivedX;
+      int? receivedY;
+      final widgetParams = PlatformInAppWebViewWidgetCreationParams(
+        controllerFromPlatform: (c) => c,
+        onScrollChanged: (c, x, y) {
+          receivedX = x;
+          receivedY = y;
+        },
+      );
+      final controllerParams = PlatformInAppWebViewControllerCreationParams(
+        id: 11111,
+        webviewParams: widgetParams,
+      );
+      final ctl = MacOSInAppWebViewController(controllerParams);
+      addTearDown(ctl.dispose);
+
+      await ctl.handleMethod(
+        MethodCall('onScrollChanged', {'x': 12, 'y': 34}),
+      );
+
+      expect(receivedX, 12);
+      expect(receivedY, 34);
+    });
+
+    test('onContentSizeChanged invokes the callback with decoded sizes',
+        () async {
+      Size? oldSize;
+      Size? newSize;
+      final widgetParams = PlatformInAppWebViewWidgetCreationParams(
+        controllerFromPlatform: (c) => c,
+        onContentSizeChanged: (c, oldContentSize, newContentSize) {
+          oldSize = oldContentSize;
+          newSize = newContentSize;
+        },
+      );
+      final controllerParams = PlatformInAppWebViewControllerCreationParams(
+        id: 22222,
+        webviewParams: widgetParams,
+      );
+      final ctl = MacOSInAppWebViewController(controllerParams);
+      addTearDown(ctl.dispose);
+
+      await ctl.handleMethod(
+        MethodCall('onContentSizeChanged', {
+          'oldContentSize': {'width': 100.0, 'height': 200.0},
+          'newContentSize': {'width': 300.0, 'height': 400.0},
+        }),
+      );
+
+      expect(oldSize, const Size(100, 200));
+      expect(newSize, const Size(300, 400));
+    });
+
+    test('onOverScrolled invokes the callback with decoded flags', () async {
+      int? x;
+      int? y;
+      bool? clampedX;
+      bool? clampedY;
+      final widgetParams = PlatformInAppWebViewWidgetCreationParams(
+        controllerFromPlatform: (c) => c,
+        onOverScrolled: (c, xv, yv, cx, cy) {
+          x = xv;
+          y = yv;
+          clampedX = cx;
+          clampedY = cy;
+        },
+      );
+      final controllerParams = PlatformInAppWebViewControllerCreationParams(
+        id: 33333,
+        webviewParams: widgetParams,
+      );
+      final ctl = MacOSInAppWebViewController(controllerParams);
+      addTearDown(ctl.dispose);
+
+      await ctl.handleMethod(
+        MethodCall('onOverScrolled', {
+          'x': 5,
+          'y': 6,
+          'clampedX': true,
+          'clampedY': false,
+        }),
+      );
+
+      expect(x, 5);
+      expect(y, 6);
+      expect(clampedX, isTrue);
+      expect(clampedY, isFalse);
+    });
+
+    test('does not throw when no callback is registered', () async {
+      // controller from setUp has no scroll callbacks wired up.
+      await controller.handleMethod(
+        MethodCall('onScrollChanged', {'x': 0, 'y': 0}),
+      );
+      await controller.handleMethod(
+        MethodCall('onContentSizeChanged', {
+          'oldContentSize': {'width': 0.0, 'height': 0.0},
+          'newContentSize': {'width': 0.0, 'height': 0.0},
+        }),
+      );
+      await controller.handleMethod(
+        MethodCall('onOverScrolled', {
+          'x': 0,
+          'y': 0,
+          'clampedX': false,
+          'clampedY': false,
+        }),
+      );
+      // reaching here without throwing is the assertion: the three case arms
+      // exist and the default throw is no longer hit for these method names.
+    });
+  });
 }


### PR DESCRIPTION
## Summary

The native macOS side already emits `onScrollChanged` / `onContentSizeChanged` / `onOverScrolled` over the method channel (issue #197), but the Dart `handleMethod` dispatcher in `MacOSInAppWebViewController` had no `case` arms for them. They fell through to `default:` and threw `UnimplementedError` on every page load and scroll, spamming the console and silently never delivering the registered callbacks.

This adds the three missing `case` arms (mirroring the existing `onProgressChanged` arm), each null-guarded and decoding the native payload, so the callbacks forward to `params.webviewParams` when registered.

## Changes

| File | Change |
|------|--------|
| `zikzak_inappwebview_macos/lib/src/in_app_webview/in_app_webview_controller.dart` | Added `case 'onScrollChanged'`, `case 'onContentSizeChanged'`, `case 'onOverScrolled'` before `default:`, each forwarding decoded native args to the corresponding `webviewParams` callback. |
| `zikzak_inappwebview_macos/test/in_app_webview_controller_test.dart` | Added `scroll callbacks (issue #197)` group: 4 tests pinning the Dart-side channel contract (and that `default:` is no longer hit for these names). |

## Verification

- `dart analyze lib` → 0 errors.
- `flutter test` (macos package) → 41/41 passed, including the 4 new scroll-callback tests.

## Notes

- Pure additive change to the macOS plugin; no platform-interface or cross-platform API breakage.
- Does not change behavior for consumers that do not register these callbacks (null-guarded).

Assessment: `.specify/bugs/macos-unimplemented-scroll-callbacks/assessment.md`
