### PR TITLE
feat(022): gym — real exercises for zikzak_inappwebview (warmup + js-bridge-round-trip)

### DIFF
--- a/zikzak_inappwebview/.gym/.gitignore
+++ b/zikzak_inappwebview/.gym/.gitignore
@@ -1,0 +1,4 @@
+# Sandbox + drop-card stores used by the zikzak_inappwebview GYM
+# exercises. Wiped between runs; never committed.
+.sandbox/
+.drops/

--- a/zikzak_inappwebview/.gym/analysis_options.yaml
+++ b/zikzak_inappwebview/.gym/analysis_options.yaml
@@ -1,0 +1,9 @@
+# GYM scripts follow the issue-#397 `<id>-<name>.dart` rep format
+# (e.g. 01-deps.dart) and the `<id>_<name>_test.dart` exercise format —
+# they are standalone scripts/tests graded by the miki GYM runner, not
+# part of the plugin's compiled surface, so they live outside the
+# package's flutter_lints regime (mirrors how zuraffa excludes .gym/**
+# in its analysis_options.yaml).
+analyzer:
+  exclude:
+    - '**'

--- a/zikzak_inappwebview/.gym/exercises/js_bridge_round_trip_test.dart
+++ b/zikzak_inappwebview/.gym/exercises/js_bridge_round_trip_test.dart
@@ -1,0 +1,164 @@
+/// GYM exercise — JS bridge message round-trip (graded).
+///
+/// Brief (spec 022 / issue #397, US2-S3): the headless form of "boot a
+/// WebView and drive its JS bridge" — a genuine dev task, not a
+/// re-skinned unit test. The exercise:
+///
+///   1. BOOTS an [InAppWebViewController] on a faked platform (the
+///      repo's established platform-interface fake pattern — no device,
+///      no emulator, no network).
+///   2. REGISTERS a Dart-side JavaScript handler through the public
+///      `JavaScriptController` facade (`addJavaScriptHandler`).
+///   3. EVALUATES JS in the bridge: calls
+///      `window.zikzak_inappwebview.callHandler(...)` through
+///      `evaluateJavascript` — the real JS-side calling convention — and
+///      the fake platform dispatches it to the registered Dart handler
+///      exactly the way the native bridge does.
+///   4. ASSERTS the full message round-trip: the arguments cross the
+///      bridge unchanged, the handler's return value is JSON-encoded
+///      back to the JS caller, handler presence is queryable
+///      (`hasJavaScriptHandler`), and the platform recorded exactly the
+///      sources that were sent.
+///
+/// `flutter test` is the grader (FR-007: exit 0 = pass). A failure is a
+/// clean, named assertion; an unexpected outcome is a mis-fire — DROP
+/// CARD convention: github.com/arrrrny/drop-card.
+///
+/// verifyCommand:
+/// `flutter test .gym/exercises/js_bridge_round_trip_test.dart`
+/// evaluate: exit 0 => pass; exit !=0 => fail
+library;
+
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+/// Platform fake that simulates the native bridge: handler registration
+/// is recorded, and a `window.zikzak_inappwebview.callHandler(...)`
+/// evaluation is dispatched to the registered Dart handler with its
+/// JSON-decoded arguments — the same dispatch the Android/iOS
+/// implementations perform when JS calls the handler. The handler's
+/// return value is JSON-encoded back, mirroring the Promise resolution
+/// the JS caller awaits.
+class _FakePlatformController extends PlatformInAppWebViewController {
+  _FakePlatformController()
+      : super.implementation(
+          const PlatformInAppWebViewControllerCreationParams(
+            id: 'gym-exercise-webview',
+          ),
+        );
+
+  final Map<String, JavaScriptHandlerCallback> _handlers =
+      <String, JavaScriptHandlerCallback>{};
+  final List<String> evaluatedSources = <String>[];
+
+  @override
+  void addJavaScriptHandler({
+    required String handlerName,
+    required JavaScriptHandlerCallback callback,
+  }) {
+    _handlers[handlerName] = callback;
+  }
+
+  @override
+  bool hasJavaScriptHandler({required String handlerName}) =>
+      _handlers.containsKey(handlerName);
+
+  @override
+  JavaScriptHandlerCallback? removeJavaScriptHandler({
+    required String handlerName,
+  }) =>
+      _handlers.remove(handlerName);
+
+  @override
+  Future<dynamic> evaluateJavascript({
+    required String source,
+    ContentWorld? contentWorld,
+  }) async {
+    evaluatedSources.add(source);
+    final match = RegExp(
+      r"callHandler\('([^']+)',\s*(.*)\)",
+    ).firstMatch(source);
+    if (match == null) {
+      return 'ok:$source';
+    }
+    final handlerName = match.group(1)!;
+    final args = jsonDecode(match.group(2)!) as List<dynamic>;
+    final handler = _handlers[handlerName];
+    if (handler == null) {
+      return null;
+    }
+    final response = await handler(args);
+    return jsonEncode(response);
+  }
+}
+
+void main() {
+  test(
+    'js-bridge-round-trip: boot the controller, register a handler, and '
+    'round-trip a message through the bridge',
+    () async {
+      // 1. Boot the controller stack on the faked platform.
+      final platform = _FakePlatformController();
+      final controller = InAppWebViewController.fromPlatform(
+        platform: platform,
+      );
+
+      // 2. Register the Dart-side handler through the public facade.
+      final receivedArgs = <dynamic>[];
+      controller.javaScript.addJavaScriptHandler(
+        handlerName: 'gymBridge',
+        callback: (arguments) {
+          receivedArgs.addAll(arguments);
+          return <String, dynamic>{'pong': arguments.first};
+        },
+      );
+      expect(
+        controller.javaScript.hasJavaScriptHandler(handlerName: 'gymBridge'),
+        isTrue,
+        reason: 'a handler registered through the public facade must be '
+            'queryable through the same facade',
+      );
+
+      // 3. Evaluate JS in the bridge: the real JS-side calling
+      //    convention, dispatched by the (faked) native bridge.
+      final result = await controller.javaScript.evaluateJavascript(
+        source: 'window.zikzak_inappwebview.callHandler('
+            "'gymBridge', [\"ping\", 42])",
+      );
+
+      // 4. The full round-trip is proven.
+      expect(receivedArgs, <dynamic>['ping', 42],
+          reason: 'the arguments must cross the bridge unchanged');
+      expect(result, isA<String>(),
+          reason: 'the handler response must be JSON-encoded back to JS');
+      expect(
+        jsonDecode(result as String),
+        <String, dynamic>{'pong': 'ping'},
+        reason: 'the handler return value must round-trip back to the JS '
+            'caller',
+      );
+      expect(platform.evaluatedSources, hasLength(1));
+      expect(
+        platform.evaluatedSources.single,
+        contains('callHandler'),
+        reason: 'the platform must have received exactly the evaluation '
+            'that was sent',
+      );
+
+      // Handler removal completes the lifecycle contract.
+      expect(
+        controller.javaScript.removeJavaScriptHandler(
+          handlerName: 'gymBridge',
+        ),
+        isNotNull,
+      );
+      expect(
+        controller.javaScript.hasJavaScriptHandler(handlerName: 'gymBridge'),
+        isFalse,
+      );
+    },
+  );
+}

