### PR TITLE
fix(windows): forward WebView load lifecycle events

### DIFF
--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -163,6 +163,8 @@ class _InAppWebViewWindowsWidgetStateImpl
         controllerParams,
         _controller,
       );
+      final callbackController =
+          widget.params.controllerFromPlatform?.call(controller) ?? controller;
 
       // Apply virtual host mappings from the environment settings. Each
       // mapping serves a local folder at https://<hostName>/ and bypasses
@@ -208,12 +210,12 @@ class _InAppWebViewWindowsWidgetStateImpl
         final url = currentUrl == null ? null : WebUri(currentUrl!);
         switch (state) {
           case LoadingState.loading:
-            widget.params.onProgressChanged?.call(controller, 0);
-            widget.params.onLoadStart?.call(controller, url);
+            widget.params.onProgressChanged?.call(callbackController, 0);
+            widget.params.onLoadStart?.call(callbackController, url);
             break;
           case LoadingState.navigationCompleted:
-            widget.params.onProgressChanged?.call(controller, 100);
-            widget.params.onLoadStop?.call(controller, url);
+            widget.params.onProgressChanged?.call(callbackController, 100);
+            widget.params.onLoadStop?.call(callbackController, url);
             break;
           case LoadingState.none:
             break;
@@ -233,9 +235,7 @@ class _InAppWebViewWindowsWidgetStateImpl
       }
 
       if (widget.params.onWebViewCreated != null) {
-        widget.params.onWebViewCreated!(
-          widget.params.controllerFromPlatform!(controller),
-        );
+        widget.params.onWebViewCreated!(callbackController);
       }
     } catch (e) {
       print("Failed to initialize webview: $e");

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -155,6 +155,15 @@ class _InAppWebViewWindowsWidgetStateImpl
 
       await _controller.initialize();
 
+      final controllerParams = PlatformInAppWebViewControllerCreationParams(
+        id: widget.params.windowId,
+        webviewParams: widget.params,
+      );
+      final controller = InAppWebViewWindowsController(
+        controllerParams,
+        _controller,
+      );
+
       // Apply virtual host mappings from the environment settings. Each
       // mapping serves a local folder at https://<hostName>/ and bypasses
       // CORS for those resources when the access kind is allowCors.
@@ -192,15 +201,22 @@ class _InAppWebViewWindowsWidgetStateImpl
       }
 
       // Setup listeners
-      _controller.url.listen((url) {
-        // TODO: handle url change
-      });
+      String? currentUrl;
+      _controller.url.listen((url) => currentUrl = url);
 
       _controller.loadingState.listen((state) {
-        if (state == LoadingState.navigationCompleted) {
-          // TODO: handle load stop
-        } else if (state == LoadingState.loading) {
-          // TODO: handle load start
+        final url = currentUrl == null ? null : WebUri(currentUrl!);
+        switch (state) {
+          case LoadingState.loading:
+            widget.params.onProgressChanged?.call(controller, 0);
+            widget.params.onLoadStart?.call(controller, url);
+            break;
+          case LoadingState.navigationCompleted:
+            widget.params.onProgressChanged?.call(controller, 100);
+            widget.params.onLoadStop?.call(controller, url);
+            break;
+          case LoadingState.none:
+            break;
         }
       });
 
@@ -215,17 +231,6 @@ class _InAppWebViewWindowsWidgetStateImpl
           widget.params.initialUrlRequest!.url.toString(),
         );
       }
