### PR TITLE
feat: extract legacy dismissDialogues into testable seam + characterization tests

### DIFF
--- a/zikzak_inappwebview/example/integration_test/dismiss_dialogues_test.dart
+++ b/zikzak_inappwebview/example/integration_test/dismiss_dialogues_test.dart
@@ -5,12 +5,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
 
-/// Dismiss-dialogue integration coverage (spec 002, SC-002 / SC-004).
+/// Dismiss-dialogue integration coverage (spec 002).
 ///
-/// Runs on macOS desktop, iOS simulator, and Android emulator. Loads a page with
-/// fixed/sticky overlays and asserts the `dismissDialogues` setting's effect on
-/// the live DOM. Avoids `pumpAndSettle` (a live WebView keeps the frame dirty and
-/// never settles); uses fixed delays plus explicit per-call timeouts instead.
+/// Combines the spec-002 SC-002/SC-003/SC-004/SC-005 coverage (macOS/iOS/Android)
+/// with the legacy `dismissDialogues` acceptance tests (US1/US2/US3, A1-A6).
+///
+/// The legacy seam fires on `onLoadStop` and injects the removal script 3x with
+/// an 800ms delay between attempts (~1.6s window), so tests wait out that window
+/// before asserting the resulting DOM. Avoids `pumpAndSettle` where a live WebView
+/// keeps the frame dirty and never settles; uses fixed delays plus explicit
+/// per-call timeouts instead.
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
@@ -125,6 +129,55 @@ void main() {
     return result == true;
   }
 
