### PR TITLE
fix(android): lower minSdkVersion to API 24 (closes #276)

### DIFF
--- a/zikzak_inappwebview/example/android/app/build.gradle.kts
+++ b/zikzak_inappwebview/example/android/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         applicationId = "com.example.example"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        minSdk = 24  // Android 7.0 (Nougat) - documented minimum (issue #276)
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/zikzak_inappwebview_android/android/build.gradle
+++ b/zikzak_inappwebview_android/android/build.gradle
@@ -38,7 +38,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 26  // Android 8.0 (Oreo) - v4.0 minimum for modern WebView features
+        minSdkVersion 24  // Android 7.0 (Nougat) - documented minimum (issue #276)
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         vectorDrawables.useSupportLibrary = true


### PR DESCRIPTION
## Summary

Lowers the Android `minSdkVersion` to **API 24 (Android 7.0 Nougat)** so the build configuration matches the documented minimum and resolves issue #276. The docs already state "Android API 24+", but `zikzak_inappwebview_android/android/build.gradle` actually set `minSdkVersion 26`, causing a confusing manifest-merger/build failure for consumers who followed the docs.

This supersedes the conflicting fork PR #277 by rebasing the same `minSdk = 24` change onto current `master`.

### Changes
- `zikzak_inappwebview_android/android/build.gradle`: `minSdkVersion 26` → `24`
- `zikzak_inappwebview/example/android/app/build.gradle.kts`: `minSdk = flutter.minSdkVersion` → `24`

### Notes
- Android only; iOS minimums are intentionally unchanged here.
- Newer-OS-only features remain guarded by existing `Build.VERSION.SDK_INT` / `@RequiresApi` checks already present on `master`, so dropping the floor to API 24 is safe from a build perspective.

Closes #276
