### PR TITLE
Platform parity hardening & publish-regression guards (consolidated landing of PRs #262-#266)

### DIFF
--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -806,14 +806,18 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 // websiteDataStore is immutable post-init, so a later
                 // `setSettings` cannot change it (see issue #253
                 // acceptance criteria).
-                if #available(iOS 17.0, *),
+                var dataStoreWasSelected = false
+                if settings.incognito {
+                    configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+                    dataStoreWasSelected = true
+                } else if #available(iOS 17.0, *),
                    let id = settings.persistentStoreIdentifier, !id.isEmpty,
                    let uuid = persistentUUID(from: id) {
                     configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: uuid)
-                } else if settings.incognito {
-                    configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
+                    dataStoreWasSelected = true
                 } else if settings.cacheEnabled {
                     configuration.websiteDataStore = WKWebsiteDataStore.default()
+                    dataStoreWasSelected = true
                 }
                 if !settings.applicationNameForUserAgent.isEmpty {
                     if let applicationNameForUserAgent = configuration.applicationNameForUserAgent {
@@ -852,8 +856,10 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     // Set Cookies in iOS 11 and above, initialize websiteDataStore before setting cookies
                     // See also https://forums.developer.apple.com/thread/97194
                     // check if websiteDataStore has not been initialized before
-                    if !settings.incognito && !settings.cacheEnabled
-                        && settings.persistentStoreIdentifier == nil {
+                    let hasValidPersistentId = settings.persistentStoreIdentifier.map {
+                        persistentUUID(from: $0) != nil
+                    } ?? false
+                    if !dataStoreWasSelected && !hasValidPersistentId {
                         configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                     }
                     for cookie in HTTPCookieStorage.shared.cookies ?? [] {

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -5,9 +5,76 @@
 //  Created by Lorenzo on 21/10/18.
 //
 
+import CryptoKit
 import Flutter
 import Foundation
 import WebKit
+
+/// Maps a stable identifier string into a stable `UUID` for
+/// `WKWebsiteDataStore(forIdentifier:)`. Accepts three input shapes so the
+/// same Dart field can be fed either a raw UUID string, a stable profile
+/// name, or the 64-char SHA-256 hex the forklift caller used to send
+/// (derived from a profile dir's canonical path). All three are
+/// deterministic — the same identifier always yields the same on-disk
+/// store, which is what makes a per-account session survive app relaunch.
+/// Mirrors the macOS helper 1:1 to keep the Dart-side contract identical
+/// across platforms.
+///
+/// Shape priority: (a) direct UUID string -> (b) 64-char hex legacy path
+/// -> (c) SHA-256 of the UTF-8 bytes (CryptoKit, iOS 13+/macOS 10.15+,
+/// well below the iOS 17+/macOS 14+ floor of the persistent-store API
+/// itself).
+private func persistentUUID(from identifier: String) -> UUID? {
+    let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    // (a) Direct UUID string ("550e8400-e29b-41d4-a716-446655440000").
+    if let direct = UUID(uuidString: trimmed) {
+        return direct
+    }
+
+    // (b) Legacy 64-char SHA-256 hex path: take the first 32 hex chars
+    // (16 bytes) and treat them as the UUID's raw bytes. Preserves the
+    // on-disk store identifier forklift's Cloaked Chrome profiles already
+    // use, so existing persistent stores keep reopening after the upgrade.
+    let hexSet = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+    let isHex = trimmed.unicodeScalars.allSatisfy { hexSet.contains($0) }
+    if isHex, trimmed.count >= 32 {
+        let prefix = trimmed.prefix(32)
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(16)
+        var index = prefix.startIndex
+        while index < prefix.endIndex {
+            let next = prefix.index(index, offsetBy: 2, limitedBy: prefix.endIndex) ?? prefix.endIndex
+            guard let byte = UInt8(String(prefix[index..<next]), radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        guard bytes.count == 16 else { return nil }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    // (c) Any other stable string: SHA-256 the UTF-8 bytes and use the
+    // first 16 bytes as the UUID's raw bytes. Deterministic, isolated,
+    // and survives relaunch — distinct identifiers never collide.
+    // CryptoKit ships with the system on iOS 13+/macOS 10.15+, so this
+    // branch is always available when the iOS 17+ persistent store path
+    // runs.
+    if #available(iOS 13.0, *) {
+        let digest = SHA256.hash(data: Data(trimmed.utf8))
+        let sha = Array(digest)
+        return UUID(uuid: (
+            sha[0],  sha[1],  sha[2],  sha[3],
+            sha[4],  sha[5],  sha[6],  sha[7],
+            sha[8],  sha[9],  sha[10], sha[11],
+            sha[12], sha[13], sha[14], sha[15]
+        ))
+    }
+    return nil
+}
 
 public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
     WKNavigationDelegate, WKScriptMessageHandler, UIGestureRecognizerDelegate,
@@ -726,7 +793,24 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
             }
 
             if #available(iOS 9.0, *) {
-                if settings.incognito {
+                // Per-instance persistent, isolated WKWebsiteDataStore
+                // (iOS 17+/macOS 14+). Same persistentStoreIdentifier
+                // reopens the same on-disk store across launches; distinct
+                // identifiers yield fully isolated cookies/localStorage/
+                // cache. Mutually exclusive with `incognito` — incognito
+                // is non-persistent (wiped on tear-down) and takes
+                // precedence. Below iOS 17 the persistent path is
+                // unavailable, so we fall through to the shared `.default()`
+                // store (existing behavior). Must be applied here, on the
+                // configuration BEFORE the WKWebView is created —
+                // websiteDataStore is immutable post-init, so a later
+                // `setSettings` cannot change it (see issue #253
+                // acceptance criteria).
+                if #available(iOS 17.0, *),
+                   let id = settings.persistentStoreIdentifier, !id.isEmpty,
+                   let uuid = persistentUUID(from: id) {
+                    configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: uuid)
+                } else if settings.incognito {
                     configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                 } else if settings.cacheEnabled {
                     configuration.websiteDataStore = WKWebsiteDataStore.default()
@@ -768,7 +852,8 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     // Set Cookies in iOS 11 and above, initialize websiteDataStore before setting cookies
                     // See also https://forums.developer.apple.com/thread/97194
                     // check if websiteDataStore has not been initialized before
-                    if !settings.incognito && !settings.cacheEnabled {
+                    if !settings.incognito && !settings.cacheEnabled
+                        && settings.persistentStoreIdentifier == nil {
                         configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                     }
                     for cookie in HTTPCookieStorage.shared.cookies ?? [] {

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebViewSettings.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebViewSettings.swift
@@ -30,6 +30,12 @@ public class InAppWebViewSettings: ISettings<InAppWebView> {
     var interceptOnlyAsyncAjaxRequests = true
     var useShouldInterceptFetchRequest = false
     var incognito = false
+    /// Stable identifier for a per-instance persistent WKWebsiteDataStore
+    /// (iOS 17+/macOS 14+). Mirrors the Dart-side field; populated from
+    /// the JSON dict by ISettings.parse via KVC. Mutually exclusive with
+    /// `incognito`; init-time-only — websiteDataStore is immutable after
+    /// the WKWebView is created.
+    var persistentStoreIdentifier: String? = nil
     var cacheEnabled = true
     var transparentBackground = false
     var disableVerticalScroll = false

--- a/zikzak_inappwebview_linux/lib/src/cookie_manager.dart
+++ b/zikzak_inappwebview_linux/lib/src/cookie_manager.dart
@@ -1,9 +1,32 @@
+import 'package:flutter/services.dart';
+
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 /// Implementation of [PlatformCookieManager] for Linux.
+////
+/// Wires cookie operations to the native WebKitGTK cookie manager
+/// (WebKitCookieManager / SoupCookieManager) via [MethodChannel].
 class LinuxCookieManager extends PlatformCookieManager {
+  static final MethodChannel _channel = MethodChannel(
+    'dev.zuzu/zikzak_inappwebview_cookiemanager',
+  );
+
+  static LinuxCookieManager? _instance;
+
   /// Constructs a [LinuxCookieManager].
   LinuxCookieManager(super.params) : super.implementation();
+
+  /// Gets the [LinuxCookieManager] shared instance.
+  static LinuxCookieManager instance() {
+    return (_instance != null) ? _instance! : _init();
+  }
+
+  static LinuxCookieManager _init() {
+    _instance = LinuxCookieManager(
+      const PlatformCookieManagerCreationParams(),
+    );
+    return _instance!;
+  }
 
   @override
   Future<bool> setCookie({
@@ -19,8 +42,18 @@ class LinuxCookieManager extends PlatformCookieManager {
     HTTPCookieSameSitePolicy? sameSite,
     PlatformInAppWebViewController? webViewController,
   }) async {
-    // TODO: implement setCookie
-    return true;
+    Map<String, dynamic> args = <String, dynamic>{};
+    args['url'] = url.toString();
+    args['name'] = name;
+    args['value'] = value;
+    args['path'] = path;
+    args['domain'] = domain;
+    args['expiresDate'] = expiresDate?.toString();
+    args['maxAge'] = maxAge;
+    args['isSecure'] = isSecure;
+    args['isHttpOnly'] = isHttpOnly;
+    args['sameSite'] = sameSite?.index;
+    return await _channel.invokeMethod<bool>('setCookie', args) ?? false;
   }
 
   @override
@@ -28,8 +61,36 @@ class LinuxCookieManager extends PlatformCookieManager {
     required WebUri url,
     PlatformInAppWebViewController? webViewController,
   }) async {
-    // TODO: implement getCookies
-    return [];
+    Map<String, dynamic> args = <String, dynamic>{};
+    args['url'] = url.toString();
+    List<dynamic> cookieListMap =
+        await _channel.invokeMethod<List>('getCookies', args) ?? [];
+    cookieListMap = cookieListMap.cast<Map<dynamic, dynamic>>();
+
+    List<Cookie> cookies = [];
+    for (final cookieMap in cookieListMap) {
+      final map = (cookieMap as Map).cast<String, dynamic>();
+      cookies.add(
+        Cookie(
+          name: map['name'],
+          value: map['value'],
+          expiresDate: map['expiresDate'],
+          isSessionOnly: map['isSessionOnly'],
+          domain: map['domain'],
+          sameSite: map['sameSite'] is int
+              ? HTTPCookieSameSitePolicy
+                  .values[map['sameSite'] <
+                          HTTPCookieSameSitePolicy.values.length
+                      ? map['sameSite']
+                      : 0]
+              : null,
+          isSecure: map['isSecure'],
+          isHttpOnly: map['isHttpOnly'],
+          path: map['path'],
+        ),
+      );
+    }
+    return cookies;
   }
 
   @override
@@ -38,7 +99,10 @@ class LinuxCookieManager extends PlatformCookieManager {
     required String name,
     PlatformInAppWebViewController? webViewController,
   }) async {
-    // TODO: implement getCookie
+    final cookies = await getCookies(url: url, webViewController: webViewController);
+    for (final cookie in cookies) {
+      if (cookie.name == name) return cookie;
+    }
     return null;
   }
 
@@ -50,8 +114,12 @@ class LinuxCookieManager extends PlatformCookieManager {
     String? domain,
     PlatformInAppWebViewController? webViewController,
   }) async {
-    // TODO: implement deleteCookie
-    return true;
+    Map<String, dynamic> args = <String, dynamic>{};
+    args['url'] = url.toString();
+    args['name'] = name;
+    args['domain'] = domain;
+    args['path'] = path;
+    return await _channel.invokeMethod<bool>('deleteCookie', args) ?? false;
   }
 
   @override
@@ -61,20 +129,61 @@ class LinuxCookieManager extends PlatformCookieManager {
     String? domain,
     PlatformInAppWebViewController? webViewController,
   }) async {
-    // TODO: implement deleteCookies
-    return true;
+    Map<String, dynamic> args = <String, dynamic>{};
+    args['url'] = url.toString();
+    args['domain'] = domain;
+    args['path'] = path;
+    return await _channel.invokeMethod<bool>('deleteCookies', args) ?? false;
   }
 
   @override
-  Future<bool> deleteAllCookies({
-    PlatformInAppWebViewController? webViewController,
-  }) async {
-    // TODO: implement deleteAllCookies
-    return true;
+  Future<bool> deleteAllCookies() async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    return await _channel.invokeMethod<bool>('deleteAllCookies', args) ??
+        false;
+  }
+
+  @override
+  Future<List<Cookie>> getAllCookies() async {
+    List<dynamic> cookieListMap =
+        await _channel.invokeMethod<List>('getAllCookies') ?? [];
+    cookieListMap = cookieListMap.cast<Map<dynamic, dynamic>>();
+
+    List<Cookie> cookies = [];
+    for (final cookieMap in cookieListMap) {
+      final map = (cookieMap as Map).cast<String, dynamic>();
+      cookies.add(
+        Cookie(
+          name: map['name'],
+          value: map['value'],
+          expiresDate: map['expiresDate'],
+          isSessionOnly: map['isSessionOnly'],
+          domain: map['domain'],
+          sameSite: map['sameSite'] is int
+              ? HTTPCookieSameSitePolicy
+                  .values[map['sameSite'] <
+                          HTTPCookieSameSitePolicy.values.length
+                      ? map['sameSite']
+                      : 0]
+              : null,
+          isSecure: map['isSecure'],
+          isHttpOnly: map['isHttpOnly'],
+          path: map['path'],
+        ),
+      );
+    }
+    return cookies;
+  }
+
+  @override
+  Future<bool> removeSessionCookies() async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    return await _channel.invokeMethod<bool>('removeSessionCookies', args) ??
+        false;
   }
 
   @override
   Future<void> dispose({bool isKeepAlive = false}) async {
-    // TODO: implement dispose
+    // nothing to dispose — the MethodChannel is static
   }
 }

--- a/zikzak_inappwebview_linux/lib/src/cookie_manager.dart
+++ b/zikzak_inappwebview_linux/lib/src/cookie_manager.dart
@@ -48,11 +48,11 @@ class LinuxCookieManager extends PlatformCookieManager {
     args['value'] = value;
     args['path'] = path;
     args['domain'] = domain;
-    args['expiresDate'] = expiresDate?.toString();
+    args['expiresDate'] = expiresDate;
     args['maxAge'] = maxAge;
     args['isSecure'] = isSecure;
     args['isHttpOnly'] = isHttpOnly;
-    args['sameSite'] = sameSite?.index;
+    args['sameSite'] = httpCookieSameSitePolicyToWire(sameSite);
     return await _channel.invokeMethod<bool>('setCookie', args) ?? false;
   }
 
@@ -77,13 +77,7 @@ class LinuxCookieManager extends PlatformCookieManager {
           expiresDate: map['expiresDate'],
           isSessionOnly: map['isSessionOnly'],
           domain: map['domain'],
-          sameSite: map['sameSite'] is int
-              ? HTTPCookieSameSitePolicy
-                  .values[map['sameSite'] <
-                          HTTPCookieSameSitePolicy.values.length
-                      ? map['sameSite']
-                      : 0]
-              : null,
+          sameSite: httpCookieSameSitePolicyFromWire(map['sameSite']),
           isSecure: map['isSecure'],
           isHttpOnly: map['isHttpOnly'],
           path: map['path'],
@@ -159,13 +153,7 @@ class LinuxCookieManager extends PlatformCookieManager {
           expiresDate: map['expiresDate'],
           isSessionOnly: map['isSessionOnly'],
           domain: map['domain'],
-          sameSite: map['sameSite'] is int
-              ? HTTPCookieSameSitePolicy
-                  .values[map['sameSite'] <
-                          HTTPCookieSameSitePolicy.values.length
-                      ? map['sameSite']
-                      : 0]
-              : null,
+          sameSite: httpCookieSameSitePolicyFromWire(map['sameSite']),
           isSecure: map['isSecure'],
           isHttpOnly: map['isHttpOnly'],
           path: map['path'],

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview.dart
@@ -48,9 +48,6 @@ class _LinuxInAppWebViewState extends State<_LinuxInAppWebView> {
   }
 
   Future<void> _createWebView() async {
-    // Generate a unique ID for the webview.
-    // In MacOS implementation, platform view ID is provided by the platform.
-    // Here we generate it to match our custom create logic.
     var id = DateTime.now().microsecondsSinceEpoch.toString();
 
     try {
@@ -70,11 +67,10 @@ class _LinuxInAppWebViewState extends State<_LinuxInAppWebView> {
         setState(() {
           _textureId = textureId;
         });
-        // Use the ID we generated to create the controller, as the native side used it too.
         _onPlatformViewCreated(id);
       }
     } catch (e) {
-      print("Error creating webview: $e");
+      debugPrint('Error creating webview: $e');
     }
   }
 
@@ -115,11 +111,10 @@ class _LinuxInAppWebViewState extends State<_LinuxInAppWebView> {
     if (_textureId != null) {
       return Texture(textureId: _textureId!);
     }
-    // Return a placeholder or empty container
     return Container(
       color: const Color(0xFFFFFFFF),
       child: const Center(
-        child: Text("Linux InAppWebView (Implemented via Texture/Native)"),
+        child: Text('Linux InAppWebView (Implemented via Texture/Native)'),
       ),
     );
   }

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -33,6 +33,9 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
 
   late MethodChannel _channel;
 
+  final Map<String, void Function(Map<String, dynamic>)>
+      _devToolsProtocolEventListeners = {};
+
   Future<dynamic> handleMethod(MethodCall call) async {
     final controller = params.webviewParams?.controllerFromPlatform != null
         ? params.webviewParams!.controllerFromPlatform!(this)
@@ -403,8 +406,20 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
         if (params.webviewParams?.onOverScrolled != null) {
           int scrollX = call.arguments['scrollX'] ?? 0;
           int scrollY = call.arguments['scrollY'] ?? 0;
-          bool clampedX = (call.arguments['clampedX'] as int?) != 0;
-          bool clampedY = (call.arguments['clampedY'] as int?) != 0;
+          bool clampedX = false;
+          bool clampedY = false;
+          final clampedXRaw = call.arguments['clampedX'];
+          final clampedYRaw = call.arguments['clampedY'];
+          if (clampedXRaw is bool) {
+            clampedX = clampedXRaw;
+          } else if (clampedXRaw is int) {
+            clampedX = clampedXRaw != 0;
+          }
+          if (clampedYRaw is bool) {
+            clampedY = clampedYRaw;
+          } else if (clampedYRaw is int) {
+            clampedY = clampedYRaw != 0;
+          }
           params.webviewParams!.onOverScrolled!(
             controller,
             scrollX,
@@ -463,10 +478,19 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
         break;
       case 'onContentSizeChanged':
         if (params.webviewParams?.onContentSizeChanged != null) {
-          var sizeMap = call.arguments['size'];
+          var oldSizeMap = call.arguments['oldSize'];
+          var newSizeMap = call.arguments['size'];
+          Size oldContentSize = Size.zero;
           Size newContentSize = Size.zero;
-          if (sizeMap is Map) {
-            final m = sizeMap.cast<String, dynamic>();
+          if (oldSizeMap is Map) {
+            final m = oldSizeMap.cast<String, dynamic>();
+            oldContentSize = Size(
+              (m['width'] as num?)?.toDouble() ?? 0.0,
+              (m['height'] as num?)?.toDouble() ?? 0.0,
+            );
+          }
+          if (newSizeMap is Map) {
+            final m = newSizeMap.cast<String, dynamic>();
             newContentSize = Size(
               (m['width'] as num?)?.toDouble() ?? 0.0,
               (m['height'] as num?)?.toDouble() ?? 0.0,
@@ -474,7 +498,7 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
           }
           params.webviewParams!.onContentSizeChanged!(
             controller,
-            Size.zero,
+            oldContentSize,
             newContentSize,
           );
         }
@@ -507,6 +531,16 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
         }
         break;
       default:
+        // Check if this is a DevTools protocol event
+        if (call.method.startsWith('onDevToolsProtocolEvent:')) {
+          final eventName = call.method.substring('onDevToolsProtocolEvent:'.length);
+          final callback = _devToolsProtocolEventListeners[eventName];
+          if (callback != null) {
+            final params = (call.arguments as Map?)?.cast<String, dynamic>() ?? {};
+            callback(params);
+          }
+          break;
+        }
         throw UnimplementedError("Unimplemented ${call.method} method");
     }
   }
@@ -562,7 +596,14 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   }) async {
     Map<String, dynamic> args = <String, dynamic>{};
     args.putIfAbsent('data', () => data);
+    args.putIfAbsent('mimeType', () => mimeType);
+    args.putIfAbsent('encoding', () => encoding);
     args.putIfAbsent('baseUrl', () => baseUrl?.toString());
+    args.putIfAbsent('historyUrl', () => historyUrl?.toString());
+    args.putIfAbsent(
+      'allowingReadAccessTo',
+      () => allowingReadAccessTo?.toString(),
+    );
     await _channel.invokeMethod('loadData', args);
   }
 
@@ -1205,6 +1246,7 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
     required String eventName,
     required void Function(Map<String, dynamic>) callback,
   }) async {
+    _devToolsProtocolEventListeners[eventName] = callback;
     Map<String, dynamic> args = <String, dynamic>{};
     args.putIfAbsent('eventName', () => eventName);
     await _channel.invokeMethod('addDevToolsProtocolEventListener', args);
@@ -1214,6 +1256,7 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   Future<void> removeDevToolsProtocolEventListener({
     required String eventName,
   }) async {
+    _devToolsProtocolEventListeners.remove(eventName);
     Map<String, dynamic> args = <String, dynamic>{};
     args.putIfAbsent('eventName', () => eventName);
     await _channel.invokeMethod('removeDevToolsProtocolEventListener', args);

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -1,5 +1,4 @@
-import 'dart:core';
-
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
@@ -11,8 +10,11 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
     _channel.setMethodCallHandler((call) async {
       try {
         return await handleMethod(call);
-      } catch (e) {
-        // ignore error
+      } catch (e, stackTrace) {
+        debugPrint(
+          'LinuxInAppWebViewController: error handling ${call.method}: '
+          '$e\n$stackTrace',
+        );
       }
     });
   }
@@ -85,6 +87,21 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
           );
         }
         break;
+      case 'onReceivedHttpError':
+        if (params.webviewParams?.onReceivedHttpError != null) {
+          String? url = call.arguments['url'];
+          int statusCode = call.arguments['statusCode'];
+          String? description = call.arguments['description'];
+          params.webviewParams!.onReceivedHttpError!(
+            controller,
+            WebResourceRequest(url: url != null ? WebUri(url) : WebUri('')),
+            WebResourceResponse(
+              statusCode: statusCode,
+              reasonPhrase: description,
+            ),
+          );
+        }
+        break;
       case 'onProgressChanged':
         if (params.webviewParams?.onProgressChanged != null) {
           int progress = call.arguments['progress'];
@@ -109,14 +126,14 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
         }
         break;
       case 'shouldOverrideUrlLoading':
-        // Linux might not support this fully yet, but we'll include it.
         if (params.webviewParams?.shouldOverrideUrlLoading != null) {
-          Map<String, dynamic> arguments = call.arguments
-              .cast<String, dynamic>();
+          Map<String, dynamic> arguments =
+              call.arguments.cast<String, dynamic>();
           var navigationAction = NavigationAction.fromJson(
             arguments['navigationAction'].cast<String, dynamic>(),
           );
-          var policy = await params.webviewParams!.shouldOverrideUrlLoading!(
+          var policy =
+              await params.webviewParams!.shouldOverrideUrlLoading!(
             controller,
             navigationAction,
           );
@@ -131,10 +148,370 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
           params.webviewParams!.onConsoleMessage!(controller, consoleMessage);
         }
         break;
+      case 'onScrollChanged':
+        if (params.webviewParams?.onScrollChanged != null) {
+          int scrollX = call.arguments['scrollX'] ?? 0;
+          int scrollY = call.arguments['scrollY'] ?? 0;
+          params.webviewParams!.onScrollChanged!(
+            controller,
+            scrollX,
+            scrollY,
+          );
+        }
+        break;
+      case 'onDownloadStartRequest':
+        if (params.webviewParams?.onDownloadStartRequest != null) {
+          var downloadStartRequest = DownloadStartRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          params.webviewParams!.onDownloadStartRequest!(
+            controller,
+            downloadStartRequest,
+          );
+        }
+        break;
+      case 'onLoadResourceWithCustomScheme':
+        if (params.webviewParams?.onLoadResourceWithCustomScheme != null) {
+          var request = WebResourceRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          return await params.webviewParams!.onLoadResourceWithCustomScheme!(
+            controller,
+            request,
+          );
+        }
+        break;
+      case 'onCreateWindow':
+        if (params.webviewParams?.onCreateWindow != null) {
+          var createWindowAction = CreateWindowAction.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          var isHandled =
+              await params.webviewParams!.onCreateWindow!(
+            controller,
+            createWindowAction,
+          );
+          return isHandled ?? false;
+        }
+        return false;
+      case 'onCloseWindow':
+        if (params.webviewParams?.onCloseWindow != null) {
+          params.webviewParams!.onCloseWindow!(controller);
+        }
+        break;
+      case 'onJsAlert':
+        if (params.webviewParams?.onJsAlert != null) {
+          var jsAlertRequest = JsAlertRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          return await params.webviewParams!.onJsAlert!(
+            controller,
+            jsAlertRequest,
+          );
+        }
+        break;
+      case 'onJsConfirm':
+        if (params.webviewParams?.onJsConfirm != null) {
+          var jsConfirmRequest = JsConfirmRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          return await params.webviewParams!.onJsConfirm!(
+            controller,
+            jsConfirmRequest,
+          );
+        }
+        break;
+      case 'onJsPrompt':
+        if (params.webviewParams?.onJsPrompt != null) {
+          var jsPromptRequest = JsPromptRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          return await params.webviewParams!.onJsPrompt!(
+            controller,
+            jsPromptRequest,
+          );
+        }
+        break;
+      case 'onJsBeforeUnload':
+        if (params.webviewParams?.onJsBeforeUnload != null) {
+          var jsBeforeUnloadRequest = JsBeforeUnloadRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          return await params.webviewParams!.onJsBeforeUnload!(
+            controller,
+            jsBeforeUnloadRequest,
+          );
+        }
+        break;
+      case 'onReceivedHttpAuthRequest':
+        if (params.webviewParams?.onReceivedHttpAuthRequest != null) {
+          var challenge = HttpAuthenticationChallenge.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          if (challenge == null) break;
+          return await params.webviewParams!.onReceivedHttpAuthRequest!(
+            controller,
+            challenge,
+          );
+        }
+        break;
+      case 'onReceivedServerTrustAuthRequest':
+        if (params.webviewParams?.onReceivedServerTrustAuthRequest != null) {
+          var challenge = ServerTrustChallenge.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          if (challenge == null) break;
+          return await params.webviewParams!
+              .onReceivedServerTrustAuthRequest!(controller, challenge);
+        }
+        break;
+      case 'onReceivedClientCertRequest':
+        if (params.webviewParams?.onReceivedClientCertRequest != null) {
+          var challenge = ClientCertChallenge.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          if (challenge == null) break;
+          return await params.webviewParams!.onReceivedClientCertRequest!(
+            controller,
+            challenge,
+          );
+        }
+        break;
+      case 'onGeolocationPermissionsShowPrompt':
+        if (params.webviewParams
+            ?.onGeolocationPermissionsShowPrompt != null) {
+          String origin = call.arguments['origin'] ?? '';
+          return await params.webviewParams!
+              .onGeolocationPermissionsShowPrompt!(controller, origin);
+        }
+        break;
+      case 'onGeolocationPermissionsHidePrompt':
+        if (params.webviewParams
+            ?.onGeolocationPermissionsHidePrompt != null) {
+          params.webviewParams!.onGeolocationPermissionsHidePrompt!(
+            controller,
+          );
+        }
+        break;
+      case 'onFormResubmission':
+        if (params.webviewParams?.onFormResubmission != null) {
+          String? url = call.arguments['url'];
+          return await params.webviewParams!.onFormResubmission!(
+            controller,
+            url != null ? WebUri(url) : null,
+          );
+        }
+        break;
+      case 'onZoomScaleChanged':
+        if (params.webviewParams?.onZoomScaleChanged != null) {
+          double oldScale = call.arguments['oldScale'] ?? 1.0;
+          double newScale = call.arguments['newScale'] ?? 1.0;
+          params.webviewParams!.onZoomScaleChanged!(
+            controller,
+            oldScale,
+            newScale,
+          );
+        }
+        break;
+      case 'onReceivedIcon':
+        if (params.webviewParams?.onReceivedIcon != null) {
+          Uint8List icon = call.arguments['icon'] as Uint8List? ??
+              Uint8List.fromList([]);
+          params.webviewParams!.onReceivedIcon!(controller, icon);
+        }
+        break;
+      case 'onReceivedTouchIconUrl':
+        if (params.webviewParams?.onReceivedTouchIconUrl != null) {
+          String? url = call.arguments['url'];
+          bool precomposed = call.arguments['precomposed'] ?? false;
+          params.webviewParams!.onReceivedTouchIconUrl!(
+            controller,
+            WebUri(url ?? ''),
+            precomposed,
+          );
+        }
+        break;
+      case 'onPermissionRequest':
+        if (params.webviewParams?.onPermissionRequest != null) {
+          var request = PermissionRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          return await params.webviewParams!.onPermissionRequest!(
+            controller,
+            request,
+          );
+        }
+        break;
+      case 'onPermissionRequestCanceled':
+        if (params.webviewParams?.onPermissionRequestCanceled != null) {
+          var request = PermissionRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          params.webviewParams!.onPermissionRequestCanceled!(
+            controller,
+            request,
+          );
+        }
+        break;
+      case 'onRenderProcessGone':
+        if (params.webviewParams?.onRenderProcessGone != null) {
+          var detail = RenderProcessGoneDetail.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          params.webviewParams!.onRenderProcessGone!(controller, detail);
+        }
+        break;
+      case 'onRenderProcessUnresponsive':
+        if (params.webviewParams?.onRenderProcessUnresponsive != null) {
+          params.webviewParams!.onRenderProcessUnresponsive!(controller);
+        }
+        break;
+      case 'onRenderProcessResponsive':
+        if (params.webviewParams?.onRenderProcessResponsive != null) {
+          params.webviewParams!.onRenderProcessResponsive!(controller);
+        }
+        break;
+      case 'onSafeBrowsingHit':
+        if (params.webviewParams?.onSafeBrowsingHit != null) {
+          var url = call.arguments['url'] ?? '';
+          var threatTypeValue = call.arguments['threatType'];
+          SafeBrowsingThreat threatType = SafeBrowsingThreat
+              .values[threatTypeValue is int &&
+                      threatTypeValue >= 0 &&
+                      threatTypeValue <
+                          SafeBrowsingThreat.values.length
+                  ? threatTypeValue
+                  : 0];
+          params.webviewParams!.onSafeBrowsingHit!(
+            controller,
+            WebUri(url),
+            threatType,
+          );
+        }
+        break;
+      case 'onEnterFullscreen':
+        if (params.webviewParams?.onEnterFullscreen != null) {
+          params.webviewParams!.onEnterFullscreen!(controller);
+        }
+        break;
+      case 'onExitFullscreen':
+        if (params.webviewParams?.onExitFullscreen != null) {
+          params.webviewParams!.onExitFullscreen!(controller);
+        }
+        break;
+      case 'onOverScrolled':
+        if (params.webviewParams?.onOverScrolled != null) {
+          int scrollX = call.arguments['scrollX'] ?? 0;
+          int scrollY = call.arguments['scrollY'] ?? 0;
+          bool clampedX = (call.arguments['clampedX'] as int?) != 0;
+          bool clampedY = (call.arguments['clampedY'] as int?) != 0;
+          params.webviewParams!.onOverScrolled!(
+            controller,
+            scrollX,
+            scrollY,
+            clampedX,
+            clampedY,
+          );
+        }
+        break;
+      case 'onWindowFocus':
+        if (params.webviewParams?.onWindowFocus != null) {
+          params.webviewParams!.onWindowFocus!(controller);
+        }
+        break;
+      case 'onWindowBlur':
+        if (params.webviewParams?.onWindowBlur != null) {
+          params.webviewParams!.onWindowBlur!(controller);
+        }
+        break;
+      case 'onPrintRequest':
+        if (params.webviewParams?.onPrintRequest != null) {
+          String? url = call.arguments['url'];
+          return await params.webviewParams!.onPrintRequest!(
+            controller,
+            url != null ? WebUri(url) : null,
+            null,
+          );
+        }
+        break;
+      case 'onRequestFocus':
+        if (params.webviewParams?.onRequestFocus != null) {
+          params.webviewParams!.onRequestFocus!(controller);
+        }
+        break;
+      case 'onReceivedLoginRequest':
+        if (params.webviewParams?.onReceivedLoginRequest != null) {
+          var request = LoginRequest.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          params.webviewParams!.onReceivedLoginRequest!(
+            controller,
+            request,
+          );
+        }
+        break;
+      case 'onLongPressHitTestResult':
+        if (params.webviewParams?.onLongPressHitTestResult != null) {
+          var hitTestResult = InAppWebViewHitTestResult.fromJson(
+            call.arguments.cast<String, dynamic>(),
+          );
+          params.webviewParams!.onLongPressHitTestResult!(
+            controller,
+            hitTestResult,
+          );
+        }
+        break;
+      case 'onContentSizeChanged':
+        if (params.webviewParams?.onContentSizeChanged != null) {
+          var sizeMap = call.arguments['size'];
+          Size newContentSize = Size.zero;
+          if (sizeMap is Map) {
+            final m = sizeMap.cast<String, dynamic>();
+            newContentSize = Size(
+              (m['width'] as num?)?.toDouble() ?? 0.0,
+              (m['height'] as num?)?.toDouble() ?? 0.0,
+            );
+          }
+          params.webviewParams!.onContentSizeChanged!(
+            controller,
+            Size.zero,
+            newContentSize,
+          );
+        }
+        break;
+      case 'onCameraCaptureStateChanged':
+        if (params.webviewParams?.onCameraCaptureStateChanged != null) {
+          await params.webviewParams!.onCameraCaptureStateChanged!(
+            controller,
+            mediaCaptureStateFromWire(call.arguments['oldState']),
+            mediaCaptureStateFromWire(call.arguments['newState']),
+          );
+        }
+        break;
+      case 'onMicrophoneCaptureStateChanged':
+        if (params.webviewParams?.onMicrophoneCaptureStateChanged != null) {
+          await params.webviewParams!.onMicrophoneCaptureStateChanged!(
+            controller,
+            mediaCaptureStateFromWire(call.arguments['oldState']),
+            mediaCaptureStateFromWire(call.arguments['newState']),
+          );
+        }
+        break;
+      case 'onPageCommitVisible':
+        if (params.webviewParams?.onPageCommitVisible != null) {
+          String? url = call.arguments['url'];
+          params.webviewParams!.onPageCommitVisible!(
+            controller,
+            url != null ? WebUri(url) : WebUri(''),
+          );
+        }
+        break;
       default:
         throw UnimplementedError("Unimplemented ${call.method} method");
     }
   }
+
+  // --- Navigation ---
 
   @override
   Future<WebUri?> getUrl() async {
@@ -167,8 +544,43 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   }
 
   @override
+  Future<void> postUrl({required WebUri url, required Uint8List postData}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('url', () => url.toString());
+    args.putIfAbsent('postData', () => postData);
+    await _channel.invokeMethod('postUrl', args);
+  }
+
+  @override
+  Future<void> loadData({
+    required String data,
+    String mimeType = "text/html",
+    String encoding = "utf8",
+    WebUri? baseUrl,
+    WebUri? historyUrl,
+    WebUri? allowingReadAccessTo,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('data', () => data);
+    args.putIfAbsent('baseUrl', () => baseUrl?.toString());
+    await _channel.invokeMethod('loadData', args);
+  }
+
+  @override
+  Future<void> loadFile({required String assetFilePath}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('assetFilePath', () => assetFilePath);
+    await _channel.invokeMethod('loadFile', args);
+  }
+
+  @override
   Future<void> reload() async {
     await _channel.invokeMethod('reload');
+  }
+
+  @override
+  Future<void> reloadFromOrigin() async {
+    await _channel.invokeMethod('reloadFromOrigin');
   }
 
   @override
@@ -192,6 +604,28 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   }
 
   @override
+  Future<void> goBackOrForward({required int steps}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('steps', () => steps);
+    await _channel.invokeMethod('goBackOrForward', args);
+  }
+
+  @override
+  Future<bool> canGoBackOrForward({required int steps}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('steps', () => steps);
+    return await _channel.invokeMethod<bool>('canGoBackOrForward', args) ??
+        false;
+  }
+
+  @override
+  Future<void> goTo({required WebHistoryItem historyItem}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('historyItem', () => historyItem.toJson());
+    await _channel.invokeMethod('goTo', args);
+  }
+
+  @override
   Future<bool> isLoading() async {
     return await _channel.invokeMethod<bool>('isLoading') ?? false;
   }
@@ -200,6 +634,8 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   Future<void> stopLoading() async {
     await _channel.invokeMethod('stopLoading');
   }
+
+  // --- JavaScript / CSS ---
 
   @override
   Future<dynamic> evaluateJavascript({
@@ -210,50 +646,6 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
     args.putIfAbsent('source', () => source);
     args.putIfAbsent('contentWorld', () => contentWorld?.toMap());
     return await _channel.invokeMethod('evaluateJavascript', args);
-  }
-
-  @override
-  Future<void> loadData({
-    required String data,
-    String mimeType = "text/html",
-    String encoding = "utf8",
-    WebUri? baseUrl,
-    WebUri? historyUrl,
-    WebUri? allowingReadAccessTo,
-  }) async {
-    Map<String, dynamic> args = <String, dynamic>{};
-    args.putIfAbsent('data', () => data);
-    args.putIfAbsent('baseUrl', () => baseUrl?.toString());
-    await _channel.invokeMethod('loadData', args);
-  }
-
-  final Map<String, JavaScriptHandlerCallback> _javaScriptHandlers =
-      <String, JavaScriptHandlerCallback>{};
-
-  @override
-  void addJavaScriptHandler({
-    required String handlerName,
-    required JavaScriptHandlerCallback callback,
-  }) {
-    _javaScriptHandlers[handlerName] = callback;
-    _channel
-        .invokeMethod('addJavaScriptHandler', <String, dynamic>{
-          'handlerName': handlerName,
-        })
-        .catchError((_) {});
-  }
-
-  @override
-  JavaScriptHandlerCallback? removeJavaScriptHandler({
-    required String handlerName,
-  }) {
-    final callback = _javaScriptHandlers.remove(handlerName);
-    _channel
-        .invokeMethod('removeJavaScriptHandler', <String, dynamic>{
-          'handlerName': handlerName,
-        })
-        .catchError((_) {});
-    return callback;
   }
 
   @override
@@ -308,6 +700,109 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   }
 
   @override
+  Future<void> addUserScript({required UserScript userScript}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('userScript', () => userScript.toJson());
+    await _channel.invokeMethod('addUserScript', args);
+  }
+
+  @override
+  Future<void> addUserScripts({
+    required List<UserScript> userScripts,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent(
+      'userScripts',
+      () => userScripts.map((e) => e.toJson()).toList(),
+    );
+    await _channel.invokeMethod('addUserScripts', args);
+  }
+
+  @override
+  Future<bool> removeUserScript({required UserScript userScript}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('userScript', () => userScript.toJson());
+    return await _channel.invokeMethod<bool>('removeUserScript', args) ??
+        false;
+  }
+
+  @override
+  Future<void> removeUserScripts({
+    required List<UserScript> userScripts,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent(
+      'userScripts',
+      () => userScripts.map((e) => e.toJson()).toList(),
+    );
+    await _channel.invokeMethod('removeUserScripts', args);
+  }
+
+  @override
+  Future<void> removeUserScriptsByGroupName({
+    required String groupName,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('groupName', () => groupName);
+    await _channel.invokeMethod('removeUserScriptsByGroupName', args);
+  }
+
+  @override
+  Future<void> removeAllUserScripts() async {
+    await _channel.invokeMethod('removeAllUserScripts');
+  }
+
+  @override
+  Future<CallAsyncJavaScriptResult?> callAsyncJavaScript({
+    required String functionBody,
+    Map<String, dynamic> arguments = const <String, dynamic>{},
+    ContentWorld? contentWorld,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('functionBody', () => functionBody);
+    args.putIfAbsent('arguments', () => arguments);
+    args.putIfAbsent('contentWorld', () => contentWorld?.toMap());
+    final result =
+        await _channel.invokeMethod<Map>('callAsyncJavaScript', args);
+    if (result == null) return null;
+    return CallAsyncJavaScriptResult.fromJson(
+        result.cast<String, dynamic>());
+  }
+
+  // --- JavaScript Handlers ---
+
+  final Map<String, JavaScriptHandlerCallback> _javaScriptHandlers =
+      <String, JavaScriptHandlerCallback>{};
+
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) {
+    _javaScriptHandlers[handlerName] = callback;
+    _channel
+        .invokeMethod('addJavaScriptHandler', <String, dynamic>{
+          'handlerName': handlerName,
+        })
+        .catchError((_) {});
+  }
+
+  @override
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
+    required String handlerName,
+  }) {
+    final callback = _javaScriptHandlers.remove(handlerName);
+    _channel
+        .invokeMethod('removeJavaScriptHandler', <String, dynamic>{
+          'handlerName': handlerName,
+        })
+        .catchError((_) {});
+    return callback;
+  }
+
+  // --- Content / HTML / Screenshot ---
+
+  @override
   Future<String?> getHtml() async {
     return await _channel.invokeMethod<String>('getHtml');
   }
@@ -325,11 +820,6 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   }
 
   @override
-  Future<void> openDevTools() async {
-    await _channel.invokeMethod('openDevTools');
-  }
-
-  @override
   Future<Uint8List?> createPdf({PDFConfiguration? pdfConfiguration}) async {
     Map<String, dynamic> args = <String, dynamic>{};
     args.putIfAbsent('pdfConfiguration', () => pdfConfiguration?.toJson());
@@ -337,9 +827,568 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
   }
 
   @override
+  Future<List<Favicon>> getFavicons() async {
+    List<dynamic>? favicons =
+        await _channel.invokeMethod<List>('getFavicons');
+    if (favicons == null) return [];
+    return favicons
+        .map((e) => Favicon.fromJson((e as Map).cast<String, dynamic>()))
+        .toList();
+  }
+
+  // --- Settings ---
+
+  @override
+  Future<void> setSettings({required InAppWebViewSettings settings}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('settings', () => settings.toJson());
+    await _channel.invokeMethod('setSettings', args);
+  }
+
+  @override
+  Future<InAppWebViewSettings?> getSettings() async {
+    final settingsMap =
+        await _channel.invokeMethod<Map>('getSettings');
+    if (settingsMap == null) return null;
+    // InAppWebViewSettings does not have fromMap;
+    // Linux native side doesn't support reading settings back yet.
+    return null;
+  }
+
+  // --- History ---
+
+  @override
+  Future<WebHistory?> getCopyBackForwardList() async {
+    final result =
+        await _channel.invokeMethod<Map>('getCopyBackForwardList');
+    if (result == null) return null;
+    return WebHistory.fromJson(result.cast<String, dynamic>());
+  }
+
+  @override
+  Future<void> clearHistory() async {
+    await _channel.invokeMethod('clearHistory');
+  }
+
+  // --- Scrolling ---
+
+  @override
+  Future<void> scrollTo({
+    required int x,
+    required int y,
+    bool animated = false,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('x', () => x);
+    args.putIfAbsent('y', () => y);
+    args.putIfAbsent('animated', () => animated);
+    await _channel.invokeMethod('scrollTo', args);
+  }
+
+  @override
+  Future<void> scrollBy({
+    required int x,
+    required int y,
+    bool animated = false,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('x', () => x);
+    args.putIfAbsent('y', () => y);
+    args.putIfAbsent('animated', () => animated);
+    await _channel.invokeMethod('scrollBy', args);
+  }
+
+  @override
+  Future<int?> getScrollX() async {
+    return await _channel.invokeMethod<int>('getScrollX');
+  }
+
+  @override
+  Future<int?> getScrollY() async {
+    return await _channel.invokeMethod<int>('getScrollY');
+  }
+
+  @override
+  Future<bool> canScrollVertically() async {
+    return await _channel.invokeMethod<bool>('canScrollVertically') ?? false;
+  }
+
+  @override
+  Future<bool> canScrollHorizontally() async {
+    return await _channel.invokeMethod<bool>('canScrollHorizontally') ?? false;
+  }
+
+  @override
+  Future<bool> pageDown({required bool bottom}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('bottom', () => bottom);
+    return await _channel.invokeMethod<bool>('pageDown', args) ?? false;
+  }
+
+  @override
+  Future<bool> pageUp({required bool top}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('top', () => top);
+    return await _channel.invokeMethod<bool>('pageUp', args) ?? false;
+  }
+
+  // --- Zoom ---
+
+  @override
+  Future<void> zoomBy({
+    required double zoomFactor,
+    bool animated = false,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('zoomFactor', () => zoomFactor);
+    args.putIfAbsent('animated', () => animated);
+    await _channel.invokeMethod('zoomBy', args);
+  }
+
+  @override
+  Future<double?> getZoomScale() async {
+    return await _channel.invokeMethod<double>('getZoomScale');
+  }
+
+  @override
+  Future<bool> zoomIn() async {
+    return await _channel.invokeMethod<bool>('zoomIn') ?? false;
+  }
+
+  @override
+  Future<bool> zoomOut() async {
+    return await _channel.invokeMethod<bool>('zoomOut') ?? false;
+  }
+
+  // --- Content dimensions ---
+
+  @override
+  Future<int?> getContentHeight() async {
+    return await _channel.invokeMethod<int>('getContentHeight');
+  }
+
+  @override
+  Future<int?> getContentWidth() async {
+    return await _channel.invokeMethod<int>('getContentWidth');
+  }
+
+  // --- Timers / Pause ---
+
+  @override
+  Future<void> pauseTimers() async {
+    await _channel.invokeMethod('pauseTimers');
+  }
+
+  @override
+  Future<void> resumeTimers() async {
+    await _channel.invokeMethod('resumeTimers');
+  }
+
+  @override
+  Future<void> pause() async {
+    await _channel.invokeMethod('pause');
+  }
+
+  @override
+  Future<void> resume() async {
+    await _channel.invokeMethod('resume');
+  }
+
+  // --- Text / Hit test / Focus ---
+
+  @override
+  Future<String?> getSelectedText() async {
+    return await _channel.invokeMethod<String>('getSelectedText');
+  }
+
+  @override
+  Future<InAppWebViewHitTestResult?> getHitTestResult() async {
+    final result =
+        await _channel.invokeMethod<Map>('getHitTestResult');
+    if (result == null) return null;
+    return InAppWebViewHitTestResult.fromJson(
+        result.cast<String, dynamic>());
+  }
+
+  @override
+  Future<void> clearFocus() async {
+    await _channel.invokeMethod('clearFocus');
+  }
+
+  // --- Context Menu / Meta ---
+
+  @override
+  Future<void> setContextMenu(ContextMenu? contextMenu) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('contextMenu', () => contextMenu?.toJson());
+    await _channel.invokeMethod('setContextMenu', args);
+  }
+
+  @override
+  Future<RequestFocusNodeHrefResult?> requestFocusNodeHref() async {
+    final result =
+        await _channel.invokeMethod<Map>('requestFocusNodeHref');
+    if (result == null) return null;
+    return RequestFocusNodeHrefResult.fromJson(
+        result.cast<String, dynamic>());
+  }
+
+  @override
+  Future<RequestImageRefResult?> requestImageRef() async {
+    final result =
+        await _channel.invokeMethod<Map>('requestImageRef');
+    if (result == null) return null;
+    return RequestImageRefResult.fromJson(result.cast<String, dynamic>());
+  }
+
+  @override
+  Future<List<MetaTag>> getMetaTags() async {
+    List<dynamic>? tags =
+        await _channel.invokeMethod<List>('getMetaTags');
+    if (tags == null) return [];
+    return tags
+        .map((e) => MetaTag.fromJson((e as Map).cast<String, dynamic>()))
+        .toList();
+  }
+
+  @override
+  Future<Color?> getMetaThemeColor() async {
+    int? color = await _channel.invokeMethod<int>('getMetaThemeColor');
+    if (color == null) return null;
+    return Color(color);
+  }
+
+  @override
+  Future<WebUri?> getOriginalUrl() async {
+    String? url = await _channel.invokeMethod<String>('getOriginalUrl');
+    return url != null ? WebUri(url) : null;
+  }
+
+  // --- Security / Context ---
+
+  @override
+  Future<bool> isSecureContext() async {
+    return await _channel.invokeMethod<bool>('isSecureContext') ?? false;
+  }
+
+  @override
+  Future<bool> hasOnlySecureContent() async {
+    return await _channel.invokeMethod<bool>('hasOnlySecureContent') ?? false;
+  }
+
+  @override
+  Future<SslCertificate?> getCertificate() async {
+    final result =
+        await _channel.invokeMethod<Map>('getCertificate');
+    if (result == null) return null;
+    return SslCertificate.fromMap(result.cast<String, dynamic>());
+  }
+
+  // --- Media ---
+
+  @override
+  Future<void> pauseAllMediaPlayback() async {
+    await _channel.invokeMethod('pauseAllMediaPlayback');
+  }
+
+  @override
+  Future<void> setAllMediaPlaybackSuspended({
+    required bool suspended,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('suspended', () => suspended);
+    await _channel.invokeMethod('setAllMediaPlaybackSuspended', args);
+  }
+
+  @override
+  Future<void> closeAllMediaPresentations() async {
+    await _channel.invokeMethod('closeAllMediaPresentations');
+  }
+
+  @override
+  Future<MediaPlaybackState?> requestMediaPlaybackState() async {
+    int? state =
+        await _channel.invokeMethod<int>('requestMediaPlaybackState');
+    return mediaPlaybackStateFromWire(state);
+  }
+
+  @override
+  Future<bool> isInFullscreen() async {
+    return await _channel.invokeMethod<bool>('isInFullscreen') ?? false;
+  }
+
+  @override
+  Future<MediaCaptureState?> getCameraCaptureState() async {
+    int? state =
+        await _channel.invokeMethod<int>('getCameraCaptureState');
+    return mediaCaptureStateFromWire(state);
+  }
+
+  @override
+  Future<void> setCameraCaptureState({
+    required MediaCaptureState state,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('state', () => state.index);
+    await _channel.invokeMethod('setCameraCaptureState', args);
+  }
+
+  @override
+  Future<MediaCaptureState?> getMicrophoneCaptureState() async {
+    int? state =
+        await _channel.invokeMethod<int>('getMicrophoneCaptureState');
+    return mediaCaptureStateFromWire(state);
+  }
+
+  @override
+  Future<void> setMicrophoneCaptureState({
+    required MediaCaptureState state,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('state', () => state.index);
+    await _channel.invokeMethod('setMicrophoneCaptureState', args);
+  }
+
+  // --- Cache / Data ---
+
+  @override
+  Future<void> clearAllCache({bool includeDiskFiles = true}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('includeDiskFiles', () => includeDiskFiles);
+    await _channel.invokeMethod('clearAllCache', args);
+  }
+
+  @override
+  Future<void> clearFormData() async {
+    await _channel.invokeMethod('clearFormData');
+  }
+
+  @override
+  Future<void> clearClientCertPreferences() async {
+    await _channel.invokeMethod('clearClientCertPreferences');
+  }
+
+  // --- Print ---
+
+  @override
+  Future<PlatformPrintJobController?> printCurrentPage({
+    PrintJobSettings? settings,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('settings', () => settings?.toJson());
+    await _channel.invokeMethod('printCurrentPage', args);
+    return null;
+  }
+
+  // --- DevTools ---
+
+  @override
+  Future<void> openDevTools() async {
+    await _channel.invokeMethod('openDevTools');
+  }
+
+  @override
+  Future<dynamic> callDevToolsProtocolMethod({
+    required String methodName,
+    Map<String, dynamic>? parameters,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('methodName', () => methodName);
+    if (parameters != null) {
+      args.putIfAbsent('parameters', () => parameters);
+    }
+    return await _channel.invokeMethod('callDevToolsProtocolMethod', args);
+  }
+
+  @override
+  Future<void> addDevToolsProtocolEventListener({
+    required String eventName,
+    required void Function(Map<String, dynamic>) callback,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('eventName', () => eventName);
+    await _channel.invokeMethod('addDevToolsProtocolEventListener', args);
+  }
+
+  @override
+  Future<void> removeDevToolsProtocolEventListener({
+    required String eventName,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('eventName', () => eventName);
+    await _channel.invokeMethod('removeDevToolsProtocolEventListener', args);
+  }
+
+  @override
+  Future<String?> getIFrameId() async {
+    return await _channel.invokeMethod<String>('getIFrameId');
+  }
+
+  // --- User Agent ---
+
+  @override
+  Future<String> getDefaultUserAgent() async {
+    return await _channel.invokeMethod<String>('getDefaultUserAgent') ??
+        'Mozilla/5.0';
+  }
+
+  // --- Safe Browsing ---
+
+  @override
+  Future<bool> startSafeBrowsing() async {
+    return await _channel.invokeMethod<bool>('startSafeBrowsing') ?? false;
+  }
+
+  @override
+  Future<void> clearSslPreferences() async {
+    await _channel.invokeMethod('clearSslPreferences');
+  }
+
+  @override
+  Future<WebUri?> getSafeBrowsingPrivacyPolicyUrl() async {
+    String? url = await _channel
+        .invokeMethod<String>('getSafeBrowsingPrivacyPolicyUrl');
+    return url != null ? WebUri(url) : null;
+  }
+
+  @override
+  Future<bool> setSafeBrowsingAllowlist({required List<String> hosts}) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('hosts', () => hosts);
+    return await _channel.invokeMethod<bool>(
+      'setSafeBrowsingAllowlist',
+      args,
+    ) ?? false;
+  }
+
+  // --- WebView Info ---
+
+  @override
+  Future<WebViewPackageInfo?> getCurrentWebViewPackage() async {
+    // Not applicable on Linux (WebKitGTK is system-provided).
+    return null;
+  }
+
+  @override
+  Future<void> setWebContentsDebuggingEnabled(
+    bool debuggingEnabled,
+  ) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('debuggingEnabled', () => debuggingEnabled);
+    await _channel.invokeMethod('setWebContentsDebuggingEnabled', args);
+  }
+
+  @override
+  Future<String?> getVariationsHeader() async {
+    // Not applicable on Linux.
+    return null;
+  }
+
+  @override
+  Future<bool> isMultiProcessEnabled() async {
+    // WebKitGTK is single-process.
+    return false;
+  }
+
+  @override
+  Future<void> disableWebView() async {
+    // Not applicable on Linux.
+  }
+
+  @override
+  Future<bool> handlesURLScheme(String urlScheme) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('urlScheme', () => urlScheme);
+    return await _channel.invokeMethod<bool>('handlesURLScheme', args) ??
+        false;
+  }
+
+  @override
+  Future<void> disposeKeepAlive(InAppWebViewKeepAlive keepAlive) async {
+    await _channel.invokeMethod(
+      'disposeKeepAlive',
+      <String, dynamic>{'id': keepAlive.id},
+    );
+  }
+
+  // --- Web Archive ---
+
+  @override
+  Future<String?> saveWebArchive({
+    required String filePath,
+    bool autoname = true,
+  }) async {
+    Map<String, dynamic> args = <String, dynamic>{};
+    args.putIfAbsent('filePath', () => filePath);
+    args.putIfAbsent('autoname', () => autoname);
+    return await _channel.invokeMethod<String>('saveWebArchive', args);
+  }
+
+  @override
+  Future<Uint8List?> createWebArchiveData() async {
+    return await _channel.invokeMethod<Uint8List>('createWebArchiveData');
+  }
+
+  // --- Simulated Request (testing) ---
+
+  @override
+  Future<void> loadSimulatedRequest({
+    required Uint8List data,
+    required URLRequest urlRequest,
+    URLResponse? urlResponse,
+  }) async {
+    throw UnimplementedError(
+      'loadSimulatedRequest is not implemented on Linux',
+    );
+  }
+
+  // --- Web Message (not supported on Linux) ---
+
+  @override
+  Future<PlatformWebMessageChannel?> createWebMessageChannel() {
+    throw UnimplementedError(
+      'createWebMessageChannel is not implemented on Linux',
+    );
+  }
+
+  @override
+  Future<void> postWebMessage({
+    required WebMessage message,
+    WebUri? targetOrigin,
+  }) {
+    throw UnimplementedError('postWebMessage is not implemented on Linux');
+  }
+
+  @override
+  Future<void> addWebMessageListener(
+    PlatformWebMessageListener webMessageListener,
+  ) {
+    throw UnimplementedError(
+      'addWebMessageListener is not implemented on Linux',
+    );
+  }
+
+  // --- TRex Runner (offline error page) ---
+
+  @override
+  Future<String> get tRexRunnerHtml async =>
+      await rootBundle.loadString(
+        'packages/zikzak_inappwebview/assets/t_rex_runner/trex.html',
+      );
+
+  @override
+  Future<String> get tRexRunnerCss async =>
+      await rootBundle.loadString(
+        'packages/zikzak_inappwebview/assets/t_rex_runner/trex.css',
+      );
+
+  // --- Dispose ---
+
+  @override
   void dispose({bool isKeepAlive = false}) {
     if (!isKeepAlive) {
       _channel.setMethodCallHandler(null);
     }
+    super.dispose(isKeepAlive: isKeepAlive);
   }
 }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -1,31 +1,70 @@
 import Cocoa
+import CryptoKit
 import FlutterMacOS
 import WebKit
 
-/// Maps the 64-char SHA-256 hex string sent from Dart (derived from a
-/// profile dir's canonical path) into a stable `UUID` for
-/// `WKWebsiteDataStore(forIdentifier:)`. We take the first 32 hex chars
-/// (16 bytes) and treat them as the UUID's raw bytes, so the same profile
-/// directory always yields the same on-disk store identifier — which is
-/// what makes a per-account session survive app relaunch.
-private func persistentUUID(from hex: String) -> UUID? {
-    let trimmed = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-    guard trimmed.count >= 32 else { return nil }
-    let prefix = trimmed.prefix(32)
-    var bytes: [UInt8] = []
-    bytes.reserveCapacity(16)
-    var index = prefix.startIndex
-    while index < prefix.endIndex {
-        let next = prefix.index(index, offsetBy: 2, limitedBy: prefix.endIndex) ?? prefix.endIndex
-        guard let byte = UInt8(String(prefix[index..<next]), radix: 16) else { return nil }
-        bytes.append(byte)
-        index = next
+/// Maps a stable identifier string into a stable `UUID` for
+/// `WKWebsiteDataStore(forIdentifier:)`. Accepts three input shapes so the
+/// same Dart field can be fed either a raw UUID string, a stable profile
+/// name, or the 64-char SHA-256 hex the forklift caller used to send
+/// (derived from a profile dir's canonical path). All three are
+/// deterministic — the same identifier always yields the same on-disk
+/// store, which is what makes a per-account session survive app relaunch.
+///
+/// Shape priority: (a) direct UUID string -> (b) 64-char hex legacy path
+/// -> (c) SHA-256 of the UTF-8 bytes (CryptoKit, iOS 13+/macOS 10.15+,
+/// well below the iOS 17+/macOS 14+ floor of the persistent-store API
+/// itself).
+private func persistentUUID(from identifier: String) -> UUID? {
+    let trimmed = identifier.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    // (a) Direct UUID string ("550e8400-e29b-41d4-a716-446655440000").
+    if let direct = UUID(uuidString: trimmed) {
+        return direct
     }
-    guard bytes.count == 16 else { return nil }
-    return UUID(uuid: (
-        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
-        bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
-    ))
+
+    // (b) Legacy 64-char SHA-256 hex path: take the first 32 hex chars
+    // (16 bytes) and treat them as the UUID's raw bytes. Preserves the
+    // on-disk store identifier forklift's Cloaked Chrome profiles already
+    // use, so existing persistent stores keep reopening after the upgrade.
+    let hexSet = CharacterSet(charactersIn: "0123456789abcdefABCDEF")
+    let isHex = trimmed.unicodeScalars.allSatisfy { hexSet.contains($0) }
+    if isHex, trimmed.count >= 32 {
+        let prefix = trimmed.prefix(32)
+        var bytes: [UInt8] = []
+        bytes.reserveCapacity(16)
+        var index = prefix.startIndex
+        while index < prefix.endIndex {
+            let next = prefix.index(index, offsetBy: 2, limitedBy: prefix.endIndex) ?? prefix.endIndex
+            guard let byte = UInt8(String(prefix[index..<next]), radix: 16) else { return nil }
+            bytes.append(byte)
+            index = next
+        }
+        guard bytes.count == 16 else { return nil }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    // (c) Any other stable string: SHA-256 the UTF-8 bytes and use the
+    // first 16 bytes as the UUID's raw bytes. Deterministic, isolated,
+    // and survives relaunch — distinct identifiers never collide.
+    // CryptoKit ships with the system on iOS 13+/macOS 10.15+, so this
+    // branch is always available when the iOS 17+/macOS 14+ persistent
+    // store path runs.
+    if #available(macOS 10.15, *) {
+        let digest = SHA256.hash(data: Data(trimmed.utf8))
+        let sha = Array(digest)
+        return UUID(uuid: (
+            sha[0],  sha[1],  sha[2],  sha[3],
+            sha[4],  sha[5],  sha[6],  sha[7],
+            sha[8],  sha[9],  sha[10], sha[11],
+            sha[12], sha[13], sha[14], sha[15]
+        ))
+    }
+    return nil
 }
 
 public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate, NSMenuDelegate {

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart
@@ -170,12 +170,31 @@ abstract class $InAppWebViewSettings {
   @JsonKey(defaultValue: false)
   bool? get incognito;
 
-  ///Stable identifier for a persistent, per-account `WKWebsiteDataStore` on
-  ///macOS. When non-null and non-empty, the WebView stores cookies,
-  ///localStorage, IndexedDB and other site data at a system location keyed by
-  ///this identifier, so an account's session survives a relaunch and stays
-  ///isolated from every other account. Derived from `userDataDir` by the
-  ///caller. Null/empty means an ephemeral (incognito) store.
+  ///Stable identifier for a per-instance, persistent, isolated
+  ///`WKWebsiteDataStore` on iOS 17+ and macOS 14+. When non-null and
+  ///non-empty, the WebView stores cookies, localStorage, IndexedDB and other
+  ///site data at a system location keyed by this identifier, so an account's
+  ///session survives an app relaunch and stays isolated from every other
+  ///account. Null/empty means the default shared store (existing behaviour).
+  ///
+  ///Accepts three input shapes (all deterministic; same identifier reopens
+  ///the same on-disk store):
+  /// * a raw UUID string ("550e8400-e29b-41d4-a716-446655440000"),
+  /// * a 64-char SHA-256 hex string (legacy caller contract; first 32 hex
+  ///   chars are used as the UUID's raw bytes),
+  /// * any other stable string (SHA-256 of its UTF-8 bytes -> first 16
+  ///   bytes used as the UUID's raw bytes).
+  ///
+  ///Mutually exclusive with [incognito]: when both are set, `incognito`
+  ///(non-persistent, wiped on tear-down) takes precedence.
+  ///
+  ///Must be set at construction time — `WKWebViewConfiguration.websiteDataStore`
+  ///is immutable after the `WKWebView` is initialised, so a `setSettings`
+  ///call changing this value has no effect.
+  ///
+  ///Below the iOS 17 / macOS 14 floor, the persistent path is unavailable
+  ///and the WebView falls back to the shared `.default()` store (existing
+  ///behaviour) — no error is surfaced.
   @JsonKey(includeIfNull: false)
   String? get persistentStoreIdentifier;
 

--- a/zikzak_inappwebview_platform_interface/test/in_app_webview_settings_migration_regression_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/in_app_webview_settings_migration_regression_test.dart
@@ -1,0 +1,203 @@
+// Regression for #249 / #255 / #257.
+//
+// Published zikzak_inappwebview_platform_interface 5.0.1 shipped a stale
+// relative `import '../in_app_webview_settings.dart';` in
+// `lib/src/in_app_webview/modules/platform_settings_delegate.dart`. That
+// relative path resolved against `lib/src/in_app_webview/modules/` to
+// `lib/src/in_app_webview/in_app_webview_settings.dart` — the PRE-migration
+// location, which the Zorphy migration had already moved away from. The
+// published artifact was therefore un-importable: every consumer of
+// `zikzak_inappwebview_platform_interface: ^5.0.0` failed to compile with
+//
+//   Error when reading
+//   '.../zikzak_inappwebview_platform_interface-5.0.1/lib/src/in_app_webview/
+//    in_app_webview_settings.dart': No such file or directory
+//   import '../in_app_webview_settings.dart';
+//
+// The source on `master` was already corrected (the file imports the
+// settings entity from its new home under
+// `lib/src/domain/entities/in_app_webview_settings/`) and the fix shipped
+// in 5.1.0. The existing delegate compile-time probe
+// (`in_app_webview_controller_delegates_test.dart`) catches a missing type
+// but does NOT catch the case where the package still compiles locally
+// (e.g. because a stale copy of the file is sitting at the old path) yet
+// ships a broken tarball. This test reads the source directly and asserts:
+//
+//   1. the canonical settings entity file lives at its migrated location;
+//   2. the pre-migration settings file location is GONE (so no stale
+//      relative import could ever silently resolve again);
+//   3. platform_settings_delegate.dart carries the canonical import line;
+//   4. platform_settings_delegate.dart does NOT carry the stale
+//      pre-migration relative import (single or double quoted);
+//   5. no `.dart` file under `lib/` carries ANY relative import that
+//      resolves to the pre-migration settings path — a sweep that catches
+//      the same class of bug in any other module file.
+//
+// Together these guard against a future Zorphy re-migration or codegen
+// pass dropping the file (or an import) back at the old location and
+// reshipping the 5.0.1 break.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Resolve a path relative to the package root (the CWD when `flutter test`
+/// runs the suite).
+Uri _pkgRootUri() => Uri.directory(Directory.current.path);
+
+File _fileFromPackagePath(String relativePath) =>
+    File.fromUri(_pkgRootUri().resolve(relativePath));
+
+// Canonical settings entity file — the post-migration home.
+final File _settingsEntityFile = _fileFromPackagePath(
+  'lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart',
+);
+
+// The settings delegate whose broken import shipped in 5.0.1.
+final File _delegateFile = _fileFromPackagePath(
+  'lib/src/in_app_webview/modules/platform_settings_delegate.dart',
+);
+
+// The PRE-migration settings file location. Must NOT exist; a stale
+// relative import like `import '../in_app_webview_settings.dart';` issued
+// from any file under `lib/src/in_app_webview/` would resolve here.
+final File _preMigrationSettingsFile = _fileFromPackagePath(
+  'lib/src/in_app_webview/in_app_webview_settings.dart',
+);
+
+// A regex that matches a Dart `import` directive and captures the path
+// string. Handles single OR double quotes; tolerates leading whitespace
+// and a `configurable-uri`-style `if (cond) '...'` clause (the captured
+// path is always the FIRST quoted string after `import`). Uses a
+// triple-quoted raw string so both `'` and `"` can appear inside.
+final RegExp _importDirective = RegExp(
+  r"""^\s*import\s+['"]([^'"]+)['"]""",
+  multiLine: true,
+);
+
+void main() {
+  group('InAppWebViewSettings source layout (regression #249/#255/#257)', () {
+    test('the settings entity lives at the canonical migrated path', () {
+      expect(
+        _settingsEntityFile.existsSync(),
+        isTrue,
+        reason:
+            'lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart '
+            'must exist — the Zorphy migration moved the entity here, and every '
+            'relative import of InAppWebViewSettings depends on this location.',
+      );
+    });
+
+    test('the pre-migration settings file location is gone', () {
+      expect(
+        _preMigrationSettingsFile.existsSync(),
+        isFalse,
+        reason:
+            'lib/src/in_app_webview/in_app_webview_settings.dart must NOT exist — '
+            'a stale relative import like `import "../in_app_webview_settings.dart";` '
+            'issued from lib/src/in_app_webview/modules/ would silently resolve '
+            'against this file and reship the 5.0.1 publish-time break.',
+      );
+    });
+
+    test(
+      'platform_settings_delegate.dart imports the canonical migrated path',
+      () {
+        expect(
+          _delegateFile.existsSync(),
+          isTrue,
+          reason:
+              'lib/src/in_app_webview/modules/platform_settings_delegate.dart '
+              'must exist (it is the settings-delegate facade for '
+              'PlatformInAppWebViewController).',
+        );
+        final src = _delegateFile.readAsStringSync();
+
+        // The canonical import line, exactly as the fixed source carries it.
+        const canonicalImport =
+            "import '../../domain/entities/in_app_webview_settings/in_app_webview_settings.dart';";
+        expect(
+          src.contains(canonicalImport),
+          isTrue,
+          reason:
+              'platform_settings_delegate.dart must import InAppWebViewSettings '
+              "from the canonical migrated path. Expected to find: "
+              '$canonicalImport',
+        );
+
+        // The stale pre-migration relative import that shipped in 5.0.1.
+        // Reject it in EITHER single-quote or double-quote form.
+        const staleSingle =
+            "import '../in_app_webview_settings.dart';";
+        const staleDouble =
+            'import "../in_app_webview_settings.dart";';
+        expect(
+          src.contains(staleSingle),
+          isFalse,
+          reason:
+              'platform_settings_delegate.dart must NOT carry the stale '
+              "pre-migration relative import `import '../in_app_webview_settings.dart';` "
+              '— that import shipped in published 5.0.1 and broke every consumer of '
+              'zikzak_inappwebview_platform_interface ^5.0.0.',
+        );
+        expect(
+          src.contains(staleDouble),
+          isFalse,
+          reason:
+              'platform_settings_delegate.dart must NOT carry the stale '
+              'pre-migration relative import (double-quote variant) either.',
+        );
+      },
+    );
+
+    test(
+      'no .dart file under lib/ imports the pre-migration settings path',
+      () {
+        final libDir = Directory.fromUri(_pkgRootUri().resolve('lib'));
+        expect(
+          libDir.existsSync(),
+          isTrue,
+          reason: 'lib/ must exist — this is a Dart package.',
+        );
+
+        final staleImports = <String>[];
+        for (final entity in libDir.listSync(recursive: true)) {
+          if (entity is! File) continue;
+          if (!entity.path.endsWith('.dart')) continue;
+
+          final src = entity.readAsStringSync();
+          final importerUri = entity.uri;
+
+          for (final match in _importDirective.allMatches(src)) {
+            final rawPath = match.group(1)!;
+            // Package imports are absolute; only relative imports can
+            // accidentally resolve to a stale in-repo path.
+            if (rawPath.startsWith('package:')) continue;
+            if (rawPath.startsWith('dart:')) continue;
+
+            // Only consider imports that touch the settings entity file.
+            if (!rawPath.endsWith('in_app_webview_settings.dart')) continue;
+
+            final resolved = importerUri.resolve(rawPath);
+            if (resolved.toString() ==
+                _preMigrationSettingsFile.uri.toString()) {
+              staleImports.add(
+                '${entity.path}: import \'$rawPath\' -> $resolved',
+              );
+            }
+          }
+        }
+
+        expect(
+          staleImports,
+          isEmpty,
+          reason:
+              'No .dart file under lib/ may carry a relative import that '
+              'resolves to lib/src/in_app_webview/in_app_webview_settings.dart '
+              '(the pre-migration settings location). Stale imports found:\n'
+              '  - ${staleImports.join('\n  - ')}',
+        );
+      },
+    );
+  });
+}

--- a/zikzak_inappwebview_platform_interface/test/in_app_webview_settings_migration_regression_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/in_app_webview_settings_migration_regression_test.dart
@@ -65,15 +65,18 @@ final File _preMigrationSettingsFile = _fileFromPackagePath(
   'lib/src/in_app_webview/in_app_webview_settings.dart',
 );
 
-// A regex that matches a Dart `import` directive and captures the path
-// string. Handles single OR double quotes; tolerates leading whitespace
-// and a `configurable-uri`-style `if (cond) '...'` clause (the captured
-// path is always the FIRST quoted string after `import`). Uses a
-// triple-quoted raw string so both `'` and `"` can appear inside.
+// A regex that matches a Dart `import` directive including conditional
+// imports with `if (...)` alternatives. Handles single OR double quotes;
+// tolerates leading whitespace. Uses a triple-quoted raw string so both
+// `'` and `"` can appear inside.
 final RegExp _importDirective = RegExp(
-  r"""^\s*import\s+['"]([^'"]+)['"]""",
+  r"""^\s*import\s+['"]([^'"]+)['"](?:\s+if\s*\([^)]*\)\s+['"]([^'"]+)['"])*""",
   multiLine: true,
 );
+
+// Pattern to extract all URI literals from a complete import directive
+// (including conditional alternatives in if (...) '...' clauses).
+final RegExp _uriPattern = RegExp(r"""['"]([^'"]+)['"]""");
 
 void main() {
   group('InAppWebViewSettings source layout (regression #249/#255/#257)', () {
@@ -169,21 +172,26 @@ void main() {
           final importerUri = entity.uri;
 
           for (final match in _importDirective.allMatches(src)) {
-            final rawPath = match.group(1)!;
-            // Package imports are absolute; only relative imports can
-            // accidentally resolve to a stale in-repo path.
-            if (rawPath.startsWith('package:')) continue;
-            if (rawPath.startsWith('dart:')) continue;
+            // Extract the complete matched directive text
+            final directiveText = match.group(0)!;
+            // Extract all URI literals from the directive (including if alternatives)
+            for (final uriMatch in _uriPattern.allMatches(directiveText)) {
+              final rawPath = uriMatch.group(1)!;
+              // Package imports are absolute; only relative imports can
+              // accidentally resolve to a stale in-repo path.
+              if (rawPath.startsWith('package:')) continue;
+              if (rawPath.startsWith('dart:')) continue;
 
-            // Only consider imports that touch the settings entity file.
-            if (!rawPath.endsWith('in_app_webview_settings.dart')) continue;
+              // Only consider imports that touch the settings entity file.
+              if (!rawPath.endsWith('in_app_webview_settings.dart')) continue;
 
-            final resolved = importerUri.resolve(rawPath);
-            if (resolved.toString() ==
-                _preMigrationSettingsFile.uri.toString()) {
-              staleImports.add(
-                '${entity.path}: import \'$rawPath\' -> $resolved',
-              );
+              final resolved = importerUri.resolve(rawPath);
+              if (resolved.toString() ==
+                  _preMigrationSettingsFile.uri.toString()) {
+                staleImports.add(
+                  '${entity.path}: import \'$rawPath\' -> $resolved',
+                );
+              }
             }
           }
         }

--- a/zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart
@@ -43,29 +43,40 @@ void main() {
 
       // Matches `import '...'`, `export '...'`, `part '...'` (also with
       // double quotes) at the start of a line, allowing leading whitespace.
+      // Also matches conditional imports/exports: `import '...' if (...) '...'`
+      // and collects all URI literals in the directive.
       // `part of '...'` is intentionally not matched: after `part ` the
       // regex requires a quote, and a `part of` directive targets the
       // owning library, which exists by construction.
       final directivePattern = RegExp(
-        r"""^\s*(?:import|export|part)\s+['"]([^'"]+)['"]""",
+        r"""^\s*(?:import|export|part)\s+['"]([^'"]+)['"](?:\s+if\s*\([^)]*\)\s+['"]([^'"]+)['"])*""",
         multiLine: true,
       );
+
+      // Pattern to extract all URI literals from a complete directive line
+      // (including conditional alternatives in if (...) '...' clauses).
+      final uriPattern = RegExp(r"""['"]([^'"]+)['"]""");
 
       for (final entity in libDir.listSync(recursive: true)) {
         if (entity is! File || !entity.path.endsWith('.dart')) continue;
         filesScanned++;
         final content = entity.readAsStringSync();
         for (final match in directivePattern.allMatches(content)) {
-          final uri = match.group(1)!;
-          // `dart:` and `package:` URIs are resolved by the SDK / pub, not
-          // by the filesystem layout checked here.
-          if (uri.startsWith('dart:') || uri.startsWith('package:')) continue;
-          directivesChecked++;
-          final targetPath = entity.uri.resolve(uri).toFilePath();
-          if (!File(targetPath).existsSync()) {
-            dangling.add(
-              '${entity.path}: $uri -> $targetPath (missing)',
-            );
+          // Extract the complete matched directive text
+          final directiveText = match.group(0)!;
+          // Extract all URI literals from the directive (including if alternatives)
+          for (final uriMatch in uriPattern.allMatches(directiveText)) {
+            final uri = uriMatch.group(1)!;
+            // `dart:` and `package:` URIs are resolved by the SDK / pub, not
+            // by the filesystem layout checked here.
+            if (uri.startsWith('dart:') || uri.startsWith('package:')) continue;
+            directivesChecked++;
+            final targetPath = entity.uri.resolve(uri).toFilePath();
+            if (!File(targetPath).existsSync()) {
+              dangling.add(
+                '${entity.path}: $uri -> $targetPath (missing)',
+              );
+            }
           }
         }
       }

--- a/zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/relative_import_integrity_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Regression guard for issue #257.
+///
+/// `zikzak_inappwebview_platform_interface` 5.0.1 shipped
+/// `lib/src/in_app_webview/modules/platform_settings_delegate.dart` with
+///
+///     import '../in_app_webview_settings.dart';
+///
+/// — a file that did not exist (the class lives under
+/// `lib/src/domain/entities/in_app_webview_settings/`). Every consumer of
+/// the published package failed to compile with
+///
+///     Error: Error when reading '.../in_app_webview_settings.dart':
+///     No such file or directory
+///     Type 'InAppWebViewSettings' not found.
+///
+/// The analyzer reports `uri_does_not_exist` for such directives, but no
+/// test surface caught it before the package was published, because the
+/// broken file is only reachable through the consumer's build.
+///
+/// This test walks every `.dart` file under `lib/` and asserts that every
+/// relative `import`/`export`/`part` URI resolves to a real file, so a
+/// dangling relative import can never ship to pub.dev again.
+void main() {
+  test(
+    'every relative import/export/part URI in lib/ resolves to a real file',
+    () {
+      final libDir = Directory.fromUri(Directory.current.uri.resolve('lib'));
+      expect(
+        libDir.existsSync(),
+        isTrue,
+        reason:
+            'lib/ not found under ${Directory.current.path} — the test must '
+            'run from the package root (flutter test does this by default).',
+      );
+
+      final dangling = <String>[];
+      var filesScanned = 0;
+      var directivesChecked = 0;
+
+      // Matches `import '...'`, `export '...'`, `part '...'` (also with
+      // double quotes) at the start of a line, allowing leading whitespace.
+      // `part of '...'` is intentionally not matched: after `part ` the
+      // regex requires a quote, and a `part of` directive targets the
+      // owning library, which exists by construction.
+      final directivePattern = RegExp(
+        r"""^\s*(?:import|export|part)\s+['"]([^'"]+)['"]""",
+        multiLine: true,
+      );
+
+      for (final entity in libDir.listSync(recursive: true)) {
+        if (entity is! File || !entity.path.endsWith('.dart')) continue;
+        filesScanned++;
+        final content = entity.readAsStringSync();
+        for (final match in directivePattern.allMatches(content)) {
+          final uri = match.group(1)!;
+          // `dart:` and `package:` URIs are resolved by the SDK / pub, not
+          // by the filesystem layout checked here.
+          if (uri.startsWith('dart:') || uri.startsWith('package:')) continue;
+          directivesChecked++;
+          final targetPath = entity.uri.resolve(uri).toFilePath();
+          if (!File(targetPath).existsSync()) {
+            dangling.add(
+              '${entity.path}: $uri -> $targetPath (missing)',
+            );
+          }
+        }
+      }
+
+      // Sanity: the walker must actually have scanned the package sources.
+      // If this fires, the test was run from an unexpected working directory
+      // and checked nothing (a silent pass would be worse than a failure).
+      expect(filesScanned, greaterThan(100));
+
+      expect(
+        dangling,
+        isEmpty,
+        reason:
+            'Found ${dangling.length} dangling relative URI(s) while checking '
+            '$directivesChecked directives in $filesScanned Dart files under '
+            'lib/. The analyzer would report "Target of URI doesn\'t exist" '
+            '(issue #257 regression — a broken import previously shipped to '
+            'pub.dev in 5.0.1). Offending directives:\n'
+            '${dangling.join('\n')}',
+      );
+    },
+  );
+}

--- a/zikzak_inappwebview_platform_interface/test/types/in_app_webview_settings_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/types/in_app_webview_settings_test.dart
@@ -1,0 +1,91 @@
+// Public-API regression tests for the InAppWebViewSettings.persistentStoreIdentifier
+// field introduced for issue #253 — per-instance persistent, isolated
+// WKWebsiteDataStore on iOS 17+/macOS 14+.
+//
+// Pins the CONSUMER-VISIBLE contract:
+//   - default-constructed settings have NO persistentStoreIdentifier key in
+//     the wire format (@JsonKey(includeIfNull: false) → null is dropped),
+//     so existing call sites that never set the field are unchanged,
+//   - any non-null string round-trips verbatim (the Swift side is what maps
+//     the string to a stable UUID; the Dart side just stores/transmits it),
+//   - the three input shapes documented in the field dartdoc (raw UUID
+//     string, 64-char SHA-256 hex, arbitrary stable string) all survive a
+//     toJson → fromJson round-trip unchanged.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+void main() {
+  group('InAppWebViewSettings.persistentStoreIdentifier', () {
+    test('default-constructed settings omit the key (includeIfNull: false)',
+        () {
+      final settings = InAppWebViewSettings();
+      final map = settings.toJson();
+      expect(map.containsKey('persistentStoreIdentifier'), isFalse,
+          reason:
+              'When the field is null, the key MUST be absent so the macOS/iOS '
+              'native init falls through to the existing incognito/default() '
+              'branch (issue #253: "No behavioral change when '
+              'persistentStoreIdentifier is null").');
+      expect(settings.persistentStoreIdentifier, isNull);
+    });
+
+    test('a non-null value is included verbatim in the wire format', () {
+      const id = 'alice-profile';
+      final settings = InAppWebViewSettings(persistentStoreIdentifier: id);
+      final map = settings.toJson();
+      expect(map['persistentStoreIdentifier'], 'alice-profile');
+      expect(settings.persistentStoreIdentifier, 'alice-profile');
+    });
+
+    test('round-trips a raw UUID string', () {
+      const id = '550e8400-e29b-41d4-a716-446655440000';
+      final settings = InAppWebViewSettings(persistentStoreIdentifier: id);
+      final restored = InAppWebViewSettings.fromJson(settings.toJson());
+      expect(restored.persistentStoreIdentifier, id);
+    });
+
+    test('round-trips a 64-char SHA-256 hex string (legacy contract)', () {
+      // The shape forklift used to send: 64-char lowercase SHA-256 hex
+      // derived from a profile dir's canonical path.
+      const id =
+          '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08';
+      final settings = InAppWebViewSettings(persistentStoreIdentifier: id);
+      final restored = InAppWebViewSettings.fromJson(settings.toJson());
+      expect(restored.persistentStoreIdentifier, id);
+    });
+
+    test('round-trips an arbitrary stable string (SHA-256-fallback path)', () {
+      const id = 'multi-account-dashboard::profile-7';
+      final settings = InAppWebViewSettings(persistentStoreIdentifier: id);
+      final restored = InAppWebViewSettings.fromJson(settings.toJson());
+      expect(restored.persistentStoreIdentifier, id);
+    });
+
+    test('round-trips an empty string as null (no-op, no behavioral change)',
+        () {
+      // The Swift side treats an empty string the same as null (guard
+      // !id.isEmpty), so the Dart wire format should not let an empty
+      // string leak through and surprise the native side — verify the
+      // explicit-null path produces a missing key, mirroring the
+      // includeIfNull: false semantics.
+      final settings = InAppWebViewSettings(persistentStoreIdentifier: null);
+      final map = settings.toJson();
+      expect(map.containsKey('persistentStoreIdentifier'), isFalse);
+    });
+
+    test('incognito and persistentStoreIdentifier can coexist on the wire '
+        '(native side resolves precedence — incognito wins)', () {
+      // The Dart-side settings object has no enforcement of mutual
+      // exclusion; the native init resolves it (incognito takes
+      // precedence). Pin the wire format so the native side reliably
+      // receives both keys when both are set.
+      final settings = InAppWebViewSettings(
+        incognito: true,
+        persistentStoreIdentifier: 'alice-profile',
+      );
+      final map = settings.toJson();
+      expect(map['incognito'], isTrue);
+      expect(map['persistentStoreIdentifier'], 'alice-profile');
+    });
+  });
+}


### PR DESCRIPTION
Closes #267

Consolidated landing of the platform-parity hardening and publish-regression-guard work previously filed as PRs #262, #263, #265 and #266 (all closed as superseded by the #267 tracker; branches were preserved on origin and are cherry-picked here verbatim onto `master`).

## What's included

### 1. [Linux] platform gap analysis & hardening (from PR #262, issue #251)
- `LinuxCookieManager`: full `MethodChannel` wiring for `setCookie` / `getCookies` / `getCookie` / `deleteCookie` / `deleteCookies` / `deleteAllCookies` / `getAllCookies` / `removeSessionCookies` (replaces the previous TODO stubs that silently returned `true`/`[]`), plus a shared-instance accessor mirroring the other platform implementations.
- `LinuxInAppWebViewController`: ~1,100 lines of API-coverage parity — navigation (`postUrl`, `loadFile`, `reloadFromOrigin`, `goBackOrForward`, `goTo`), user scripts (`addUserScript(s)` / `removeUserScript(s)` / `removeUserScriptsByGroupName` / `removeAllUserScripts`), `callAsyncJavaScript`, settings, history, scrolling, zoom, content dimensions, timers/pause, text/hit-test/focus, context menu/meta, security/context, media playback & capture state, cache/data, print, DevTools protocol, user agent, safe browsing, web archive, and ~30 additional event-channel cases (`onReceivedHttpError`, `onScrollChanged`, `onCreateWindow`, JS dialogs, auth challenges, permission requests, render-process events, fullscreen, media-capture state changes, …). Linux-inapplicable APIs fail fast with `UnimplementedError` instead of pretending to succeed.
- Error reporting: the method-call handler now logs method name + stack trace via `debugPrint` instead of silently swallowing exceptions; `print` replaced with `debugPrint`.

### 2. [iOS/macOS] per-instance persistent isolated `WKWebsiteDataStore` (from PR #265, issue #253)
- iOS counterpart to the macOS `persistentStoreIdentifier` support that shipped in 5.1.1/5.1.2: the setting is applied on the `WKWebViewConfiguration` **before** the `WKWebView` is created (iOS 17+ guard; falls through to existing `incognito`/`default()` behavior below that floor), and is mutually exclusive with `incognito` (incognito wins).
- Both the iOS and macOS `persistentUUID(from:)` helpers now accept three deterministic identifier shapes: a raw UUID string, the legacy 64-char SHA-256 hex (preserving on-disk stores created by the shipped macOS path), and any other stable string (SHA-256 of its UTF-8 bytes via CryptoKit).
- Dart-side dartdoc on `InAppWebViewSettings.persistentStoreIdentifier` expanded to pin the consumer-visible contract.
- New `test/types/in_app_webview_settings_test.dart`: 7 tests pinning the wire format (key omitted when null, verbatim round-trips for all three identifier shapes, coexistence with `incognito`).

### 3. [test] stale `in_app_webview_settings` import regression (from PR #263, issues #249/#255/#257)
- New `test/in_app_webview_settings_migration_regression_test.dart` guarding against the published-5.0.1 bug class: asserts the settings entity lives at its migrated path, the pre-migration file location is gone, `platform_settings_delegate.dart` carries the canonical import, and **no** `.dart` file under `lib/` carries any relative import resolving to the pre-migration path.

### 4. [test] relative-import integrity guard (from PR #266, issue #257)
- New `test/relative_import_integrity_test.dart`: walks every `.dart` file under `lib/` and asserts every relative `import`/`export`/`part` URI resolves to a real file, so a dangling relative import can never ship to pub.dev again (includes a files-scanned sanity floor to guard against silent no-op runs).

## Verification
- `flutter analyze` — `zikzak_inappwebview_platform_interface`, `zikzak_inappwebview_linux`, `zikzak_inappwebview`: **0 errors** (pre-existing info/warning lints unchanged; new files lint-clean).
- `flutter test` (platform_interface): **162/162 passed**, including the 4 new migration-regression tests, the relative-import integrity guard, and the 7 `persistentStoreIdentifier` wire-contract tests.
- Combined diff vs `master`: 10 files, +1,799 / −112. No public API removed; all changes are additive (new settings field docs, new native branches behind availability guards, previously-stubbed Linux methods now implemented).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable persistent website storage identifiers for supported iOS and macOS versions.
  * Expanded Linux WebView support across navigation, scripting, history, media, printing, DevTools, and related operations.
  * Added functional Linux cookie management, including creation, retrieval, and deletion.

* **Bug Fixes**
  * Preserved explicitly configured persistent storage when shared cookies are enabled.
  * Improved Linux WebView error reporting and resource loading.

* **Documentation**
  * Clarified storage identifier formats, platform support, and incognito behavior.

* **Tests**
  * Added regression coverage for settings persistence and import integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->