### PR TITLE
fix: address review comments on #274

### DIFF
--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -1153,7 +1153,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         // so a runtime change is a no-op. Surface it instead of silently
         // dropping it (issue #272).
         if newSettingsMap["webAuthenticationSupport"] != nil
-            && settings?.webAuthenticationSupport != newSettings.webAuthenticationSupport
+            && settings != nil && settings!.webAuthenticationSupport != newSettings.webAuthenticationSupport
         {
             print(
                 "webAuthenticationSupport cannot be changed after the WebView has been created (WKWebViewConfiguration is immutable); ignoring the new value"

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -1665,7 +1665,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         // so a runtime change is a no-op. Surface it instead of silently
         // dropping it (issue #272).
         if newSettingsMap["webAuthenticationSupport"] != nil
-            && settings?.webAuthenticationSupport != newSettings.webAuthenticationSupport
+            && settings != nil && settings!.webAuthenticationSupport != newSettings.webAuthenticationSupport
         {
             print(
                 "webAuthenticationSupport cannot be changed after the WebView has been created (WKWebViewConfiguration is immutable); ignoring the new value"


### PR DESCRIPTION
## CodeRabbit Autofix — PR #274

This PR applies the autofix-style changes requested in the review of #274.

### Threads

- **FIXED** — 🎯 Functional Correctness (macOS `InAppWebView.swift` ~L1667)
  Spurious creation-time warning for `webAuthenticationSupport`. At creation, `settings` is still `nil`, so `settings?.webAuthenticationSupport` evaluated to `nil`, and `nil != newSettings.webAuthenticationSupport` was **always true** whenever a developer set `webAuthenticationSupport`. That emitted a false "cannot be changed … ignoring the new value" warning even though the value was applied and passkeys worked.
  Fix: require `settings` to be non-nil before comparing:
  `&& settings != nil && settings!.webAuthenticationSupport != newSettings.webAuthenticationSupport`

- **FIXED** — 🎯 Functional Correctness (iOS `InAppWebView.swift` ~L1155)
  Identical `settings?.webAuthenticationSupport != newSettings.webAuthenticationSupport` guard with the same spurious creation-time behavior. Applied the same fix.

- **SKIPPED** — iOS `InAppBrowserWebViewController.swift` ~L523
  No `webAuthenticationSupport` guard exists in this file. It only contains unrelated `webView?.settings?.contentBlockers` / `allowingReadAccessTo` accesses, which are not the creation-time-warning pattern. No change needed.

- **SKIPPED** — macOS `InAppBrowserWebViewController.swift` ~L523
  No `webAuthenticationSupport` reference at all. No change needed.

### Verification
- `git diff --stat`: 2 files changed, 2 insertions(+), 2 deletions(-).
- Swift cannot be compiled in this environment; edits are syntactically consistent with the surrounding code and the force-unwrap is guarded by the preceding `settings != nil` check.
