### PR TITLE
fix(ios,android): bulletproof the WebAuthn/passkey wiring (#272 follow-up)

### DIFF
--- a/zikzak_inappwebview_android/CHANGELOG.md
+++ b/zikzak_inappwebview_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- Harden the WebAuthn/passkey wiring (#272 follow-up): log a warning when `webAuthenticationSupport` is requested but `WebViewFeature.WEB_AUTHENTICATION` is not supported by the installed WebView (init and `setSettings` paths) instead of silently dropping the setting, broaden the compat-call catch to `RuntimeException` so OEM WebView wrappers can never crash the app, and guard the `getSettings()` read-back with the same protection (a missing key still parses as `null` on the Dart side).
+
 ## 5.1.2 - 2026-08-24
 
 * chore: restore development path dependencies after 5.1.1 publish

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebView.java
@@ -749,12 +749,27 @@ public final class InAppWebView
           }
         }
 
-        if (customSettings.webAuthenticationSupport != null &&
-                WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
-          try {
-            WebSettingsCompat.setWebAuthenticationSupport(settings, customSettings.webAuthenticationSupport);
-          } catch (ClassCastException e) {
-            Log.w(LOG_TAG, "OEM WebView wrapper incompatible with setWebAuthenticationSupport", e);
+        if (customSettings.webAuthenticationSupport != null) {
+          if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+            try {
+              WebSettingsCompat.setWebAuthenticationSupport(settings, customSettings.webAuthenticationSupport);
+            } catch (RuntimeException e) {
+              // ClassCastException: OEM WebView wrapper incompatibility; other
+              // RuntimeExceptions: provider glue failures. Applying a settings
+              // value must never crash the app.
+              Log.w(LOG_TAG, "Failed to apply webAuthenticationSupport", e);
+            }
+          } else if (customSettings.webAuthenticationSupport != 0) {
+            // The setting was explicitly requested but this WebView does not
+            // support WebAuthn — surface it instead of silently dropping it
+            // (the same class of silent no-op as issue #272 on macOS).
+            Log.w(
+                LOG_TAG,
+                "webAuthenticationSupport="
+                    + customSettings.webAuthenticationSupport
+                    + " requested but WebViewFeature.WEB_AUTHENTICATION is not supported"
+                    + " by this WebView; passkey sign-in will not work. Update the"
+                    + " Android System WebView component.");
           }
         }
 
@@ -2213,12 +2228,19 @@ public final class InAppWebView
         }
 
         if (newSettingsMap.get("webAuthenticationSupport") != null &&
-                !Util.objEquals(customSettings.webAuthenticationSupport, newCustomSettings.webAuthenticationSupport) &&
-                WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
-            try {
-                WebSettingsCompat.setWebAuthenticationSupport(settings, newCustomSettings.webAuthenticationSupport);
-            } catch (ClassCastException e) {
-                Log.w(LOG_TAG, "OEM WebView wrapper incompatible with setWebAuthenticationSupport", e);
+                !Util.objEquals(customSettings.webAuthenticationSupport, newCustomSettings.webAuthenticationSupport)) {
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.WEB_AUTHENTICATION)) {
+                try {
+                    WebSettingsCompat.setWebAuthenticationSupport(settings, newCustomSettings.webAuthenticationSupport);
+                } catch (RuntimeException e) {
+                    Log.w(LOG_TAG, "Failed to apply webAuthenticationSupport", e);
+                }
+            } else {
+                Log.w(
+                        LOG_TAG,
+                        "webAuthenticationSupport change requested but"
+                                + " WebViewFeature.WEB_AUTHENTICATION is not supported by this"
+                                + " WebView; ignoring");
             }
         }
 

--- a/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebViewSettings.java
+++ b/zikzak_inappwebview_android/android/src/main/java/wtf/zikzak/zikzak_inappwebview_android/webview/in_app_webview/InAppWebViewSettings.java
@@ -5,6 +5,7 @@ import static android.webkit.WebSettings.LayoutAlgorithm.NORMAL;
 
 import android.annotation.SuppressLint;
 import android.os.Build;
