### PR TITLE
fix: address review comments on #271

### DIFF
--- a/zikzak_inappwebview_module/lib/src/services/capture_service.dart
+++ b/zikzak_inappwebview_module/lib/src/services/capture_service.dart
@@ -22,7 +22,9 @@ class CaptureService implements CaptureSource {
       throw StateError('Capture already active for session $sessionId');
     }
     _active[sessionId] = true;
-    _budgets[sessionId] = config.maxEvents;
+    // Encode "unlimited" (maxEvents == 0) as -1 so a zero budget can be
+    // distinguished from an exhausted budget at injection time.
+    _budgets[sessionId] = config.maxEvents > 0 ? config.maxEvents : -1;
     final controller = StreamController<CaptureEvent>.broadcast();
     _controllers[sessionId] = controller;
     return controller.stream;
@@ -51,10 +53,14 @@ class CaptureService implements CaptureSource {
   bool injectEvent(String sessionId, CaptureEvent event) {
     if (_active[sessionId] != true) return false;
     final budget = _budgets[sessionId] ?? 0;
-    if (budget <= 0 && budget != 0) return false; // 0 means unlimited
-    if (budget > 0) {
-      _budgets[sessionId] = budget - 1;
+    // Negative budget means "unlimited" (maxEvents == 0): always emit.
+    if (budget < 0) {
+      _controllers[sessionId]?.add(event);
+      return true;
     }
+    // Bounded budget: stop emitting once exhausted so maxEvents is enforced.
+    if (budget <= 0) return false;
+    _budgets[sessionId] = budget - 1;
     _controllers[sessionId]?.add(event);
     return true;
   }

--- a/zikzak_inappwebview_module/lib/src/services/webview_pool.dart
+++ b/zikzak_inappwebview_module/lib/src/services/webview_pool.dart
@@ -78,7 +78,10 @@ class WebViewPool implements WebViewSessionFactory {
   // Generic idle sessions (no domain affinity)
   final List<PoolSession> _genericIdle = [];
 
-  // Mutex for thread-safe operations
+  // Serializes critical sections (acquire/release/disposeAll) so concurrent
+  // callers cannot observe an inconsistent pool state or exceed
+  // maxLiveInstances. Each caller waits on the previous one's completion.
+  Future<void> _lock = Future.value();
 
   // TTL eviction timer
   Timer? _evictionTimer;
@@ -124,6 +127,9 @@ class WebViewPool implements WebViewSessionFactory {
       session ??= await _createSession(sessionId, domainHint, etld, settings);
 
       // 5. Register as active
+      // Reused idle sessions retain a stale releasedAt (set on release),
+      // which would make isActive report false for a live, reused session.
+      session.releasedAt = null;
       _active[sessionId] = session;
       return session;
     });
@@ -204,9 +210,19 @@ class WebViewPool implements WebViewSessionFactory {
   // --- Private ---
 
   Future<T> _synchronized<T>(Future<T> Function() fn) async {
-    // Dart is single-threaded for sync code; async gaps are the concern.
-    // We use a simple lock object for logical synchronization.
-    return fn();
+    // Serialize critical sections via a future-chain mutex: each caller
+    // appends its work after the previous caller finishes, so only one
+    // critical section runs at a time. This prevents concurrent acquire()
+    // calls from exceeding maxLiveInstances.
+    final previous = _lock;
+    final completer = Completer<void>();
+    _lock = completer.future;
+    try {
+      await previous;
+      return await fn();
+    } finally {
+      completer.complete();
+    }
   }
 
   Future<PoolSession> _createSession(
@@ -266,7 +282,7 @@ class WebViewPool implements WebViewSessionFactory {
       entries.removeWhere((s) {
         final expired = s.releasedAt != null && s.releasedAt!.isBefore(cutoff);
         if (expired) {
-          s.webview.dispose();
+          unawaited(s.webview.dispose());
         }
         return expired;
       });
@@ -276,7 +292,7 @@ class WebViewPool implements WebViewSessionFactory {
     _genericIdle.removeWhere((s) {
       final expired = s.releasedAt != null && s.releasedAt!.isBefore(cutoff);
       if (expired) {
-        s.webview.dispose();
+        unawaited(s.webview.dispose());
       }
       return expired;
     });
@@ -297,13 +313,13 @@ class WebViewPool implements WebViewSessionFactory {
     // Active sessions remain intact.
     for (final entries in _idle.values) {
       for (final session in entries) {
-        session.webview.dispose();
+        unawaited(session.webview.dispose());
       }
     }
     _idle.clear();
 
     for (final session in _genericIdle) {
-      session.webview.dispose();
+      unawaited(session.webview.dispose());
     }
     _genericIdle.clear();
   }

--- a/zikzak_inappwebview_module/lib/src/vcr/cassette_engine_impl.dart
+++ b/zikzak_inappwebview_module/lib/src/vcr/cassette_engine_impl.dart
@@ -47,13 +47,16 @@ class CassetteEngineImpl implements CassetteEngine {
 
   @override
   Future<Cassette> saveCassette() async {
-    final cassette = Cassette(
+    // Snapshot the entries before clearing: List.unmodifiable() is a LIVE
+    // VIEW over _recordedEntries, so clearing the source afterwards would
+    // empty the returned cassette and silently lose every recording.
+    final entries = List<CassetteEntry>.from(_recordedEntries);
+    _recordedEntries.clear();
+    return Cassette(
       name: 'recording-${DateTime.now().millisecondsSinceEpoch}',
       recordedAt: DateTime.now(),
-      entries: List.unmodifiable(_recordedEntries),
+      entries: entries,
     );
-    _recordedEntries.clear();
-    return cassette;
   }
 
   /// Records a navigation entry.


### PR DESCRIPTION
## CodeRabbit autofix for PR #271

Branch `coderabbit-fixes/pr-271` (head `7739de33`) targeting `455-gi-264-wave-z-rewrite-zuraffa-v6-web-7584`.

### FIXED

**MAJOR 1 — `cassette_engine_impl.dart` (`CassetteEngineImpl.saveCassette`)**
- `List.unmodifiable(_recordedEntries)` is a **live view** over `_recordedEntries`. The old code returned it and then called `_recordedEntries.clear()`, which emptied the returned cassette and silently discarded every recording.
- Fix: snapshot the entries into a real list before clearing:
  `final entries = List<CassetteEntry>.from(_recordedEntries); _recordedEntries.clear(); return Cassette(..., entries: entries);`

**MAJOR 2 — `capture_service.dart` (`CaptureService.injectEvent`)**
- The guard `if (budget <= 0 && budget != 0) return false;` is **dead code** — `budget` only ever decrements from `maxEvents` toward `0` and never goes negative, so the `maxEvents` cap was never enforced and events were emitted unbounded once the budget hit 0.
- Fix: encode "unlimited" (`maxEvents == 0`) as `-1` in `start()` so it can be distinguished from an exhausted budget, then in `injectEvent` emit while `budget < 0` (unlimited) and `return false` once `budget <= 0` (exhausted). The cap is now actually enforced for bounded sessions while preserving the documented `0 = unlimited` behavior.

**MAJOR 3 — `webview_pool.dart` (`WebViewPool.acquire`)**
- When reusing an idle session (domain-affinity or generic idle), the session still carried the stale `releasedAt` set on `release()`, so `PoolSession.isActive` returned `false` for a live, reused session.
- Fix: reset `session.releasedAt = null` before registering the reused session as active. (`sessionId` and `acquiredAt` are `final` on `PoolSession`, so they cannot be mutated here; the pool map key already reflects the new `sessionId` in `sessions()`, and `acquiredAt` is a non-functional metadata field — reset via `releasedAt` is sufficient to fix `isActive`.)

**MINOR — `webview_pool.dart` (`WebViewPool._synchronized`)**
- The method was a **no-op** (`return fn();`) despite the docstring claiming thread-safe concurrent acquisition, so concurrent `acquire()` calls could observe inconsistent state and exceed `maxLiveInstances`.
- Fix: implemented a real async mutex via a future chain — each caller appends its critical section after the previous one completes (`_lock` future), guaranteeing only one critical section runs at a time.

**NITPICK — `webview_pool.dart` (unawaited `dispose()` futures)**
- In eviction/lifecycle code (`_evictExpired`, `_onLifecycleInactive`) `webview.dispose()` futures were fired off without `await` and without an explicit `unawaited(...)`, which trips the `unawaited_futures` analyzer hint.
- Fix: wrapped the four fire-and-forget `dispose()` calls in `unawaited(...)` (already imported via `dart:async`) to make the intent explicit. `disposeAll`/`_evictOldestIdle` already `await`, so they were left unchanged.

### SKIPPED

**NITPICK — `scripts/grep_gate.sh` (`continue 2` carve-out)**
- SKIPPED. The `continue 2` skips the *entire* pattern when the carve-out string `network_capture_interceptor_js` appears in *any* matched file, which could mask a real violation in a different matched file. A correct fix requires a per-file carve-out loop rather than the whole-pattern skip, and that rewrite risks breaking the legitimate carve-out for the raw capture-event plumbing file. Low priority and non-trivial; left as-is.

**NITPICK — `pubspec.lock` inconsistency with `pubspec.yaml`**
- SKIPPED (recommendation, not fixed). The reported `>=3.12.0` vs `>=3.6.0` SDK mismatch and missing `zuraffa` entry in `pubspec.lock` would require a full `dart pub get` to regenerate. That pulls potentially heavy transitive deps and could unexpectedly bump versions; per the autofix guidance we did not blindly regenerate it. Recommend a maintainer run `dart pub get` to refresh `pubspec.lock` deliberately.

### Verification
- `dart analyze` (via `flutter analyze`) on the three edited files: **No issues found.**
- `git diff --stat`: 3 files changed, 41 insertions, 16 deletions.
