### PR TITLE
fix(macos): enable WebAuthn/passkey sign-in by wiring webAuthenticationSupport into WKWebViewConfiguration

### DIFF
--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- Enable WebAuthn / passkey sign-in on macOS (#272): wire the `webAuthenticationSupport` setting into the native `WKWebViewConfiguration` (via KVC, `boundKeychainForPasskeys = true` when `WebAuthenticationSupport.FOR_APP`), matching the iOS wiring. The configuration is immutable after `WKWebView` init, so the setting is applied in the `init` config builder, guarded by `#available(macOS 13.3, *)`. Also adds the `getRealSettings` read-back so `PlatformInAppWebViewController.getSettings()` reports the effective value. Note: the host app still needs the `webcredentials:` Associated Domains entitlement and the site must serve a valid `apple-app-site-association`.
+
 ## 5.1.2 - 2026-08-24
 
 ### Fixes

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -159,6 +159,22 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                           incognito {
                     configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                 }
+                // WebAuthn / passkey support (issue #272).
+                // Mirrors the iOS KVC wiring (PR #131).
+                // Must be set before super.init because the configuration is
+                // immutable afterwards.
+                if #available(macOS 13.3, *) {
+                    if let webAuthnSupport = settingsMap["webAuthenticationSupport"] as? Int,
+                       webAuthnSupport == 1 {  // FOR_APP
+                        let selector = Selector(("webAuthenticationSupport"))
+                        if configuration.responds(to: selector),
+                           let webAuthSupport = configuration.perform(selector)?.takeUnretainedValue()
+                               as? NSObject
+                        {
+                            webAuthSupport.setValue(true, forKey: "boundKeychainForPasskeys")
+                        }
+                    }
+                }
             }
         }
 

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewSettings.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewSettings.swift
@@ -126,6 +126,18 @@ public class InAppWebViewSettings: ISettings<InAppWebView> {
                 realSettings["isElementFullscreenEnabled"] =
                     configuration.preferences.isElementFullscreenEnabled
             }
+            // WebAuthn / passkey read-back (issue #272)
+            if #available(macOS 13.3, *) {
+                let selector = Selector(("webAuthenticationSupport"))
+                if configuration.responds(to: selector),
+                   let webAuthSupport = configuration.perform(selector)?.takeUnretainedValue()
+                       as? NSObject
+                {
+                    let boundValue =
+                        webAuthSupport.value(forKey: "boundKeychainForPasskeys") as? Bool ?? false
+                    realSettings["webAuthenticationSupport"] = boundValue ? 1 : 0
+                }
+            }
             // isFindInteractionEnabled is not available on macOS
         }
         return realSettings