-
-      // Create controller
-      final controllerParams = PlatformInAppWebViewControllerCreationParams(
-        id: widget.params.windowId,
-        webviewParams: widget.params,
-      );
-
-      final controller = InAppWebViewWindowsController(
-        controllerParams,
-        _controller,
-      );
 
       if (widget.params.onWebViewCreated != null) {
         widget.params.onWebViewCreated!(

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
 
 import 'package:path_provider/path_provider.dart';
 import 'package:webview_windows/webview_windows.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 import 'in_app_webview_windows_controller.dart';
+
+bool isEnvironmentAlreadyInitializedError(Object error) {
+  return error is PlatformException &&
+      error.code == 'environment_already_initialized';
+}
 
 class _VirtualHostMappingInfo {
   final String folderPath;
@@ -99,12 +105,18 @@ class _InAppWebViewWindowsWidgetStateImpl
         defaultUserDataFolder: () => defaultUserDataFolder,
       );
 
-      // Initialize the shared WebView2 environment with the resolved args.
-      await WebviewController.initializeEnvironment(
-        userDataPath: args.userDataPath,
-        browserExePath: args.browserExePath,
-        additionalArguments: args.additionalArguments,
-      );
+      // The WebView2 environment is shared by all controllers and can only be
+      // initialized once. Reusing it is valid when another WebView already
+      // initialized the process-wide environment.
+      try {
+        await WebviewController.initializeEnvironment(
+          userDataPath: args.userDataPath,
+          browserExePath: args.browserExePath,
+          additionalArguments: args.additionalArguments,
+        );
+      } on PlatformException catch (error) {
+        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+      }
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show PlatformException;
 
@@ -13,6 +14,48 @@ import 'in_app_webview_windows_controller.dart';
 bool isEnvironmentAlreadyInitializedError(Object error) {
   return error is PlatformException &&
       error.code == 'environment_already_initialized';
+}
+
+/// Ensures the process-wide WebView2 environment exists.
+///
+/// Calls [WebviewController.initializeEnvironment] with [args] when no
+/// environment has been created yet. The environment can only be created once
+/// per process, so when an earlier WebView already initialized it the platform
+/// reports a [PlatformException] with code `environment_already_initialized`;
+/// that is a benign signal that reuse succeeded and is swallowed here. Every
+/// other error is rethrown so real failures (for example
+/// `environment_creation_failed`) still surface.
+///
+/// Extracted from `initPlatformState` so the reuse logic is unit-testable
+/// against a mocked `webview_windows` method channel without booting a real
+/// WebView2 runtime.
+@visibleForTesting
+Future<void> ensureWebView2Environment(WebViewEnvironmentInitArgs args) async {
+  try {
+    await WebviewController.initializeEnvironment(
+      userDataPath: args.userDataPath,
+      browserExePath: args.browserExePath,
+      additionalArguments: args.additionalArguments,
+    );
+  } on PlatformException catch (error) {
+    if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+
+    // The process-wide environment already exists, so this WebView runs under
+    // whatever environment the first WebView created. Any configuration
+    // supplied here may therefore be ignored. Surface it in debug builds so
+    // divergent configurations are discoverable during development.
+    if (kDebugMode) {
+      debugPrint(
+        'WebView2 environment was already initialized and is being reused. '
+        'Environment settings supplied to this WebView '
+        '(userDataPath: ${args.userDataPath}, '
+        'browserExePath: ${args.browserExePath}, '
+        'additionalArguments: ${args.additionalArguments}) may not take '
+        'effect because the process-wide environment is controlled by the '
+        'first WebView that initialized it.',
+      );
+    }
+  }
 }
 
 class _VirtualHostMappingInfo {
@@ -108,15 +151,7 @@ class _InAppWebViewWindowsWidgetStateImpl
       // The WebView2 environment is shared by all controllers and can only be
       // initialized once. Reusing it is valid when another WebView already
       // initialized the process-wide environment.
-      try {
-        await WebviewController.initializeEnvironment(
-          userDataPath: args.userDataPath,
-          browserExePath: args.browserExePath,
-          additionalArguments: args.additionalArguments,
-        );
-      } on PlatformException catch (error) {
-        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
-      }
+      await ensureWebView2Environment(args);
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -58,6 +58,44 @@ Future<void> ensureWebView2Environment(WebViewEnvironmentInitArgs args) async {
   }
 }
 
+/// Maps a [LoadingState] transition from `webview_windows` onto the plugin's
+/// load callbacks.
+///
+/// `webview_windows` reports load progress through a single [LoadingState]
+/// stream. This translates it onto the equivalent `zikzak_inappwebview`
+/// callbacks:
+/// - [LoadingState.loading] → `onProgressChanged(0)` and `onLoadStart`
+/// - [LoadingState.navigationCompleted] → `onProgressChanged(100)` and
+///   `onLoadStop`
+/// - [LoadingState.none] → no callback
+///
+/// [url] is the URL last reported on the separate `url` stream; it may be
+/// `null` (or stale) because URL changes and load-state changes arrive on two
+/// independent native event channels whose relative ordering is not
+/// guaranteed.
+///
+/// Extracted as a pure function so the state→callback mapping can be
+/// unit-tested without booting a WebView2 runtime.
+@visibleForTesting
+void dispatchLoadingState(
+  LoadingState state, {
+  required WebUri? url,
+  void Function(int progress)? onProgressChanged,
+  void Function(WebUri? url)? onLoadStart,
+  void Function(WebUri? url)? onLoadStop,
+}) {
+  switch (state) {
+    case LoadingState.loading:
+      onProgressChanged?.call(0);
+      onLoadStart?.call(url);
+    case LoadingState.navigationCompleted:
+      onProgressChanged?.call(100);
+      onLoadStop?.call(url);
+    case LoadingState.none:
+      break;
+  }
+}
+
 class _VirtualHostMappingInfo {
   final String folderPath;
   final int accessKind;
@@ -105,6 +143,10 @@ class _InAppWebViewWindowsWidgetStateImpl
     extends State<_InAppWebViewWindowsWidgetState> {
   final _controller = WebviewController();
   bool _isInitialized = false;
+
+  String? _currentUrl;
+  StreamSubscription<String>? _urlSubscription;
+  StreamSubscription<LoadingState>? _loadingStateSubscription;
 
   @override
   void initState() {
@@ -163,8 +205,21 @@ class _InAppWebViewWindowsWidgetStateImpl
         controllerParams,
         _controller,
       );
+      // The widget wrapper installs `controllerFromPlatform` in every current
+      // call path, but the `?? controller` fallback intentionally keeps
+      // initialization working (with the raw controller) instead of crashing
+      // if a caller ever omits it.
       final callbackController =
           widget.params.controllerFromPlatform?.call(controller) ?? controller;
+
+      // Deliver onWebViewCreated before wiring load listeners and starting the
+      // initial navigation. Otherwise load events for the initial page could
+      // reach consumers before they receive the controller, which violates the
+      // documented contract that onWebViewCreated fires first on every
+      // platform.
+      if (widget.params.onWebViewCreated != null) {
+        widget.params.onWebViewCreated!(callbackController);
+      }
 
       // Apply virtual host mappings from the environment settings. Each
       // mapping serves a local folder at https://<hostName>/ and bypasses
@@ -202,24 +257,32 @@ class _InAppWebViewWindowsWidgetStateImpl
         }
       }
 
-      // Setup listeners
-      String? currentUrl;
-      _controller.url.listen((url) => currentUrl = url);
+      // Setup listeners. The subscriptions are stored so they can be
+      // cancelled in dispose(); `webview_windows` does not close its stream
+      // controllers on dispose, so without this events could still be
+      // delivered after the widget is unmounted.
+      //
+      // `urlChanged` and `loadingStateChanged` arrive on two separate stream
+      // controllers fed by the same native event channel, so their relative
+      // ordering is not guaranteed. `onLoadStart` may therefore legitimately
+      // carry a null or stale URL when the URL event has not landed yet.
+      _urlSubscription = _controller.url.listen((url) {
+        _currentUrl = url;
+      });
 
-      _controller.loadingState.listen((state) {
-        final url = currentUrl == null ? null : WebUri(currentUrl!);
-        switch (state) {
-          case LoadingState.loading:
-            widget.params.onProgressChanged?.call(callbackController, 0);
-            widget.params.onLoadStart?.call(callbackController, url);
-            break;
-          case LoadingState.navigationCompleted:
-            widget.params.onProgressChanged?.call(callbackController, 100);
-            widget.params.onLoadStop?.call(callbackController, url);
-            break;
-          case LoadingState.none:
-            break;
-        }
+      _loadingStateSubscription = _controller.loadingState.listen((state) {
+        if (!mounted) return;
+        final url = _currentUrl == null ? null : WebUri(_currentUrl!);
+        dispatchLoadingState(
+          state,
+          url: url,
+          onProgressChanged: (progress) => widget.params.onProgressChanged
+              ?.call(callbackController, progress),
+          onLoadStart: (url) =>
+              widget.params.onLoadStart?.call(callbackController, url),
+          onLoadStop: (url) =>
+              widget.params.onLoadStop?.call(callbackController, url),
+        );
       });
 
       if (!mounted) return;
@@ -232,10 +295,6 @@ class _InAppWebViewWindowsWidgetStateImpl
         await _controller.loadUrl(
           widget.params.initialUrlRequest!.url.toString(),
         );
-      }
-
-      if (widget.params.onWebViewCreated != null) {
-        widget.params.onWebViewCreated!(callbackController);
       }
     } catch (e) {
       print("Failed to initialize webview: $e");
@@ -251,6 +310,12 @@ class _InAppWebViewWindowsWidgetStateImpl
 
   @override
   void dispose() {
+    // Cancel the load-event subscriptions before disposing the controller.
+    // The upstream controller does not close its stream controllers, so
+    // cancelling here prevents in-flight events from invoking user callbacks
+    // after the widget has been unmounted.
+    _urlSubscription?.cancel();
+    _loadingStateSubscription?.cancel();
     _controller.dispose();
     super.dispose();
   }

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,9 +1,11 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   const defaultFolder = '/tmp/default-zikzak-webview2-data';
 
   group('WebView2 environment initialization', () {
@@ -23,6 +25,97 @@ void main() {
         ),
         isFalse,
       );
+    });
+
+    test('does not treat non-platform errors as reuse', () {
+      expect(isEnvironmentAlreadyInitializedError(StateError('x')), isFalse);
+    });
+  });
+
+  group('ensureWebView2Environment', () {
+    // The webview_windows package routes every controller call through a
+    // single process-wide method channel. Mocking it lets the tests exercise
+    // the real reuse wiring without booting a WebView2 runtime.
+    const channel = MethodChannel('io.jns.webview.win');
+
+    void mockEnvironment({required Object? Function() onInitialize}) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            expect(call.method, 'initializeEnvironment');
+            return onInitialize();
+          });
+    }
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+
+    test('initializes when no environment exists', () async {
+      var invoked = false;
+      mockEnvironment(onInitialize: () => invoked = true);
+
+      await ensureWebView2Environment(
+        WebViewEnvironmentInitArgs(userDataPath: defaultFolder),
+      );
+
+      expect(invoked, isTrue);
+    });
+
+    test('reuses an already-initialized environment', () async {
+      mockEnvironment(
+        onInitialize: () =>
+            throw PlatformException(code: 'environment_already_initialized'),
+      );
+
+      await expectLater(
+        ensureWebView2Environment(
+          WebViewEnvironmentInitArgs(userDataPath: defaultFolder),
+        ),
+        completes,
+      );
+    });
+
+    test('rethrows unrelated platform errors', () async {
+      mockEnvironment(
+        onInitialize: () =>
+            throw PlatformException(code: 'environment_creation_failed'),
+      );
+
+      await expectLater(
+        ensureWebView2Environment(
+          WebViewEnvironmentInitArgs(userDataPath: defaultFolder),
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'environment_creation_failed',
+          ),
+        ),
+      );
+    });
+
+    test('forwards the resolved args to the platform channel', () async {
+      Map<String, dynamic>? received;
+      mockEnvironment(onInitialize: () => null);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+            received = Map<String, dynamic>.from(call.arguments as Map);
+            return null;
+          });
+
+      await ensureWebView2Environment(
+        WebViewEnvironmentInitArgs(
+          userDataPath: 'D:/appdata/wbv2',
+          browserExePath: 'C:/wbv2/fixed',
+          additionalArguments: '--disable-web-security',
+        ),
+      );
+
+      expect(received?['userDataPath'], 'D:/appdata/wbv2');
+      expect(received?['browserExePath'], 'C:/wbv2/fixed');
+      expect(received?['additionalArguments'], '--disable-web-security');
     });
   });
 

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,9 +1,30 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
 
 void main() {
   const defaultFolder = '/tmp/default-zikzak-webview2-data';
+
+  group('WebView2 environment initialization', () {
+    test('recognizes an already initialized environment', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'environment_already_initialized'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not swallow unrelated platform errors', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'other_error'),
+        ),
+        isFalse,
+      );
+    });
+  });
 
   group('resolveEnvironmentInitArgs', () {
     group('issue #178 regression — additionalBrowserArguments', () {
@@ -20,7 +41,8 @@ void main() {
           // `WebViewEnvironmentInitArgs.additionalArguments` so the
           // caller can forward it to
           // `WebviewController.initializeEnvironment(additionalArguments:)`.
-          const args = '--disable-web-security '
+          const args =
+              '--disable-web-security '
               '--allow-running-insecure-content '
               '--use-fake-ui-for-media-stream '
               '--use-fake-device-for-media-stream';
@@ -100,20 +122,23 @@ void main() {
       expect(resolved.additionalArguments, isNull);
     });
 
-    test('defaultUserDataFolder is NOT invoked when settings.userDataFolder is set', () {
-      var defaultInvoked = 0;
-      resolveEnvironmentInitArgs(
-        settings: WebViewEnvironmentSettings(
-          userDataFolder: '/tmp/explicit',
-          additionalBrowserArguments: '--disable-web-security',
-        ),
-        defaultUserDataFolder: () {
-          defaultInvoked++;
-          return defaultFolder;
-        },
-      );
+    test(
+      'defaultUserDataFolder is NOT invoked when settings.userDataFolder is set',
+      () {
+        var defaultInvoked = 0;
+        resolveEnvironmentInitArgs(
+          settings: WebViewEnvironmentSettings(
+            userDataFolder: '/tmp/explicit',
+            additionalBrowserArguments: '--disable-web-security',
+          ),
+          defaultUserDataFolder: () {
+            defaultInvoked++;
+            return defaultFolder;
+          },
+        );
 
-      expect(defaultInvoked, 0);
-    });
+        expect(defaultInvoked, 0);
+      },
+    );
   });
 }

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_loading_state_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_loading_state_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_windows/webview_windows.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
+
+void main() {
+  group('dispatchLoadingState', () {
+    test('loading fires progress 0 and onLoadStart with the current url', () {
+      final progresses = <int>[];
+      final starts = <WebUri?>[];
+      final stops = <WebUri?>[];
+      final url = WebUri('https://example.com/');
+
+      dispatchLoadingState(
+        LoadingState.loading,
+        url: url,
+        onProgressChanged: progresses.add,
+        onLoadStart: starts.add,
+        onLoadStop: stops.add,
+      );
+
+      expect(progresses, [0]);
+      expect(starts, [url]);
+      expect(stops, isEmpty);
+    });
+
+    test(
+      'navigationCompleted fires progress 100 and onLoadStop with the url',
+      () {
+        final progresses = <int>[];
+        final starts = <WebUri?>[];
+        final stops = <WebUri?>[];
+        final url = WebUri('https://example.com/');
+
+        dispatchLoadingState(
+          LoadingState.navigationCompleted,
+          url: url,
+          onProgressChanged: progresses.add,
+          onLoadStart: starts.add,
+          onLoadStop: stops.add,
+        );
+
+        expect(progresses, [100]);
+        expect(starts, isEmpty);
+        expect(stops, [url]);
+      },
+    );
+
+    test('none fires no callbacks', () {
+      final progresses = <int>[];
+      final starts = <WebUri?>[];
+      final stops = <WebUri?>[];
+
+      dispatchLoadingState(
+        LoadingState.none,
+        url: WebUri('https://example.com/'),
+        onProgressChanged: progresses.add,
+        onLoadStart: starts.add,
+        onLoadStop: stops.add,
+      );
+
+      expect(progresses, isEmpty);
+      expect(starts, isEmpty);
+      expect(stops, isEmpty);
+    });
+
+    test('forwards a null url when the url stream has not landed yet', () {
+      final progresses = <int>[];
+      final starts = <WebUri?>[];
+      var startCalled = false;
+
+      dispatchLoadingState(
+        LoadingState.loading,
+        url: null,
+        onProgressChanged: progresses.add,
+        onLoadStart: (url) {
+          startCalled = true;
+          starts.add(url);
+        },
+      );
+
+      expect(progresses, [0]);
+      expect(startCalled, isTrue);
+      expect(starts, [null]);
+    });
+
+    test('absent callbacks are tolerated', () {
+      expect(
+        () => dispatchLoadingState(LoadingState.loading, url: null),
+        returnsNormally,
+      );
+      expect(
+        () => dispatchLoadingState(
+          LoadingState.navigationCompleted,
+          url: WebUri('https://example.com/'),
+        ),
+        returnsNormally,
+      );
+      expect(
+        () => dispatchLoadingState(LoadingState.none, url: null),
+        returnsNormally,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- map webview_windows loading to onLoadStart
- map navigationCompleted to onLoadStop
- emit matching 0/100 progress callbacks

## Reproduction
Windows InAppWebView currently subscribes to WebviewController.loadingState but leaves both branches as TODO, so consumers never receive onLoadStart/onLoadStop and loading overlays remain visible after content renders.

## Tests
- flutter analyze lib/src/in_app_webview_windows_platform.dart
- flutter test test/in_app_webview_windows_environment_args_test.dart