### PR TITLE
fix: address review comments on #232

### DIFF
--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/content_blocker_trigger_load_context.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/content_blocker_trigger_load_context.dart
@@ -1,4 +1,3 @@
-
 import '../../../content_blocker.dart';
 
 
@@ -14,7 +13,6 @@ enum ContentBlockerTriggerLoadContext {
 ///ContentBlockerTriggerLoadContext wire values are the content-blocker strings ('top-frame', 'child-frame'),
 ///which differ from the member names — lookup by value.
 
-///ContentBlockerTriggerLoadContext wire values are the content-blocker strings (top-frame, child-frame) — lookup by value.
 const _contentBlockerTriggerLoadContext_wire = ['top-frame', 'child-frame'];
 
 ContentBlockerTriggerLoadContext? contentBlockerTriggerLoadContextFromWire(String? value) {

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/website_data_type.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/enums/website_data_type.dart
@@ -1,5 +1,3 @@
-
-
 ///Class that represents a website data type.
 enum WebsiteDataType {
   ///On-disk Fetch caches.


### PR DESCRIPTION
## Summary

This PR applies the two cosmetic CodeRabbit review nitpicks on #232. No functional code or test assertions were changed — only whitespace/doc-comment cleanup.

## Changes

### FIXED 1 — `content_blocker_trigger_load_context.dart`
- **Lines 1 & 16-17**: Removed the stray leading blank line (line 1) and the duplicated/near-identical doc comment above the `_contentBlockerTriggerLoadContext_wire` constant (lines 16-17). Kept the correct doc comment (lines 14-15) which quotes the actual wire values (`'top-frame'`, `'child-frame'`). The constant value and all code are unchanged.

### FIXED 2 — `website_data_type.dart`
- **Lines 1-2**: Removed the two stray leading blank lines so the file now starts cleanly with the `///Class that represents a website data type.` doc comment on line 1. All content below is unchanged.

## Verification
- `git diff` shows only the intended whitespace/doc removals (2 files, 4 deletions, 0 additions).
- `dart analyze` on both files reports no new warnings/errors; the only findings are pre-existing `constant_identifier_names` info-level lints on intentionally platform-named enum members, unrelated to this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that content blocker context values are wire-format strings used for lookup and may differ from enum member names.

* **Maintenance**
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->