+  Future<InAppWebViewController> pumpDismissWebView(
+    WidgetTester tester, {
+    required String html,
+    required bool dismissDialogues,
+    Completer<void>? loadCompleter,
+  }) async {
+    final created = Completer<InAppWebViewController>();
+    final loaded = loadCompleter ?? Completer<void>();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: InAppWebView(
+            initialSettings: InAppWebViewSettings(dismissDialogues: dismissDialogues),
+            onWebViewCreated: (c) {
+              if (!created.isCompleted) created.complete(c);
+            },
+            onLoadStop: (c, url) {
+              if (!loaded.isCompleted) loaded.complete();
+            },
+          ),
+        ),
+      ),
+    );
+    final controller = await created.future.timeout(const Duration(seconds: 15));
+    await controller.loadData(data: html);
+    await loaded.future.timeout(const Duration(seconds: 15));
+    // Wait out the legacy dismissal retry window (3x with 800ms between).
+    await Future.delayed(const Duration(seconds: 3));
+    await tester.pumpAndSettle();
+    return controller;
+  }
+
+  int toInt(dynamic v) => v is num ? v.toInt() : int.parse(v.toString());
+
+  Future<int> countFixedSticky(InAppWebViewController c) async {
+    final raw = await c.evaluateJavascript(
+      source: r'''
+(function() {
+  var els = Array.from(document.querySelectorAll('*'));
+  return els.filter(function(e) {
+    var p = getComputedStyle(e).position;
+    return p === 'fixed' || p === 'sticky';
+  }).length;
+})()
+''',
+    );
+    return toInt(raw);
+  }
+
   group('dismissDialogues (spec 002)', () {
     testWidgets(
       'SC-002: dismissDialogues removes fixed/sticky overlays when enabled',
@@ -211,5 +264,130 @@ void main() {
       },
       timeout: const Timeout(Duration(minutes: 8)),
     );
+
+    // A1 — US1-S1, US1-S2, FR-003, FR-004
+    testWidgets('A1: dismissDialogues removes all fixed AND sticky elements', (
+      WidgetTester tester,
+    ) async {
+      const html = '''
+<!DOCTYPE html><html><head><style>
+.fixed{position:fixed;top:0;left:0;}
+.sticky{position:sticky;top:0;}
+</style></head><body>
+<h1>content</h1>
+<div id="ovl" class="fixed">overlay</div>
+<div id="stk" class="sticky">sticky</div>
+</body></html>''';
+      final c = await pumpDismissWebView(tester, html: html, dismissDialogues: true);
+      expect(await countFixedSticky(c), 0);
+      final out = await c.getHtml();
+      expect(out, isNotNull);
+      expect(out!, isNot(contains('id="ovl"')));
+      expect(out, isNot(contains('id="stk"')));
+    });
+
+    // A2 — US1-S3, FR-005
+    testWidgets('A2: dismissDialogues resets overflow/margin on documentElement and body', (
+      WidgetTester tester,
+    ) async {
+      const html = '''
+<!DOCTYPE html><html><head></head>
+<body style="overflow:hidden;margin:10px">
+<div id="ovl" style="position:fixed">overlay</div>
+</body></html>''';
+      final c = await pumpDismissWebView(tester, html: html, dismissDialogues: true);
+      expect(await c.evaluateJavascript(source: "document.documentElement.style.overflow"), '');
+      expect(await c.evaluateJavascript(source: "document.documentElement.style.margin"), '');
+      expect(await c.evaluateJavascript(source: "document.body.style.overflow"), '');
+      expect(await c.evaluateJavascript(source: "document.body.style.margin"), '');
+    });
+
+    // A3 — US2-S1, FR-007
+    testWidgets('A3: dismissDialogues false keeps fixed/sticky elements', (
+      WidgetTester tester,
+    ) async {
+      const html = '''
+<!DOCTYPE html><html><head><style>
+.fixed{position:fixed;top:0;left:0;}
+.sticky{position:sticky;top:0;}
+</style></head><body>
+<h1>content</h1>
+<div id="ovl" class="fixed">overlay</div>
+<div id="stk" class="sticky">sticky</div>
+</body></html>''';
+      final c = await pumpDismissWebView(tester, html: html, dismissDialogues: false);
+      expect(await countFixedSticky(c), 2);
+      final out = await c.getHtml();
+      expect(out, isNotNull);
+      expect(out!, contains('id="ovl"'));
+      expect(out, contains('id="stk"'));
+    });
+
+    // A4 — US2-S2, SC-004
+    testWidgets('A4: dismissDialogues false leaves overlays in a screenshot capture', (
+      WidgetTester tester,
+    ) async {
+      const html = '''
+<!DOCTYPE html><html><head></head>
+<body><div id="ovl" style="position:fixed">overlay</div></body></html>''';
+      final c = await pumpDismissWebView(tester, html: html, dismissDialogues: false);
+      expect(await countFixedSticky(c), 1);
+      final shot = await c.takeScreenshot();
+      expect(shot, isNotNull);
+      expect(shot!.length, greaterThan(0));
+    });
+
+    // A5 — US3-S1, FR-006
+    testWidgets('A5: dismissDialogues removes a fixed overlay injected after load', (
+      WidgetTester tester,
+    ) async {
+      const html = '<!DOCTYPE html><html><body><h1>content</h1></body></html>';
+      final loaded = Completer<void>();
+      final created = Completer<InAppWebViewController>();
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: InAppWebView(
+              initialSettings: InAppWebViewSettings(dismissDialogues: true),
+              onWebViewCreated: (c) {
+                if (!created.isCompleted) created.complete(c);
+              },
+              onLoadStop: (c, url) {
+                if (!loaded.isCompleted) loaded.complete();
+              },
+            ),
+          ),
+        ),
+      );
+      final c = await created.future.timeout(const Duration(seconds: 15));
+      await c.loadData(data: html);
+      await loaded.future.timeout(const Duration(seconds: 15));
+      // Inject a fixed overlay after the first dismissal attempt but before the
+      // 800ms retry window closes, so a later retry must catch it.
+      await Future.delayed(const Duration(milliseconds: 400));
+      await c.evaluateJavascript(
+        source:
+            "var d=document.createElement('div');d.id='dyn';d.style.position='fixed';d.textContent='late';document.body.appendChild(d);",
+      );
+      await Future.delayed(const Duration(seconds: 3));
+      await tester.pumpAndSettle();
+      expect(await countFixedSticky(c), 0);
+      final out = await c.getHtml();
+      expect(out, isNotNull);
+      expect(out!, isNot(contains('id="dyn"')));
+    });
+
+    // A6 — US3-S2, FR-008, FR-009
+    testWidgets('A6: dismissDialogues with no overlays completes cleanly', (
+      WidgetTester tester,
+    ) async {
+      const html = '<!DOCTYPE html><html><body><h1>clean page</h1><p>body text</p></body></html>';
+      final c = await pumpDismissWebView(tester, html: html, dismissDialogues: true);
+      expect(await countFixedSticky(c), 0);
+      final out = await c.getHtml();
+      expect(out, isNotNull);
+      expect(out!, contains('clean page'));
+      expect(out, contains('body text'));
+    });
   });
 }