+import android.util.Log;
 import android.view.View;
 import android.webkit.WebSettings;
 import androidx.annotation.NonNull;
@@ -950,10 +951,20 @@ public class InAppWebViewSettings implements ISettings<InAppWebViewInterface> {
                     WebViewFeature.WEB_AUTHENTICATION
                 )
             ) {
-                realSettings.put(
-                    "webAuthenticationSupport",
-                    WebSettingsCompat.getWebAuthenticationSupport(settings)
-                );
+                try {
+                    realSettings.put(
+                        "webAuthenticationSupport",
+                        WebSettingsCompat.getWebAuthenticationSupport(settings)
+                    );
+                } catch (RuntimeException e) {
+                    // OEM WebView wrapper incompatibility. Omitting the key makes
+                    // the Dart side parse it as null, which signals "unsupported".
+                    Log.w(
+                        LOG_TAG,
+                        "OEM WebView wrapper incompatible with getWebAuthenticationSupport",
+                        e
+                    );
+                }
             }
             if (
                 WebViewFeature.isFeatureSupported(

--- a/zikzak_inappwebview_ios/CHANGELOG.md
+++ b/zikzak_inappwebview_ios/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes
+
+- Harden the WebAuthn/passkey wiring (#272 follow-up): guard the KVC `boundKeychainForPasskeys` write/read with `responds(to:)` so an unexpected SDK state can never raise an uncatchable `NSUnknownKeyException`, and log a warning when `webAuthenticationSupport` is changed through `setSettings` (the `WKWebViewConfiguration` is immutable after init, so the change is a documented no-op instead of a silent one).
+
 ## 5.1.2 - 2026-08-24
 
 * chore: restore development path dependencies after 5.1.1 publish

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -795,7 +795,12 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                         let webAuthSupport = configuration.perform(selector)?.takeUnretainedValue()
                             as? NSObject
                     {
-                        webAuthSupport.setValue(true, forKey: "boundKeychainForPasskeys")
+                        // Guard the inner key as well: setValue(_:forKey:) raises an
+                        // uncatchable NSUnknownKeyException when the key is missing,
+                        // which would crash the app on an unexpected SDK state.
+                        if webAuthSupport.responds(to: Selector(("boundKeychainForPasskeys"))) {
+                            webAuthSupport.setValue(true, forKey: "boundKeychainForPasskeys")
+                        }
                     }
                 }
             }
@@ -1141,6 +1146,18 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     configuration.userContentController.removeAllUserScripts()
                 }
             }
