### PR TITLE
fix: address review comments on #278

### DIFF
--- a/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
+++ b/zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart
@@ -277,9 +277,7 @@ class MacOSHeadlessInAppWebView extends PlatformHeadlessInAppWebView
       var initialSettings = params.initialSettings ?? InAppWebViewSettings();
       initialSettings = _inferInitialSettings(initialSettings);
 
-      Map<String, dynamic> settingsMap =
-          (params.initialSettings != null ? initialSettings.toJson() : null) ??
-          initialSettings.toJson();
+      Map<String, dynamic> settingsMap = initialSettings.toJson();
 
       Map<String, dynamic> pullToRefreshSettings = PullToRefreshSettings(
         enabled: false,

--- a/zikzak_inappwebview_macos/test/headless_repro_test.dart
+++ b/zikzak_inappwebview_macos/test/headless_repro_test.dart
@@ -51,5 +51,28 @@ void main() {
     expect(params?['initialSettings'], isA<Map>());
     expect((params?['initialSettings'] as Map?)?.cast<String, dynamic>()?['isInspectable'], equals(true));
     expect(params?['initialSize'], isA<Map>());
+
+    // Phase 2 — headline feature: run() must be re-callable after dispose().
+    try {
+      await headless.dispose().timeout(const Duration(seconds: 5));
+      print('DISPOSE COMPLETED OK');
+    } catch (e, st) {
+      print('DISPOSE THREW: $e');
+      print(st);
+      fail('dispose() threw: $e');
+    }
+
+    try {
+      await headless.run().timeout(const Duration(seconds: 5));
+      print('RE-RUN COMPLETED OK');
+    } catch (e, st) {
+      print('RE-RUN THREW: $e');
+      print(st);
+      fail('run() after dispose() threw: $e');
+    }
+
+    print('CHANNEL CALLS: $calls');
+    expect(calls.where((c) => c == 'run').length, greaterThanOrEqualTo(2),
+        reason: 'run() must have been invoked again after dispose()');
   });
 }


### PR DESCRIPTION
## CodeRabbit autofix for PR #278 (`fix/headless-macos-run-followups`)

This PR applies the review-fixup changes requested on PR #278, targeting the
original head branch `fix/headless-macos-run-followups`.

### Threads addressed

- **FIX A — 🧪 Tests (headless_repro_test re-runnability coverage): FIXED**
  - File: `zikzak_inappwebview_macos/test/headless_repro_test.dart`
  - The test previously only exercised the first `run()` and never called
    `dispose()` first, so the headline re-runnability feature (`run()` after
    `dispose()`) had no coverage.
  - Added a second phase that disposes the headless webview via
    `headless.dispose()`, then calls `headless.run()` again, and asserts the
    re-run succeeds and invokes the `run` channel method a second time
    (`calls.where((c) => c == 'run').length >= 2`).

- **FIX B — 📐 Maintainability (redundant null-coalescing): FIXED**
  - File: `zikzak_inappwebview_macos/lib/src/in_app_webview/headless_in_app_webview.dart`
  - Lines 280-282:
    `Map<String, dynamic> settingsMap = (params.initialSettings != null ? initialSettings.toJson() : null) ?? initialSettings.toJson();`
  - Both branches of the ternary and the `??` fallback all evaluate to
    `initialSettings.toJson()`, so the expression always equals that. Simplified
    to:
    `Map<String, dynamic> settingsMap = initialSettings.toJson();`
  - Behavior unchanged.

### Verification

- `flutter analyze` on the edited source reports **No issues found!**.
- The edited test file has no new analysis issues (two pre-existing
  `invalid_null_aware_operator` warnings on lines 50/52 were already present and
  untouched).
- `git diff --stat` shows only the two intended files.

### Notes

- `pubspec.lock` was regenerated locally by `flutter pub get` during analysis
  (mirror URL / transitive version bumps); it was restored to its original state
  and is **not** part of this commit.