--- a/zikzak_inappwebview/lib/src/in_app_webview/dismiss_dialogues_legacy.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/dismiss_dialogues_legacy.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import 'in_app_webview_controller.dart';
+
+/// Default delay between dismissal attempts in [runLegacyDismissDialogues].
+const Duration legacyDismissRetryDelay = Duration(milliseconds: 800);
+
+/// The exact legacy brute-force dismissal script injected on `onLoadStop`
+/// (by `InAppWebView` and `HeadlessInAppWebView`) when `dismissDialogues` is
+/// enabled.
+///
+/// It removes every element whose computed `position` is `fixed` or `sticky`
+/// from the top-level document, resets `overflow`/`margin` on the document
+/// element and on `body`, and returns the number of removed elements.
+///
+/// Kept verbatim (and public) so its behavior can be characterized and cannot
+/// drift silently. The script purposefully tolerates per-element errors.
+String legacyDismissDialoguesJs() => r'''
+(function() {
+  var removed = 0;
+  var all = document.querySelectorAll('*');
+  all.forEach(function(el) {
+    try {
+      var style = window.getComputedStyle(el);
+      if (style.position === 'fixed' || style.position === 'sticky') {
+        el.remove();
+        removed++;
+      }
+    } catch(e) {}
+  });
+  document.documentElement.style.overflow = '';
+  document.documentElement.style.margin = '';
+  document.body.style.overflow = '';
+  document.body.style.margin = '';
+  return removed;
+})();
+''';
+
+/// Whether the legacy dismissal script should run for [settings].
+///
+/// Mirrors the inline guard in [InAppWebView] `onLoadStop`: it runs only when
+/// `dismissDialogues` is explicitly true and is a no-op otherwise.
+bool shouldDismissDialogues(InAppWebViewSettings? settings) =>
+    settings?.dismissDialogues ?? false;
+
+/// Runs the legacy dismissal by injecting [legacyDismissDialoguesJs] up to three
+/// times, waiting [retryDelay] between attempts and after the first two.
+///
+/// Any error raised by the platform is swallowed so the web view is never left
+/// in a broken state. The returned future is intentionally fire-and-forget at
+/// the call site, matching the original behavior.
+Future<void> runLegacyDismissDialogues(
+  InAppWebViewController controller, {
+  Duration retryDelay = legacyDismissRetryDelay,
+}) async {
+  try {
+    for (var i = 0; i < 3; i++) {
+      await controller.evaluateJavascript(source: legacyDismissDialoguesJs());
+      if (i < 2) {
+        await Future.delayed(retryDelay);
+      }
+    }
+  } catch (_) {}
+}

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
@@ -12,6 +12,7 @@ import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platf
 import '../webview_environment/webview_environment.dart';
 import 'headless_in_app_webview.dart';
 import 'in_app_webview_controller.dart';
+import 'dismiss_dialogues_legacy.dart';
 import '../find_interaction/find_interaction_controller.dart';
 import '../pull_to_refresh/main.dart';
 import '../pull_to_refresh/pull_to_refresh_controller.dart';
