### PR TITLE
fix: address review comments on #270

### DIFF
--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -859,7 +859,13 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     let hasValidPersistentId = settings.persistentStoreIdentifier.map {
                         persistentUUID(from: $0) != nil
                     } ?? false
-                    if !dataStoreWasSelected && !hasValidPersistentId {
+                    // A persistent store can only be honored on iOS 17+ (the
+                    // `forIdentifier:` selector is unavailable below it). On
+                    // older iOS, `hasValidPersistentId` is meaningless for the
+                    // data store, so skip the short-circuit and fall through to
+                    // the master behavior (nonPersistent) when cacheEnabled is
+                    // false — otherwise per-account isolation is silently lost.
+                    if !dataStoreWasSelected && (!hasValidPersistentId || !#available(iOS 17.0, *)) {
                         configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                     }
                     for cookie in HTTPCookieStorage.shared.cookies ?? [] {

--- a/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart
+++ b/zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart
@@ -93,7 +93,7 @@ class LinuxInAppWebViewController extends PlatformInAppWebViewController {
       case 'onReceivedHttpError':
         if (params.webviewParams?.onReceivedHttpError != null) {
           String? url = call.arguments['url'];
-          int statusCode = call.arguments['statusCode'];
+          int statusCode = call.arguments['statusCode'] ?? 0;
           String? description = call.arguments['description'];
           params.webviewParams!.onReceivedHttpError!(
             controller,


### PR DESCRIPTION
## CodeRabbit autofix for #270

This PR applies the safe, minimal review fixes from PR #270 to the head branch
`456-gi-267-platform-parity-hardening-pub-7484`. All edits preserve the
original intent and repo style.

### FIXED

- **[MINOR 1 · 🎯 Functional · Linux]** `zikzak_inappwebview_linux/lib/src/in_app_webview/in_app_webview_controller.dart:96`
  - The `onReceivedHttpError` handler read `int statusCode = call.arguments['statusCode'];`.
    `call.arguments` is an untyped map, so the value is `dynamic`/`int?` while
    `WebResourceResponse.statusCode` is nullable. When the field is missing/null,
    the implicit downcast throws a `TypeError` that was silently swallowed by the
    surrounding `debugPrint` error wrapper, dropping the callback entirely.
  - Fix: `int statusCode = call.arguments['statusCode'] ?? 0;` — matches the
    sibling handlers (`onScrollChanged`, `onOverScrolled`, etc.) which already
    default positional ints to `0`.

- **[MINOR 2 · 🎯 Functional · iOS]** `zikzak_inappwebview_ios/.../InAppWebView/InAppWebView.swift:859-864`
  - The `hasValidPersistentId` short-circuit suppressed the `nonPersistent()`
    fallback on iOS < 17 whenever a valid `persistentStoreIdentifier` was set.
    But `WKWebsiteDataStore(forIdentifier:)` is unavailable below iOS 17, so the
    persistent branch never fired there — `dataStoreWasSelected` stayed `false`
    and the user got the shared default store instead of the master behavior
    (ephemeral for `cacheEnabled=false`), silently defeating per-account
    isolation on iOS 14–16.
  - Fix: gate the short-circuit behind `#available(iOS 17.0, *)`:
    `if !dataStoreWasSelected && (!hasValidPersistentId || !#available(iOS 17.0, *))`.
    On iOS 17+ behavior is unchanged; on iOS < 17 the fallback now runs as on
    `master`.

### SKIPPED (with reasons)

- **[NITPICK · dead `if (challenge == null) break;`]** `in_app_webview_controller.dart:254,266,276`
  - Inspected and **not** dead: `challenge` is assigned directly from
    `HttpAuthenticationChallenge.fromJson` / `ServerTrustChallenge.fromJson` /
    `ClientCertChallenge.fromJson`, all of which return **nullable** types
    (confirmed in `zikzak_inappwebview_platform_interface`). The guards are live
    null-safety, so they were kept.

- **[NITPICK · `getSettings()` / `printCurrentPage` always-null stubs]**
  - Left as-is. The Linux `getSettings()` returns `null` because
    `InAppWebViewSettings` has no `fromMap` on the native side (documented in the
    code). No trivial, safe improvement exists without native-side work —
    recommend as a follow-up, not an autofix.

- **[RECOMMENDATION · ~1,100-line untested Linux controller]**
  - No new test suite added per instructions. Recommend adding unit coverage for
    `handleMethod` (esp. `onReceivedHttpError` null-guard) as a follow-up.

### Verification

- `git diff --stat`: 2 files changed, 8 insertions(+), 2 deletions(-).
- `dart analyze` on the edited Linux file reports only pre-existing
  `override_on_non_overing_member` warnings (lines 1291+, untouched). No new
  errors from the `?? 0` edit.
- Swift changes are compile-plausible (availability condition used as a boolean
  operand); full Xcode build not run in this environment.