+        }
+
+        // webAuthenticationSupport is creation-time only: the underlying
+        // WKWebViewConfiguration is immutable after the WKWebView is created,
+        // so a runtime change is a no-op. Surface it instead of silently
+        // dropping it (issue #272).
+        if newSettingsMap["webAuthenticationSupport"] != nil
+            && settings?.webAuthenticationSupport != newSettings.webAuthenticationSupport
+        {
+            print(
+                "webAuthenticationSupport cannot be changed after the WebView has been created (WKWebViewConfiguration is immutable); ignoring the new value"
+            )
         }
 
         if newSettingsMap["transparentBackground"] != nil

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebViewSettings.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebViewSettings.swift
@@ -220,8 +220,12 @@ public class InAppWebViewSettings: ISettings<InAppWebView> {
                 let selector = Selector(("webAuthenticationSupport"))
                 if configuration.responds(to: selector),
                     let webAuthSupport = configuration.perform(selector)?.takeUnretainedValue()
-                        as? NSObject
+                        as? NSObject,
+                    webAuthSupport.responds(to: Selector(("boundKeychainForPasskeys")))
                 {
+                    // value(forKey:) throws an uncatchable NSUnknownKeyException
+                    // when the key is missing — the responds(to:) guard above keeps
+                    // getRealSettings() crash-proof on unexpected SDK states.
                     let boundValue =
                         webAuthSupport.value(forKey: "boundKeychainForPasskeys") as? Bool ?? false
                     realSettings["webAuthenticationSupport"] = boundValue ? 1 : 0

--- a/zikzak_inappwebview_macos/CHANGELOG.md
+++ b/zikzak_inappwebview_macos/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Enable WebAuthn / passkey sign-in on macOS (#272): wire the `webAuthenticationSupport` setting into the native `WKWebViewConfiguration` (via KVC, `boundKeychainForPasskeys = true` when `WebAuthenticationSupport.FOR_APP`), matching the iOS wiring. The configuration is immutable after `WKWebView` init, so the setting is applied in the `init` config builder, guarded by `#available(macOS 13.3, *)`. Also adds the `getRealSettings` read-back so `PlatformInAppWebViewController.getSettings()` reports the effective value. Note: the host app still needs the `webcredentials:` Associated Domains entitlement and the site must serve a valid `apple-app-site-association`.
+- Harden the WebAuthn/passkey wiring (#272 follow-up): guard the KVC `boundKeychainForPasskeys` write/read with `responds(to:)` against unexpected SDK states and log a warning when `webAuthenticationSupport` is changed through `setSettings` (creation-time only, as documented).
 
 ## 5.1.2 - 2026-08-24
 

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -171,7 +171,13 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                            let webAuthSupport = configuration.perform(selector)?.takeUnretainedValue()
                                as? NSObject
                         {
-                            webAuthSupport.setValue(true, forKey: "boundKeychainForPasskeys")
+                            // Guard the inner key as well: setValue(_:forKey:) raises
+                            // an uncatchable NSUnknownKeyException when the key is
+                            // missing, which would crash the app on an unexpected
+                            // SDK state.
+                            if webAuthSupport.responds(to: Selector(("boundKeychainForPasskeys"))) {
+                                webAuthSupport.setValue(true, forKey: "boundKeychainForPasskeys")
+                            }
                         }
                     }
                 }
@@ -1654,6 +1660,18 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     }
 
     func setSettings(newSettings: InAppWebViewSettings, newSettingsMap: [String: Any]) {
+        // webAuthenticationSupport is creation-time only: the underlying
+        // WKWebViewConfiguration is immutable after the WKWebView is created,
+        // so a runtime change is a no-op. Surface it instead of silently
+        // dropping it (issue #272).
+        if newSettingsMap["webAuthenticationSupport"] != nil
+            && settings?.webAuthenticationSupport != newSettings.webAuthenticationSupport
+        {
+            print(
+                "webAuthenticationSupport cannot be changed after the WebView has been created (WKWebViewConfiguration is immutable); ignoring the new value"
+            )
+        }
+
         if newSettingsMap["userAgent"] != nil
             && settings?.userAgent != newSettings.userAgent
             && newSettings.userAgent != ""

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewSettings.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewSettings.swift
@@ -131,8 +131,12 @@ public class InAppWebViewSettings: ISettings<InAppWebView> {
                 let selector = Selector(("webAuthenticationSupport"))
                 if configuration.responds(to: selector),
                    let webAuthSupport = configuration.perform(selector)?.takeUnretainedValue()
-                       as? NSObject
+                       as? NSObject,
+                   webAuthSupport.responds(to: Selector(("boundKeychainForPasskeys")))
                 {
+                    // value(forKey:) throws an uncatchable NSUnknownKeyException
+                    // when the key is missing — the responds(to:) guard above keeps
+                    // getRealSettings() crash-proof on unexpected SDK states.
                     let boundValue =
                         webAuthSupport.value(forKey: "boundKeychainForPasskeys") as? Bool ?? false
                     realSettings["webAuthenticationSupport"] = boundValue ? 1 : 0

--- a/zikzak_inappwebview_platform_interface/CHANGELOG.md
+++ b/zikzak_inappwebview_platform_interface/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - Export `webAuthenticationSupportFromWire` / `webAuthenticationSupportToWire` from the platform interface (they were generated but not exported, so custom platform implementations could not use them) and document the platform support matrix for `webAuthenticationSupport` (iOS 16.4+, macOS 13.3+, Android via `WebViewFeature.WEB_AUTHENTICATION`; ignored on Windows/Linux) (#272).
+- Document the `webAuthenticationSupport` runtime semantics (creation-time only on iOS/macOS; `null` read-back on Android when the WebView lacks `WebViewFeature.WEB_AUTHENTICATION`; WebAuthn requires a user gesture) and pin the enum to exactly NONE/FOR_APP/FOR_BROWSER in the wire-contract tests (#272 follow-up).
 
 ## 5.1.3 (unreleased)
 

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/in_app_webview_settings/in_app_webview_settings.dart
@@ -544,6 +544,17 @@ abstract class $InAppWebViewSettings {
   ///(Windows/WebView2: WebAuthn is handled by Windows Hello when available)
   ///or have no public WebAuthn API (Linux/WebKitGTK), so the setting is
   ///ignored there.
+  ///
+  ///Notes:
+  ///- On iOS and macOS this setting is applied when the WebView is created
+  ///  and cannot be changed afterwards (the underlying WKWebViewConfiguration
+  ///  is immutable after init); changing it later through setSettings is a
+  ///  no-op and logs a native warning.
+  ///- On Android, getSettings returns `null` for this setting when the
+  ///  installed WebView does not support `WebViewFeature.WEB_AUTHENTICATION`
+  ///  or the OEM WebView wrapper rejects the call.
+  ///- WebAuthn ceremonies require a user gesture (for example a sign-in
+  ///  button tap) inside the WebView.
   @JsonKey(
     toJson: webAuthenticationSupportToWire,
     fromJson: webAuthenticationSupportFromWire,

--- a/zikzak_inappwebview_platform_interface/test/types/web_authentication_support_wire_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/types/web_authentication_support_wire_test.dart
@@ -85,5 +85,19 @@ void main() {
       final defaults = InAppWebViewSettings.fromJson(const {});
       expect(defaults.webAuthenticationSupport, isNull);
     });
+
+    test('enum has exactly the three values the native sides know about', () {
+      // iOS/macOS enable passkeys when the wire value == 1 (FOR_APP) and
+      // Android passes the raw value through to WebSettingsCompat. Adding,
+      // removing, or reordering enum values without updating every native
+      // implementation would silently break passkey sign-in — fail loudly
+      // here instead.
+      expect(WebAuthenticationSupport.values.length, 3);
+      expect(WebAuthenticationSupport.values, [
+        WebAuthenticationSupport.NONE,
+        WebAuthenticationSupport.FOR_APP,
+        WebAuthenticationSupport.FOR_BROWSER,
+      ]);
+    });
   });
 }


### PR DESCRIPTION
Follow-up to #273 (issue #272) — hardening the WebAuthn/passkey wiring on **iOS** and **Android** so passkey sign-in is bulletproof.

## Why

PR #273 fixed the macOS no-op, but an audit of the iOS and Android wiring found four robustness gaps that could break or hide passkey failures:

| # | Platform | Gap | Risk |
|---|----------|-----|------|
| 1 | iOS + macOS | KVC `boundKeychainForPasskeys` write **and** read only checked the outer `webAuthenticationSupport` selector, not the inner key | `setValue/value(forKey:)` raise an **uncatchable `NSUnknownKeyException`** when the key is missing — app crash on an unexpected SDK state |
| 2 | iOS + macOS | Runtime `setSettings` change of `webAuthenticationSupport` was a **silent** no-op (config immutable after init) | Developers change the setting later and passkeys silently stay off — the exact class of confusion that produced #272 |
| 3 | Android | Setting requested but `WebViewFeature.WEB_AUTHENTICATION` unsupported — **silently dropped** | Same silent no-op class as #272 on macOS; no way to discover why passkeys do not work |
| 4 | Android | Read-back `WebSettingsCompat.getWebAuthenticationSupport` was **completely unguarded** (set path caught `ClassCastException`, get path caught nothing) | OEM WebView wrapper incompatibility crashes `getSettings()` |

## Changes

### iOS (`zikzak_inappwebview_ios`)
- `InAppWebView.swift` — the KVC write in `preWKWebViewConfiguration` now also checks `webAuthSupport.responds(to: Selector(("boundKeychainForPasskeys")))` before `setValue`, making the passkey enablement crash-proof.
- `InAppWebView.swift` — `setSettings` logs a warning when `webAuthenticationSupport` changes at runtime (creation-time only, `WKWebViewConfiguration` is immutable after init).
- `InAppWebViewSettings.swift` — the `getRealSettings` read-back gets the same inner-key guard (`value(forKey:)` on a missing key also throws).

### macOS (`zikzak_inappwebview_macos`)
- Parity hardening of the code landed in #273: same inner-key guards in `InAppWebView.swift` (init) and `InAppWebViewSettings.swift` (read-back), plus the same `setSettings` runtime-change warning.

### Android (`zikzak_inappwebview_android`)
- `InAppWebView.java` — init and `setSettings` paths now **log a warning** when a non-`NONE` value was requested but the installed WebView does not support `WebViewFeature.WEB_AUTHENTICATION` (previously silently dropped — the exact failure mode #272 reported on macOS). Message tells the developer to update the Android System WebView component.
- `InAppWebView.java` — the compat-call catch is broadened from `ClassCastException` to `RuntimeException` (OEM WebView wrappers must never crash the app over a best-effort settings application).
- `InAppWebViewSettings.java` — the `getRealSettings` read-back is wrapped in try/catch; on failure the key is omitted so the Dart side parses `null` (= unsupported). Added the missing `android.util.Log` import.

### Platform interface (`zikzak_inappwebview_platform_interface`)
- Documented the runtime semantics on the setting: creation-time only on iOS/macOS; `getSettings()` returns `null` on Android when the WebView lacks `WEB_AUTHENTICATION` support; WebAuthn ceremonies require a user gesture.
- New wire-contract test pins `WebAuthenticationSupport` to exactly `NONE`/`FOR_APP`/`FOR_BROWSER` — adding, removing or reordering values now fails loudly instead of silently breaking every native `== 1` check.

## Verification

- `dart analyze` (platform_interface): **0 errors** (941 pre-existing info-level lints, identical to baseline).
- `flutter test` (platform_interface): **156/156 passed** (155 baseline + 1 new).
- iOS/macOS verified coverage of **all** WebView creation paths (platform view, headless via `FlutterWebViewController`, `InAppBrowser`, popups inherit opener config) — all go through `preWKWebViewConfiguration` or share the opener's config.
- Swift/Java changes are guards, logs and catch-broadening around the existing, proven call sites (no Swift/Java toolchain on the Linux CI box — same caveat as #273).

## Host-app requirements (unchanged, documented in #273)

For app-bound passkeys the host app still needs the `webcredentials:` Associated Domains entitlement and the site must serve a valid `apple-app-site-association`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAuthn and passkey compatibility across Android, iOS, and macOS.
  * Prevented crashes when passkey configuration properties are unavailable.
  * Added safer handling for unsupported or incompatible WebView settings.
  * Clarified that certain authentication settings can only be configured when creating a web view; later changes now produce a warning.

* **Documentation**
  * Documented platform-specific read-back behavior and user-gesture requirements.

* **Tests**
  * Added coverage ensuring WebAuthn support enum values remain stable across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->