--- a/zikzak_inappwebview_platform_interface/CHANGELOG.md
+++ b/zikzak_inappwebview_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- Export `webAuthenticationSupportFromWire` / `webAuthenticationSupportToWire` from the platform interface (they were generated but not exported, so custom platform implementations could not use them) and document the platform support matrix for `webAuthenticationSupport` (iOS 16.4+, macOS 13.3+, Android via `WebViewFeature.WEB_AUTHENTICATION`; ignored on Windows/Linux) (#272).
+
 ## 5.1.3 (unreleased)
 
 ### Docs

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart
@@ -530,6 +530,20 @@ abstract class $InAppWebViewSettings {
   bool? get paymentRequestEnabled;
 
   ///Sets the Web Authentication support level for the WebView. The default value is [WebAuthenticationSupport.NONE].
+  ///
+  ///Supported on:
+  ///- iOS 16.4+ (app-bound passkeys; requires the host app to add the
+  ///  webcredentials Associated Domains entitlement and the site to serve
+  ///  a valid apple-app-site-association file - see the Apple passkeys docs)
+  ///- macOS 13.3+ (app-bound passkeys; same host-app Associated Domains
+  ///  entitlement and apple-app-site-association requirements as iOS)
+  ///- Android (androidx.webkit WebViewFeature.WEB_AUTHENTICATION,
+  ///  feature-detected at runtime)
+  ///
+  ///Other platforms either do not expose a per-WebView WebAuthn toggle
+  ///(Windows/WebView2: WebAuthn is handled by Windows Hello when available)
+  ///or have no public WebAuthn API (Linux/WebKitGTK), so the setting is
+  ///ignored there.
   @JsonKey(
     toJson: webAuthenticationSupportToWire,
     fromJson: webAuthenticationSupportFromWire,

--- a/zikzak_inappwebview_platform_interface/lib/src/types/main.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/types/main.dart
@@ -321,7 +321,10 @@ export '../domain/entities/enums/web_authentication_session_error.dart'
         webAuthenticationSessionErrorFromWire,
         webAuthenticationSessionErrorToWire;
 export '../domain/entities/enums/web_authentication_support.dart'
-    show WebAuthenticationSupport;
+    show
+        WebAuthenticationSupport,
+        webAuthenticationSupportFromWire,
+        webAuthenticationSupportToWire;
 export '../domain/entities/web_history/web_history.dart'
     show WebHistory, WebHistorySerialization;
 export '../domain/entities/web_history_item/web_history_item.dart'

--- a/zikzak_inappwebview_platform_interface/test/types/web_authentication_support_wire_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/types/web_authentication_support_wire_test.dart
@@ -1,0 +1,89 @@
+// Wire-contract regression tests for the `webAuthenticationSupport` setting
+// (issue #272).
+//
+// The native WebAuthn wiring on iOS and macOS compares the raw settings-map
+// integer against `1` (FOR_APP):
+//   - iOS:  InAppWebView.preWKWebViewConfiguration (iOS 16.4+)
+//   - macOS: InAppWebView.init (macOS 13.3+, this repo, issue #272)
+//   - Android: WebSettingsCompat.setWebAuthenticationSupport
+// Those comparisons only work because the Dart side serializes the
+// `WebAuthenticationSupport` enum to its INDEX on the wire. If the enum order
+// ever changes (inserting/reordering values), every native `== 1` check
+// silently breaks and passkey/WebAuthn sign-in stops being enabled. These
+// tests pin the wire contract.
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+void main() {
+  group('WebAuthenticationSupport wire contract (issue #272)', () {
+    test('enum indices are pinned: NONE=0, FOR_APP=1, FOR_BROWSER=2', () {
+      // The native iOS/macOS code enables passkeys when the wire value == 1.
+      expect(WebAuthenticationSupport.NONE.index, 0);
+      expect(WebAuthenticationSupport.FOR_APP.index, 1);
+      expect(WebAuthenticationSupport.FOR_BROWSER.index, 2);
+    });
+
+    test('toWire serializes to the enum index', () {
+      expect(
+        webAuthenticationSupportToWire(WebAuthenticationSupport.NONE),
+        0,
+      );
+      expect(
+        webAuthenticationSupportToWire(WebAuthenticationSupport.FOR_APP),
+        1,
+      );
+      expect(
+        webAuthenticationSupportToWire(WebAuthenticationSupport.FOR_BROWSER),
+        2,
+      );
+      expect(webAuthenticationSupportToWire(null), isNull);
+    });
+
+    test('fromWire parses index ints and rejects everything else', () {
+      expect(
+        webAuthenticationSupportFromWire(0),
+        WebAuthenticationSupport.NONE,
+      );
+      expect(
+        webAuthenticationSupportFromWire(1),
+        WebAuthenticationSupport.FOR_APP,
+      );
+      expect(
+        webAuthenticationSupportFromWire(2),
+        WebAuthenticationSupport.FOR_BROWSER,
+      );
+      // Out-of-range and non-int values must parse to null, never throw.
+      expect(webAuthenticationSupportFromWire(3), isNull);
+      expect(webAuthenticationSupportFromWire(-1), isNull);
+      expect(webAuthenticationSupportFromWire(null), isNull);
+      expect(webAuthenticationSupportFromWire('1'), isNull);
+      expect(webAuthenticationSupportFromWire(true), isNull);
+    });
+
+    test('settings toJson carries webAuthenticationSupport as index int', () {
+      final settings = InAppWebViewSettings(
+        webAuthenticationSupport: WebAuthenticationSupport.FOR_APP,
+      );
+      final wire = settings.toJson();
+      expect(wire['webAuthenticationSupport'], 1);
+
+      final noneSettings = InAppWebViewSettings(
+        webAuthenticationSupport: WebAuthenticationSupport.NONE,
+      );
+      expect(noneSettings.toJson()['webAuthenticationSupport'], 0);
+    });
+
+    test('settings fromJson round-trips the wire int', () {
+      final settings = InAppWebViewSettings.fromJson(const {
+        'webAuthenticationSupport': 1,
+      });
+      expect(
+        settings.webAuthenticationSupport,
+        WebAuthenticationSupport.FOR_APP,
+      );
+
+      final defaults = InAppWebViewSettings.fromJson(const {});
+      expect(defaults.webAuthenticationSupport, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Closes #272

## Problem

On macOS, when a page served in an `InAppWebView` triggers a WebAuthn flow (e.g. `navigator.credentials.get({ publicKey })` for a passkey login), the system passkey sheet never appears and sign-in cannot complete. With `webAuthenticationSupport: WebAuthenticationSupport.FOR_APP` the WebView should enable native Web Authentication so passkeys surface — the setting works on iOS but was a no-op on macOS.

## Root Cause

`webAuthenticationSupport` is declared in the macOS native settings mirror (`InAppWebViewSettings.swift:69`) and auto-parsed from the Dart settings map via KVC, but it was **never applied** to the `WKWebViewConfiguration`. Since `WKWebViewConfiguration` is immutable after `super.init`, the WebAuthn support must be enabled in the `init` config builder — and the macOS `init` only read `persistentStoreIdentifier`/`incognito`. The iOS wiring (PR #131, `WKWebViewWebAuthenticationSupport.boundKeychainForPasskeys`) was never ported to macOS.

## Changes

### macOS (`zikzak_inappwebview_macos`)
- **`InAppWebView.swift`** — apply `webAuthenticationSupport == 1` (FOR_APP) to the `WKWebViewConfiguration` in `init` via the same ObjC-runtime KVC/selector dance iOS uses (`configuration.perform(Selector(("webAuthenticationSupport")))` → `setValue(true, forKey: "boundKeychainForPasskeys")`), guarded by `#available(macOS 13.3, *)` (package minimum is macOS 12.0). KVC avoids compile-time availability issues with older SDKs (same rationale as commit 63cfd48f on iOS).
- **`InAppWebViewSettings.swift`** — `getRealSettings` read-back of the effective `boundKeychainForPasskeys` value so `getSettings()` reports it (iOS parity).

### Platform interface (`zikzak_inappwebview_platform_interface`)
- Export `webAuthenticationSupportFromWire` / `webAuthenticationSupportToWire` from the package (they were generated but never exported, so custom platform implementations and tests could not reference them).
- Document the platform support matrix + host-app requirements on the setting.
- **New regression tests** (`test/types/web_authentication_support_wire_test.dart`, 5 tests) pinning the enum-index wire contract (`NONE=0, FOR_APP=1, FOR_BROWSER=2`) — the native `== 1` (FOR_APP) checks on iOS/macOS and `WebSettingsCompat.setWebAuthenticationSupport` on Android all depend on these indices staying stable.

### Changelogs
- `zikzak_inappwebview_macos/CHANGELOG.md` and `zikzak_inappwebview_platform_interface/CHANGELOG.md` — Unreleased fixes entries.

## Cross-platform WebAuthn status (survey)

| Platform | Status |
|----------|--------|
| iOS 16.4+ | Already wired (KVC, PR #131) — unchanged |
| Android | Already wired (`WebViewFeature.WEB_AUTHENTICATION`, feature-detected) — unchanged |
| **macOS 13.3+** | **Fixed in this PR** (was a no-op) |
| Windows (WebView2) | No per-WebView WebAuthn toggle exists in `ICoreWebView2Settings`; WebAuthn is handled by Windows Hello when available — nothing to wire |
| Linux (WebKitGTK) | No public per-WebView WebAuthn settings API — nothing to wire |

## Host-app requirement (documented, not fixable in-plugin)

Enabling `webAuthenticationSupport` is necessary but not sufficient: for app-bound passkeys the host app must add the `webcredentials:` Associated Domains entitlement and the site must serve a valid `apple-app-site-association`. This is host-app configuration the plugin cannot add.

## Verification

- `dart analyze` (platform_interface): **0 errors** (941 pre-existing info-level lints, identical to the pre-change baseline).
- `flutter test` (platform_interface): **155/155 passed** (150 baseline + 5 new wire-contract tests).
- macOS Swift change is a faithful port of the proven iOS KVC pattern (compiles by construction — KVC avoids compile-time SDK symbols; no Swift toolchain on the Linux CI box).
- Manual passkey sign-in on macOS requires the entitlement setup above and cannot be exercised in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added macOS WebAuthn and passkey support for compatible systems.
  - Added support for reading back the effective Web Authentication setting.
  - Documented platform availability across iOS, macOS, Android, Windows, and Linux.

- **Bug Fixes**
  - Exported Web Authentication conversion helpers for custom platform implementations.

- **Tests**
  - Added coverage for serialization, deserialization, invalid values, and settings round-tripping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->