### PR TITLE
fix(macos): restore headless run() Dart test + make run() re-runnable after dispose

### DIFF
--- a/zikzak_inappwebview/example/lib/headless_in_app_webview.screen.dart
+++ b/zikzak_inappwebview/example/lib/headless_in_app_webview.screen.dart
@@ -81,7 +81,7 @@ class _HeadlessInAppWebViewExampleScreenState
             Center(
               child: ElevatedButton(
                 onPressed: () async {
-                  await headlessWebView?.dispose();
+                  // Run (or re-run after a dispose — run() starts fresh).
                   await headlessWebView?.run();
                 },
                 child: const Text("Run HeadlessInAppWebView"),

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -253,9 +253,17 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
   }
 
   Future<void> run() async {
-    if (_started || _disposed) {
+    if (_started && !_disposed) {
+      // Already running — no-op (matches the pre-existing guard).
       return;
     }
+    if (_disposed) {
+      // Re-run after dispose(): wait for any in-flight run to finish its
+      // deferred native teardown, then start fresh. dispose() is terminal
+      // for the PREVIOUS run, not for the webview itself.
+      await _runCompleter?.future;
+    }
+    _disposed = false;
     _started = true;
     _init();
 

--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -257,53 +257,57 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
       // Already running — no-op (matches the pre-existing guard).
       return;
     }
-    if (_disposed) {
-      // Re-run after dispose(): wait for any in-flight run to finish its
-      // deferred native teardown, then start fresh. dispose() is terminal
-      // for the PREVIOUS run, not for the webview itself.
-      await _runCompleter?.future;
-    }
-    _disposed = false;
-    _started = true;
-    _init();
-
-    var initialSettings = params.initialSettings ?? InAppWebViewSettings();
-    initialSettings = _inferInitialSettings(initialSettings);
-
-    Map<String, dynamic> settingsMap =
-        (params.initialSettings != null ? initialSettings.toJson() : null) ??
-        initialSettings.toJson();
-
-    Map<String, dynamic> pullToRefreshSettings = PullToRefreshSettings(
-      enabled: false,
-    ).toJson();
-
-    Map<String, dynamic> findInteractionSettings =
-        _macosParams.findInteractionController?.onFindResultReceived != null
-        ? {}
-        : {};
-
-    Map<String, dynamic> args = <String, dynamic>{};
-    args.putIfAbsent('id', () => id);
-    args.putIfAbsent(
-      'params',
-      () => <String, dynamic>{
-        'initialUrlRequest': params.initialUrlRequest?.toJson(),
-        'initialFile': params.initialFile,
-        'initialData': params.initialData?.toJson(),
-        'initialSettings': settingsMap,
-        'contextMenu': params.contextMenu?.toJson() ?? {},
-        'windowId': params.windowId,
-        'initialUserScripts':
-            params.initialUserScripts?.map((e) => e.toJson()).toList() ?? [],
-        'pullToRefreshSettings': pullToRefreshSettings,
-        'findInteractionSettings': findInteractionSettings,
-        'initialSize': params.initialSize.toJson(),
-      },
-    );
+    // Capture any in-flight run's completer before claiming the restart slot.
+    final previousRunCompleter = _runCompleter;
+    // Claim the restart slot synchronously before any await to prevent
+    // concurrent run() calls from both entering _init().
     final runCompleter = Completer<void>();
     _runCompleter = runCompleter;
     try {
+      if (_disposed) {
+        // Re-run after dispose(): wait for any in-flight run to finish its
+        // deferred native teardown, then start fresh. dispose() is terminal
+        // for the PREVIOUS run, not for the webview itself.
+        await previousRunCompleter?.future;
+      }
+      _disposed = false;
+      _started = true;
+      _init();
+
+      var initialSettings = params.initialSettings ?? InAppWebViewSettings();
+      initialSettings = _inferInitialSettings(initialSettings);
+
+      Map<String, dynamic> settingsMap =
+          (params.initialSettings != null ? initialSettings.toJson() : null) ??
+          initialSettings.toJson();
+
+      Map<String, dynamic> pullToRefreshSettings = PullToRefreshSettings(
+        enabled: false,
+      ).toJson();
+
+      Map<String, dynamic> findInteractionSettings =
+          _macosParams.findInteractionController?.onFindResultReceived != null
+          ? {}
+          : {};
+
+      Map<String, dynamic> args = <String, dynamic>{};
+      args.putIfAbsent('id', () => id);
+      args.putIfAbsent(
+        'params',
+        () => <String, dynamic>{
+          'initialUrlRequest': params.initialUrlRequest?.toJson(),
+          'initialFile': params.initialFile,
+          'initialData': params.initialData?.toJson(),
+          'initialSettings': settingsMap,
+          'contextMenu': params.contextMenu?.toJson() ?? {},
+          'windowId': params.windowId,
+          'initialUserScripts':
+              params.initialUserScripts?.map((e) => e.toJson()).toList() ?? [],
+          'pullToRefreshSettings': pullToRefreshSettings,
+          'findInteractionSettings': findInteractionSettings,
+          'initialSize': params.initialSize.toJson(),
+        },
+      );
       await _sharedChannel.invokeMethod('run', args);
       _running = true;
       if (_disposed) {
@@ -399,7 +403,18 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
       await _runCompleter?.future;
       return;
     }
-    await _disposeNative();
+    // Direct disposal path: create, assign, and complete _runCompleter so
+    // that a subsequent run() can await teardown and prevent channel corruption.
+    final disposeCompleter = Completer<void>();
+    _runCompleter = disposeCompleter;
+    try {
+      await _disposeNative();
+    } finally {
+      disposeCompleter.complete();
+      if (identical(_runCompleter, disposeCompleter)) {
+        _runCompleter = null;
+      }
+    }
   }
 
   Future<void> _disposeNative() async {

--- a/zikzak_inappwebview_macos/test/headless_repro_test.dart
+++ b/zikzak_inappwebview_macos/test/headless_repro_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+import 'package:zikzak_inappwebview_macos/src/in_app_webview/headless_in_app_webview.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('headless run() sends valid args without throwing', () async {
+    final headless = MacOSHeadlessInAppWebView(
+      PlatformHeadlessInAppWebViewCreationParams(
+        initialUrlRequest: URLRequest(url: WebUri('https://flutter.dev')),
+        initialSettings: InAppWebViewSettings(isInspectable: true),
+        onWebViewCreated: (controller) {
+          print('HEADLESS onWebViewCreated FIRED');
+        },
+      ),
+    );
+
+    final sharedChannel = const MethodChannel(
+      'wtf.zikzak/flutter_headless_inappwebview',
+    );
+    Map<String, dynamic>? capturedArgs;
+    final calls = <String>[];
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(sharedChannel, (call) async {
+      calls.add(call.method);
+      if (call.method == 'run') {
+        capturedArgs = (call.arguments as Map).cast<String, dynamic>();
+      }
+      return true;
+    });
+
+    try {
+      await headless.run().timeout(const Duration(seconds: 5));
+      print('RUN COMPLETED OK');
+    } catch (e, st) {
+      print('RUN THREW: $e');
+      print(st);
+      fail('run() threw: $e');
+    }
+
+    print('CHANNEL CALLS: $calls');
+    final params = (capturedArgs?['params'] as Map?)?.cast<String, dynamic>();
+    print('initialUrlRequest: ${params?['initialUrlRequest']}');
+    print('initialSettings: ${params?['initialSettings']}');
+    print('initialSize: ${params?['initialSize']}');
+    expect(params, isNotNull);
+  });
+}

