### PR TITLE
fix(windows): reuse initialized WebView2 environment

### DIFF
--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
 
 import 'package:path_provider/path_provider.dart';
 import 'package:webview_windows/webview_windows.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 import 'in_app_webview_windows_controller.dart';
+
+bool isEnvironmentAlreadyInitializedError(Object error) {
+  return error is PlatformException &&
+      error.code == 'environment_already_initialized';
+}
 
 class _VirtualHostMappingInfo {
   final String folderPath;
@@ -99,12 +105,18 @@ class _InAppWebViewWindowsWidgetStateImpl
         defaultUserDataFolder: () => defaultUserDataFolder,
       );
 
-      // Initialize the shared WebView2 environment with the resolved args.
-      await WebviewController.initializeEnvironment(
-        userDataPath: args.userDataPath,
-        browserExePath: args.browserExePath,
-        additionalArguments: args.additionalArguments,
-      );
+      // The WebView2 environment is shared by all controllers and can only be
+      // initialized once. Reusing it is valid when another WebView already
+      // initialized the process-wide environment.
+      try {
+        await WebviewController.initializeEnvironment(
+          userDataPath: args.userDataPath,
+          browserExePath: args.browserExePath,
+          additionalArguments: args.additionalArguments,
+        );
+      } on PlatformException catch (error) {
+        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+      }
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -120,6 +120,15 @@ class _InAppWebViewWindowsWidgetStateImpl
 
       await _controller.initialize();
 
+      final controllerParams = PlatformInAppWebViewControllerCreationParams(
+        id: widget.params.windowId,
+        webviewParams: widget.params,
+      );
+      final controller = InAppWebViewWindowsController(
+        controllerParams,
+        _controller,
+      );
+
       // Apply virtual host mappings from the environment settings. Each
       // mapping serves a local folder at https://<hostName>/ and bypasses
       // CORS for those resources when the access kind is allowCors.
@@ -157,15 +166,22 @@ class _InAppWebViewWindowsWidgetStateImpl
       }
 
       // Setup listeners
-      _controller.url.listen((url) {
-        // TODO: handle url change
-      });
+      String? currentUrl;
+      _controller.url.listen((url) => currentUrl = url);
 
       _controller.loadingState.listen((state) {
-        if (state == LoadingState.navigationCompleted) {
-          // TODO: handle load stop
-        } else if (state == LoadingState.loading) {
-          // TODO: handle load start
+        final url = currentUrl == null ? null : WebUri(currentUrl!);
+        switch (state) {
+          case LoadingState.loading:
+            widget.params.onProgressChanged?.call(controller, 0);
+            widget.params.onLoadStart?.call(controller, url);
+            break;
+          case LoadingState.navigationCompleted:
+            widget.params.onProgressChanged?.call(controller, 100);
+            widget.params.onLoadStop?.call(controller, url);
+            break;
+          case LoadingState.none:
+            break;
         }
       });
 
@@ -180,17 +196,6 @@ class _InAppWebViewWindowsWidgetStateImpl
           widget.params.initialUrlRequest!.url.toString(),
         );
       }
-
-      // Create controller
-      final controllerParams = PlatformInAppWebViewControllerCreationParams(
-        id: widget.params.windowId,
-        webviewParams: widget.params,
-      );
-
-      final controller = InAppWebViewWindowsController(
-        controllerParams,
-        _controller,
-      );
 
       if (widget.params.onWebViewCreated != null) {
         widget.params.onWebViewCreated!(

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,9 +1,30 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
 
 void main() {
   const defaultFolder = '/tmp/default-zikzak-webview2-data';
+
+  group('WebView2 environment initialization', () {
+    test('recognizes an already initialized environment', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'environment_already_initialized'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not swallow unrelated platform errors', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'other_error'),
+        ),
+        isFalse,
+      );
+    });
+  });
 
   group('resolveEnvironmentInitArgs', () {
     group('issue #178 regression — additionalBrowserArguments', () {
@@ -20,7 +41,8 @@ void main() {
           // `WebViewEnvironmentInitArgs.additionalArguments` so the
           // caller can forward it to
           // `WebviewController.initializeEnvironment(additionalArguments:)`.
-          const args = '--disable-web-security '
+          const args =
+              '--disable-web-security '
               '--allow-running-insecure-content '
               '--use-fake-ui-for-media-stream '
               '--use-fake-device-for-media-stream';
@@ -100,20 +122,23 @@ void main() {
       expect(resolved.additionalArguments, isNull);
     });
 
-    test('defaultUserDataFolder is NOT invoked when settings.userDataFolder is set', () {
-      var defaultInvoked = 0;
-      resolveEnvironmentInitArgs(
-        settings: WebViewEnvironmentSettings(
-          userDataFolder: '/tmp/explicit',
-          additionalBrowserArguments: '--disable-web-security',
-        ),
-        defaultUserDataFolder: () {
-          defaultInvoked++;
-          return defaultFolder;
-        },
-      );
+    test(
+      'defaultUserDataFolder is NOT invoked when settings.userDataFolder is set',
+      () {
+        var defaultInvoked = 0;
+        resolveEnvironmentInitArgs(
+          settings: WebViewEnvironmentSettings(
+            userDataFolder: '/tmp/explicit',
+            additionalBrowserArguments: '--disable-web-security',
+          ),
+          defaultUserDataFolder: () {
+            defaultInvoked++;
+            return defaultFolder;
+          },
+        );
 
-      expect(defaultInvoked, 0);
-    });
+        expect(defaultInvoked, 0);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- treat WebView2's process-wide environment as reusable across WebView widgets
- ignore only the expected environment_already_initialized PlatformException
- forward Windows loading/navigation-completed events to onLoadStart, onLoadStop, and progress callbacks
- preserve all other initialization failures
- add focused regression coverage

## Reproduction
1. Open and close one Windows InAppWebView.
2. Open a second InAppWebView in the same process.
3. Current behavior stalls after PlatformException(environment_already_initialized).
4. Even the first WebView never emits onLoadStop because the loadingState listener is left as TODO.

## Tests
- flutter analyze lib/src/in_app_webview_windows_platform.dart
- flutter test test/in_app_webview_windows_environment_args_test.dart