### PR TITLE
fix(windows): reuse initialized WebView2 environment

### DIFF
--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
 
 import 'package:path_provider/path_provider.dart';
 import 'package:webview_windows/webview_windows.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 import 'in_app_webview_windows_controller.dart';
+
+bool isEnvironmentAlreadyInitializedError(Object error) {
+  return error is PlatformException &&
+      error.code == 'environment_already_initialized';
+}
 
 class _VirtualHostMappingInfo {
   final String folderPath;
@@ -99,12 +105,18 @@ class _InAppWebViewWindowsWidgetStateImpl
         defaultUserDataFolder: () => defaultUserDataFolder,
       );
 
-      // Initialize the shared WebView2 environment with the resolved args.
-      await WebviewController.initializeEnvironment(
-        userDataPath: args.userDataPath,
-        browserExePath: args.browserExePath,
-        additionalArguments: args.additionalArguments,
-      );
+      // The WebView2 environment is shared by all controllers and can only be
+      // initialized once. Reusing it is valid when another WebView already
+      // initialized the process-wide environment.
+      try {
+        await WebviewController.initializeEnvironment(
+          userDataPath: args.userDataPath,
+          browserExePath: args.browserExePath,
+          additionalArguments: args.additionalArguments,
+        );
+      } on PlatformException catch (error) {
+        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+      }
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show PlatformException;
 