--- a/zikzak_inappwebview_macos/test/headless_repro_test.dart
+++ b/zikzak_inappwebview_macos/test/headless_repro_test.dart
@@ -46,5 +46,10 @@ void main() {
     print('initialSettings: ${params?['initialSettings']}');
     print('initialSize: ${params?['initialSize']}');
     expect(params, isNotNull);
+    expect(params?['initialUrlRequest'], isA<Map>());
+    expect((params?['initialUrlRequest'] as Map?)?.cast<String, dynamic>()?['url'], equals('https://flutter.dev'));
+    expect(params?['initialSettings'], isA<Map>());
+    expect((params?['initialSettings'] as Map?)?.cast<String, dynamic>()?['isInspectable'], equals(true));
+    expect(params?['initialSize'], isA<Map>());
   });
 }

--- a/zikzak_inappwebview_platform_interface/test/color_serialization_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/color_serialization_test.dart
@@ -10,6 +10,7 @@ void main() {
       );
       final json = settings.toJson();
       expect(json['verticalScrollbarThumbColor'], isA<String>());
+      expect(json['verticalScrollbarThumbColor'], equals('#fff44336'));
     });
 
     test('Color_ round-trips through toJson/fromJson', () {
@@ -18,8 +19,10 @@ void main() {
       );
       final json = settings.toJson();
       expect(json['verticalScrollbarThumbColor'], isA<String>());
+      expect(json['verticalScrollbarThumbColor'], equals('#fff44336'));
       final restored = InAppWebViewSettings.fromJson(json);
       expect(restored.verticalScrollbarThumbColor, isNotNull);
+      expect(restored.verticalScrollbarThumbColor?.value, equals(Colors.red.value));
     });
   });
 }