--- a/zikzak_inappwebview/.gym/gym.yaml
+++ b/zikzak_inappwebview/.gym/gym.yaml
@@ -1,0 +1,50 @@
+# GYM artifact — package-level exercises for zikzak_inappwebview.
+# See github.com/arrrrny/gym for the paradigm,
+#     github.com/arrrrny/miki (gym.mjs) for the runner that consumes this file.
+#
+# Mirrors the package-level gym.yaml shape established in
+# github.com/arrrrny/zuraffa (.gym/gym.yaml) so the miki GYM runner can
+# consume this package without code changes (spec 022 / issue #397).
+#
+# A gym is a folder of exercises with two phases:
+#   WARMUP    — mandatory reps that build reflex. No reps, no phase 2.
+#   EXERCISES — graded work that proves the muscle under real load.
+# The gate only lets the proven through. A mis-fire is a DROP CARD.
+name: zikzak_inappwebview
+version: 1.0.0
+warmup:
+  - id: 01-deps
+    name: Resolve the federated plugin dependencies (flutter pub get)
+    command: dart run .gym/warmup/01-deps.dart
+  - id: 02-build
+    name: Compile the plugin (analyze, zero errors)
+    command: dart run .gym/warmup/02-build.dart
+  - id: 03-bridge-smoke
+    name: JS bridge smoke call through the public controller API
+    command: flutter test .gym/warmup/03-bridge-smoke_test.dart
+exercises:
+  - id: js-bridge-round-trip
+    brief: |
+      A genuine dev task (spec 022 / issue #397), not a re-skinned unit
+      test — the headless form of "boot a WebView and drive its JS
+      bridge". Boots an InAppWebViewController on a faked platform (the
+      repo's established platform-interface fake pattern), registers a
+      Dart-side JavaScript handler through the public
+      `JavaScriptController` facade, dispatches a call into it the way
+      the native bridge does (`window.zikzak_inappwebview.callHandler`),
+      and asserts the full message round-trip: the arguments cross the
+      bridge unchanged, the handler's return value crosses back, and the
+      JS evaluation surface (`evaluateJavascript`) records exactly what
+      was sent. Proves the bridge contract an operator actually codes
+      against. Grading is exit-code based (flutter test); the fixture
+      fails the run (and the convention points at a DROP CARD for
+      mis-fires — github.com/arrrrny/drop-card).
+    setup: |
+      Ensure `flutter` is on PATH (the federated plugin and its tests
+      resolve through the Flutter tool; the rep fails fast with a clear
+      setup error when it is not).
+      Run the warmup reps first (.gym/warmup/*).
+      The exercise runs in-process on a faked platform — no emulator, no
+      device, no network. It never mutates the plugin source tree.
+    verifyCommand: flutter test .gym/exercises/js_bridge_round_trip_test.dart
+    evaluate: exit 0 => pass; exit !=0 => fail

--- a/zikzak_inappwebview/.gym/warmup/01-deps.dart
+++ b/zikzak_inappwebview/.gym/warmup/01-deps.dart
@@ -1,0 +1,83 @@
+/// GYM warmup rep #1 — resolve the federated plugin dependencies.
+///
+/// zikzak_inappwebview is a federated Flutter plugin: its dependency
+/// graph (`flutter: sdk: flutter`, sibling platform packages) resolves
+/// through the Flutter tool. This rep runs `flutter pub get` and asserts
+/// the produced `.dart_tool/package_config.json` references the plugin
+/// root package AND a platform implementation package — proving the
+/// federated graph actually resolved. Fails fast with a clear setup
+/// error (never a misleading grade) when the Flutter SDK is absent.
+///
+/// Run from the plugin package root:
+/// `dart run .gym/warmup/01-deps.dart`
+///
+/// A mis-fire (unexpected outcome, not a clean failure) is a DROP CARD —
+/// see github.com/arrrrny/drop-card.
+library;
+
+import 'dart:io';
+
+/// Entry point for warmup rep #1.
+Future<void> main() async {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    stderr.writeln(
+      'No pubspec.yaml in cwd=${Directory.current.path} — run this rep '
+      'from the zikzak_inappwebview package root.',
+    );
+    exit(1);
+  }
+
+  final ProcessResult result;
+  try {
+    result = await Process.run('flutter', ['pub', 'get']);
+  } on ProcessException catch (e) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — the Flutter SDK is required to resolve this '
+      'federated plugin (flutter pub get) but is not on PATH: $e.\n'
+      'This is a setup error, not a grade. Install Flutter (>=3.38.6) '
+      'and re-run.',
+    );
+    exit(1);
+  }
+
+  if (result.exitCode != 0) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — `flutter pub get` exited ${result.exitCode}',
+    );
+    stderr.writeln(result.stdout);
+    stderr.writeln(result.stderr);
+    exit(result.exitCode == 0 ? 1 : result.exitCode);
+  }
+
+  final pkgConfig = File('.dart_tool/package_config.json');
+  if (!pkgConfig.existsSync()) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — pub get exited 0 but .dart_tool/'
+      'package_config.json is missing. Mis-fire — drop a card: '
+      'github.com/arrrrny/drop-card',
+    );
+    exit(1);
+  }
+
+  final configText = pkgConfig.readAsStringSync();
+  if (!configText.contains('"name":"zikzak_inappwebview"') &&
+      !configText.contains('"name": "zikzak_inappwebview"')) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — package_config.json does not reference the '
+      '`zikzak_inappwebview` root package. Mis-fire — drop a card.',
+    );
+    exit(1);
+  }
+  if (!configText.contains('zikzak_inappwebview_android')) {
+    stderr.writeln(
+      'REP FAIL: 01-deps — the federated graph did not resolve a '
+      'platform implementation package (zikzak_inappwebview_android '
+      'absent from package_config.json). Mis-fire — drop a card.',
+    );
+    exit(1);
+  }
+
+  stdout.writeln('REP OK: 01-deps — federated plugin dependencies '
+      'resolved.');
+}

--- a/zikzak_inappwebview/.gym/warmup/02-build.dart
+++ b/zikzak_inappwebview/.gym/warmup/02-build.dart
@@ -1,0 +1,50 @@
+/// GYM warmup rep #2 — compile the plugin.
+///
+/// Proves the plugin an operator is about to use actually compiles:
+/// `dart analyze lib/` must report zero errors (the repo's pre-existing
+/// lint-level issues elsewhere are tolerated; errors are not).
+///
+/// Run from the plugin package root:
+/// `dart run .gym/warmup/02-build.dart`
+///
+/// A mis-fire (unexpected outcome, not a clean failure) is a DROP CARD —
+/// see github.com/arrrrny/drop-card.
+library;
+
+import 'dart:io';
+
+/// Entry point for warmup rep #2.
+Future<void> main() async {
+  final libDir = Directory('lib');
+  if (!libDir.existsSync()) {
+    stderr.writeln(
+      'No lib/ in cwd=${Directory.current.path} — run this rep from the '
+      'zikzak_inappwebview package root.',
+    );
+    exit(1);
+  }
+
+  final ProcessResult result;
+  try {
+    result = await Process.run('dart', ['analyze', 'lib/']);
+  } on ProcessException catch (e) {
+    stderr.writeln(
+      'REP FAIL: 02-build — `dart analyze` could not run: $e.\n'
+      'This is a setup error, not a grade.',
+    );
+    exit(1);
+  }
+
+  final out = '${result.stdout as String}${result.stderr as String}';
+  if (out.contains(' error - ')) {
+    stderr.writeln(
+      'REP FAIL: 02-build — `dart analyze lib/` reports errors (the '
+      'plugin does not compile):',
+    );
+    stderr.writeln(out);
+    exit(1);
+  }
+
+  stdout.writeln('REP OK: 02-build — plugin lib/ compiles with zero '
+      'errors.');
+}

--- a/zikzak_inappwebview/.gym/warmup/03-bridge-smoke_test.dart
+++ b/zikzak_inappwebview/.gym/warmup/03-bridge-smoke_test.dart
@@ -1,0 +1,63 @@
+/// GYM warmup rep #3 — JS bridge smoke call through the public controller
+/// API (zikzak_inappwebview).
+///
+/// The issue asks for a bridge smoke call per package. Headless CI has no
+/// device, so this rep drives the bridge the way the repo's own tests do
+/// (see test/headless_dispose_test.dart): a faked platform controller
+/// standing in for the native WebView. The rep boots an
+/// [InAppWebViewController] on the fake and round-trips ONE JavaScript
+/// evaluation through the public `JavaScriptController` facade — the
+/// same call every operator writes first. `flutter test` is the grader
+/// (exit 0 = rep OK).
+///
+/// Run from the plugin package root:
+/// `flutter test .gym/warmup/03-bridge-smoke_test.dart`
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+/// Minimal platform fake: records every evaluated source and echoes it
+/// back — enough surface for a bridge smoke call.
+class _FakePlatformController extends PlatformInAppWebViewController {
+  _FakePlatformController()
+      : super.implementation(
+          const PlatformInAppWebViewControllerCreationParams(
+            id: 'gym-smoke-webview',
+          ),
+        );
+
+  final List<String> evaluatedSources = <String>[];
+
+  @override
+  Future<dynamic> evaluateJavascript({
+    required String source,
+    ContentWorld? contentWorld,
+  }) async {
+    evaluatedSources.add(source);
+    return 'echo:$source';
+  }
+}
+
+void main() {
+  test(
+    '03-bridge-smoke: evaluateJavascript round-trips through the public '
+    'controller API',
+    () async {
+      final platform = _FakePlatformController();
+      final controller = InAppWebViewController.fromPlatform(platform: platform);
+
+      const source = 'window.gymEcho("ping")';
+      final result = await controller.javaScript.evaluateJavascript(
+        source: source,
+      );
+
+      expect(result, 'echo:$source',
+          reason: 'the JS evaluation result must round-trip to the caller');
+      expect(platform.evaluatedSources, <String>[source],
+          reason: 'the platform must receive exactly the source that was '
+              'sent through the public facade');
+    },
+  );
+}


### PR DESCRIPTION
## Summary
Stands up `zikzak_inappwebview/.gym/` (issue #397, tracked by zuraffa spec 022) with a miki-GYM-runner-consumable `gym.yaml`: three mandatory warmup reps (federated dependency resolution via `flutter pub get` with a fail-fast setup error when the Flutter SDK is absent; compile proof via `dart analyze lib/` with zero errors; a **JS bridge smoke call** round-tripping one `evaluateJavascript` through the public `JavaScriptController` facade on a faked platform) gating one graded exercise — **js-bridge-round-trip**: the headless form of "boot a WebView and drive its JS bridge". The exercise boots an `InAppWebViewController` on a platform fake (the repo's established fake pattern), registers a Dart-side JS handler through the public facade, dispatches a `window.zikzak_inappwebview.callHandler(...)` invocation the way the native bridge does, and asserts the full message round-trip — arguments cross unchanged, the JSON-encoded response crosses back, handler presence/removal is queryable. `flutter test` is the grader (exit-code based); everything runs in-process (no emulator, no device, no network) and never mutates the plugin source. Adds a scoped `.gym/analysis_options.yaml` so the rep-format file names stay outside the `flutter_lints` regime (mirrors zuraffa).

## Test plan
- [x] `dart run .gym/warmup/01-deps.dart` → REP OK (federated graph resolved, platform implementation package present)
- [x] `dart run .gym/warmup/02-build.dart` → REP OK (lib/ compiles with zero errors)
- [x] `flutter test .gym/warmup/03-bridge-smoke_test.dart` → All tests passed (exit 0)
- [x] `flutter test .gym/exercises/js_bridge_round_trip_test.dart` → All tests passed (exit 0)
- [x] Deliberate-mutant red evidence: breaking the bridge's argument decoding fails the exercise (`Expected: ['ping', 42] Actual: ['["ping", 42]']`, exit 1)

**Verification caveat (recorded honestly):** verified with Flutter 3.47.2 and the `pub.zuzu.dev` `dependency_overrides` entry removed *locally* (the private mirror requires credentials not available in this environment; pub.dev hosted `zuraffa 6.1.0` + Flutter 3.47.2 resolve the graph cleanly — with Flutter 3.41.x the SDK's `meta` pin conflicts). The committed `pubspec.yaml` is unchanged.

Part of the four-package GYM rollout (zuraffa, zorphy, zikzak_inappwebview, vendure-flutter-sdk) tracked in arrrrny/zuraffa#397 / spec 022.