@@ -13,6 +14,48 @@ import 'in_app_webview_windows_controller.dart';
 bool isEnvironmentAlreadyInitializedError(Object error) {
   return error is PlatformException &&
       error.code == 'environment_already_initialized';
+}
+
+/// Ensures the process-wide WebView2 environment exists.
+///
+/// Calls [WebviewController.initializeEnvironment] with [args] when no
+/// environment has been created yet. The environment can only be created once
+/// per process, so when an earlier WebView already initialized it the platform
+/// reports a [PlatformException] with code `environment_already_initialized`;
+/// that is a benign signal that reuse succeeded and is swallowed here. Every
+/// other error is rethrown so real failures (for example
+/// `environment_creation_failed`) still surface.
+///
+/// Extracted from `initPlatformState` so the reuse logic is unit-testable
+/// against a mocked `webview_windows` method channel without booting a real
+/// WebView2 runtime.
+@visibleForTesting
+Future<void> ensureWebView2Environment(WebViewEnvironmentInitArgs args) async {
+  try {
+    await WebviewController.initializeEnvironment(
+      userDataPath: args.userDataPath,
+      browserExePath: args.browserExePath,
+      additionalArguments: args.additionalArguments,
+    );
+  } on PlatformException catch (error) {
+    if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+
+    // The process-wide environment already exists, so this WebView runs under
+    // whatever environment the first WebView created. Any configuration
+    // supplied here may therefore be ignored. Surface it in debug builds so
+    // divergent configurations are discoverable during development.
+    if (kDebugMode) {
+      debugPrint(
+        'WebView2 environment was already initialized and is being reused. '
+        'Environment settings supplied to this WebView '
+        '(userDataPath: ${args.userDataPath}, '
+        'browserExePath: ${args.browserExePath}, '
+        'additionalArguments: ${args.additionalArguments}) may not take '
+        'effect because the process-wide environment is controlled by the '
+        'first WebView that initialized it.',
+      );
+    }
+  }
 }
 
 class _VirtualHostMappingInfo {
@@ -108,15 +151,7 @@ class _InAppWebViewWindowsWidgetStateImpl
       // The WebView2 environment is shared by all controllers and can only be
       // initialized once. Reusing it is valid when another WebView already
       // initialized the process-wide environment.
-      try {
-        await WebviewController.initializeEnvironment(
-          userDataPath: args.userDataPath,
-          browserExePath: args.browserExePath,
-          additionalArguments: args.additionalArguments,
-        );
-      } on PlatformException catch (error) {
-        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
-      }
+      await ensureWebView2Environment(args);
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,9 +1,11 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const defaultFolder = '/tmp/default-zikzak-webview2-data';
 
   group('WebView2 environment initialization', () {
@@ -23,6 +25,97 @@ void main() {
         ),
         isFalse,
       );
+    });
+
+    test('does not treat non-platform errors as reuse', () {
+      expect(isEnvironmentAlreadyInitializedError(StateError('x')), isFalse);
+    });
+  });
+
+  group('ensureWebView2Environment', () {
+    // The webview_windows package routes every controller call through a
+    // single process-wide method channel. Mocking it lets the tests exercise
+    // the real reuse wiring without booting a WebView2 runtime.
+    const channel = MethodChannel('io.jns.webview.win');
+
+    void mockEnvironment({required Object? Function() onInitialize}) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            expect(call.method, 'initializeEnvironment');
+            return onInitialize();
+          });
+    }
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('initializes when no environment exists', () async {
+      var invoked = false;
+      mockEnvironment(onInitialize: () => invoked = true);
+
+      await ensureWebView2Environment(
+        WebViewEnvironmentInitArgs(userDataPath: defaultFolder),
+      );
+
+      expect(invoked, isTrue);
+    });
+
+    test('reuses an already-initialized environment', () async {
+      mockEnvironment(
+        onInitialize: () =>
+            throw PlatformException(code: 'environment_already_initialized'),
+      );
+
+      await expectLater(
+        ensureWebView2Environment(
+          WebViewEnvironmentInitArgs(userDataPath: defaultFolder),
+        ),
+        completes,
+      );
+    });
+
+    test('rethrows unrelated platform errors', () async {
+      mockEnvironment(
+        onInitialize: () =>
+            throw PlatformException(code: 'environment_creation_failed'),
+      );
+
+      await expectLater(
+        ensureWebView2Environment(
+          WebViewEnvironmentInitArgs(userDataPath: defaultFolder),
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'environment_creation_failed',
+          ),
+        ),
+      );
+    });
+
+    test('forwards the resolved args to the platform channel', () async {
+      Map<String, dynamic>? received;
+      mockEnvironment(onInitialize: () => null);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            received = Map<String, dynamic>.from(call.arguments as Map);
+            return null;
+          });
+
+      await ensureWebView2Environment(
+        WebViewEnvironmentInitArgs(
+          userDataPath: 'D:/appdata/wbv2',
+          browserExePath: 'C:/wbv2/fixed',
+          additionalArguments: '--disable-web-security',
+        ),
+      );
+
+      expect(received?['userDataPath'], 'D:/appdata/wbv2');
+      expect(received?['browserExePath'], 'C:/wbv2/fixed');
+      expect(received?['additionalArguments'], '--disable-web-security');
     });
   });
 

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,9 +1,30 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
 
 void main() {
   const defaultFolder = '/tmp/default-zikzak-webview2-data';
+
+  group('WebView2 environment initialization', () {
+    test('recognizes an already initialized environment', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'environment_already_initialized'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not swallow unrelated platform errors', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'other_error'),
+        ),
+        isFalse,
+      );
+    });
+  });
 
   group('resolveEnvironmentInitArgs', () {
     group('issue #178 regression — additionalBrowserArguments', () {
@@ -20,7 +41,8 @@ void main() {
           // `WebViewEnvironmentInitArgs.additionalArguments` so the
           // caller can forward it to
           // `WebviewController.initializeEnvironment(additionalArguments:)`.
-          const args = '--disable-web-security '
+          const args =
+              '--disable-web-security '
               '--allow-running-insecure-content '
               '--use-fake-ui-for-media-stream '
               '--use-fake-device-for-media-stream';
@@ -100,20 +122,23 @@ void main() {
       expect(resolved.additionalArguments, isNull);
     });
 
-    test('defaultUserDataFolder is NOT invoked when settings.userDataFolder is set', () {
-      var defaultInvoked = 0;
-      resolveEnvironmentInitArgs(
-        settings: WebViewEnvironmentSettings(
-          userDataFolder: '/tmp/explicit',
-          additionalBrowserArguments: '--disable-web-security',
-        ),
-        defaultUserDataFolder: () {
-          defaultInvoked++;
-          return defaultFolder;
-        },
-      );
+    test(
+      'defaultUserDataFolder is NOT invoked when settings.userDataFolder is set',
+      () {
+        var defaultInvoked = 0;
+        resolveEnvironmentInitArgs(
+          settings: WebViewEnvironmentSettings(
+            userDataFolder: '/tmp/explicit',
+            additionalBrowserArguments: '--disable-web-security',
+          ),
+          defaultUserDataFolder: () {
+            defaultInvoked++;
+            return defaultFolder;
+          },
+        );
 
-      expect(defaultInvoked, 0);
-    });
+        expect(defaultInvoked, 0);
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- reuse WebView2's process-wide environment across WebView widgets
- ignore only environment_already_initialized
- preserve unrelated initialization failures
- add focused regression coverage

## Reproduction
1. Open and close one Windows InAppWebView.
2. Open a second InAppWebView in the same process.
3. The second view stalls after PlatformException(environment_already_initialized).

## Tests
- flutter test test/in_app_webview_windows_environment_args_test.dart