--- a/zikzak_inappwebview_platform_interface/test/color_serialization_test.dart
+++ b/zikzak_inappwebview_platform_interface/test/color_serialization_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+void main() {
+  group('Color serialization', () {
+    test('plain Color does not crash toJson', () {
+      final settings = InAppWebViewSettings(
+        verticalScrollbarThumbColor: Colors.red,
+      );
+      final json = settings.toJson();
+      expect(json['verticalScrollbarThumbColor'], isA<String>());
+    });
+
+    test('Color_ round-trips through toJson/fromJson', () {
+      final settings = InAppWebViewSettings(
+        verticalScrollbarThumbColor: Color_(Colors.red.value),
+      );
+      final json = settings.toJson();
+      expect(json['verticalScrollbarThumbColor'], isA<String>());
+      final restored = InAppWebViewSettings.fromJson(json);
+      expect(restored.verticalScrollbarThumbColor, isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
PR #230 was squash-merged before its post-merge follow-ups landed, so `master` lost them. This PR brings those follow-ups into `master`:

- **kimi review finding for #230** — restores `zikzak_inappwebview_macos/test/headless_repro_test.dart`, the only Dart-side coverage for `MacOSHeadlessInAppWebView.run()` (method-channel args + non-throwing contract).
- Adds `zikzak_inappwebview_platform_interface/test/color_serialization_test.dart` (plain `Color` `toJson` does not crash).
- `headless_in_app_webview.dart`: `run()` now resets the `disposed`/`started` state and starts fresh after a `dispose()` — `dispose()` is terminal only for the *previous* run, so a headless webview is re-runnable.
- `example`: the Run button calls `run()` (previously `dispose(); run();`, which permanently no-op'd because `run()` guarded on `_disposed`).

Excluded from this PR (already in `master` via #269): the scroll/content-size event handling in `in_app_webview_controller.dart`.

## Verification
- `zikzak_inappwebview_macos`: 42/42 tests pass (incl. `headless_repro_test.dart`).
- `zikzak_inappwebview_platform_interface`: `color_serialization_test.dart` 2/2 pass.
- `flutter analyze` clean on both changed files.

Generated with Kimi Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Headless web views can now be restarted after being disposed.
  * Running a headless web view starts a fresh session without requiring manual disposal first.
  * Improved reliability when starting headless web views.

* **Tests**
  * Added coverage for restarting disposed headless web views.
  * Added tests confirming scrollbar color settings serialize and restore correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->