@@ -334,38 +335,8 @@ class InAppWebView extends StatefulWidget implements Disposable {
         onLoadStop: (controller, url) {
           networkCaptureManager?.onPageLoad(controller);
           onLoadStop?.call(controller, url);
-          if (initialSettings?.dismissDialogues ?? false) {
-            () async {
-              try {
-                for (var i = 0; i < 3; i++) {
-                  await controller.evaluateJavascript(
-                    source: '''
-                          (function() {
-                            var removed = 0;
-                            var all = document.querySelectorAll('*');
-                            all.forEach(function(el) {
-                              try {
-                                var style = window.getComputedStyle(el);
-                                if (style.position === 'fixed' || style.position === 'sticky') {
-                                  el.remove();
-                                  removed++;
-                                }
-                              } catch(e) {}
-                            });
-                            document.documentElement.style.overflow = '';
-                            document.documentElement.style.margin = '';
-                            document.body.style.overflow = '';
-                            document.body.style.margin = '';
-                            return removed;
-                          })();
-                        ''',
-                  );
-                  if (i < 2) {
-                    await Future.delayed(const Duration(milliseconds: 800));
-                  }
-                }
-              } catch (_) {}
-            }();
+          if (shouldDismissDialogues(initialSettings)) {
+            unawaited(runLegacyDismissDialogues(controller));
           }
         },
         onReceivedError: onReceivedError != null

--- a/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
+++ b/zikzak_inappwebview/lib/src/in_app_webview/in_app_webview.dart
@@ -12,10 +12,10 @@ import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platf
 import '../webview_environment/webview_environment.dart';
 import 'headless_in_app_webview.dart';
 import 'in_app_webview_controller.dart';
-import 'dismiss_dialogues_legacy.dart';
 import '../find_interaction/find_interaction_controller.dart';
 import '../pull_to_refresh/main.dart';
 import '../pull_to_refresh/pull_to_refresh_controller.dart';
+import 'dismiss_dialogues_legacy.dart';
 import 'network_capture/network_capture_manager.dart';
 
 ///{@macro zikzak_inappwebview_platform_interface.PlatformInAppWebViewWidget}

--- a/zikzak_inappwebview/test/in_app_webview/dismiss_dialogues_legacy_test.dart
+++ b/zikzak_inappwebview/test/in_app_webview/dismiss_dialogues_legacy_test.dart
@@ -1,0 +1,113 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:zikzak_inappwebview/zikzak_inappwebview.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+import 'package:zikzak_inappwebview/src/in_app_webview/dismiss_dialogues_legacy.dart';
+
+/// Minimal [PlatformInAppWebViewController] fake that records injected scripts
+/// and optionally throws, so the legacy dismissal driver can be exercised
+/// without a real WebView.
+class _FakePlatformController extends Fake
+    implements PlatformInAppWebViewController {
+  /// Sources passed to [evaluateJavascript].
+  final List<String> evaluatedSources = <String>[];
+
+  /// When true, [evaluateJavascript] throws instead of succeeding.
+  bool throwOnEvaluate = false;
+
+  @override
+  Future<dynamic> evaluateJavascript({
+    required String source,
+    ContentWorld? contentWorld,
+  }) async {
+    evaluatedSources.add(source);
+    if (throwOnEvaluate) throw StateError('injected script failed');
+    return null;
+  }
+}
+
+InAppWebViewController _controller(_FakePlatformController platform) =>
+    InAppWebViewController.fromPlatform(platform: platform);
+
+void main() {
+  group('legacyDismissDialogues (U3-U8 characterization)', () {
+    // U3 / FR-003, FR-004 — removes every fixed/sticky element.
+    test('legacyDismissDialoguesJs removes elements whose position is fixed or sticky', () {
+      final js = legacyDismissDialoguesJs();
+      expect(js, contains("document.querySelectorAll('*')"),
+          reason: 'must scan every element');
+      expect(js, contains('window.getComputedStyle(el)'),
+          reason: 'must read computed position');
+      expect(js, contains("style.position === 'fixed'"));
+      expect(js, contains("style.position === 'sticky'"));
+      expect(js, contains('el.remove()'),
+          reason: 'matching elements must be removed');
+    });
+
+    // U4 / FR-005 — resets overflow/margin on documentElement and body.
+    test('legacyDismissDialoguesJs resets overflow and margin to empty on documentElement and body', () {
+      final js = legacyDismissDialoguesJs();
+      expect(js, contains("document.documentElement.style.overflow = '';"));
+      expect(js, contains("document.documentElement.style.margin = '';"));
+      expect(js, contains("document.body.style.overflow = '';"));
+      expect(js, contains("document.body.style.margin = '';"));
+    });
+
+    // U5 / FR-006, US3-S1 — retries 3x with an 800ms gap.
+    test('runLegacyDismissDialogues injects the script exactly 3 times with the 800ms retry delay', () async {
+      final platform = _FakePlatformController();
+      await runLegacyDismissDialogues(
+        _controller(platform),
+        retryDelay: Duration.zero,
+      );
+      expect(platform.evaluatedSources.length, 3,
+          reason: 'the legacy loop attempts three times');
+      expect(legacyDismissRetryDelay, const Duration(milliseconds: 800),
+          reason: 'default gap between attempts is 800ms');
+    });
+
+    // U6 / FR-007, US2-S1 — no injection unless dismissDialogues is true.
+    test('shouldDismissDialogues is false unless dismissDialogues is explicitly true', () {
+      expect(shouldDismissDialogues(null), isFalse);
+      expect(shouldDismissDialogues(InAppWebViewSettings()), isFalse);
+      expect(
+        shouldDismissDialogues(InAppWebViewSettings(dismissDialogues: false)),
+        isFalse,
+      );
+      expect(
+        shouldDismissDialogues(InAppWebViewSettings(dismissDialogues: true)),
+        isTrue,
+      );
+    });
+
+    // U7 / FR-008 — JS errors are swallowed; the web view is not broken.
+    test('removal errors are swallowed (inner catch + driver try/catch) and never propagate', () async {
+      // The emitted script tolerates per-element DOM errors.
+      expect(legacyDismissDialoguesJs(), contains('catch(e)'),
+          reason: 'the IIFE swallows per-element errors');
+
+      // The Dart driver swallows platform-side errors entirely.
+      final platform = _FakePlatformController()..throwOnEvaluate = true;
+      await runLegacyDismissDialogues(
+        _controller(platform),
+        retryDelay: Duration.zero,
+      );
+      expect(platform.evaluatedSources, isNotEmpty,
+          reason: 'injection was attempted before the error was swallowed');
+    });
+
+    // U8 / FR-009 — only the top-level document is touched; frames are not.
+    test('legacyDismissDialoguesJs traverses only the top-level document (no iframe/frames)', () {
+      final js = legacyDismissDialoguesJs();
+      expect(js, contains('document.querySelectorAll'),
+          reason: 'targets the top-level document');
+      expect(js, isNot(contains('iframe')),
+          reason: 'must not reach into iframes');
+      expect(js, isNot(contains('contentDocument')));
+      expect(js, isNot(contains('window.frames')));
+      expect(js, isNot(contains('.frames')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Extracts the legacy `dismissDialogues` behavior into a testable seam (`lib/src/in_app_webview/dismiss_dialogues_legacy.dart`), keeping `in_app_webview.dart` lean. The legacy `dismissDialogues` setting still exists on `master` (alongside the newer `dialogue_dismisser` package), so this characterizes and hardens the existing path.
- Adds characterization tests (`test/dismiss_dialogues_legacy_test.dart`, U3-U8) for the legacy behavior.
- Adds iOS integration tests (A1-A6) in `example/integration_test/dismiss_dialogues_test.dart` covering: enabled/disabled, fixed+sticky removal, overflow/margin reset, screenshot capture with overlays, late-injected overlay, and clean completion.

## Notes
- 3 commits; the original iOS serialization/websiteDataStore commit was dropped as redundant with already-merged upstream work.
- `dart analyze` clean (info-level lints only).

🤖 Generated with [Kimi Code CLI](https://kimi.com/code)