### PR TITLE
review(300): make WebView2 environment reuse observable and regression-tested

### DIFF
--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart'
+    show debugPrint, kDebugMode, visibleForTesting;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show PlatformException;
 
@@ -13,6 +15,37 @@ import 'in_app_webview_windows_controller.dart';
 bool isEnvironmentAlreadyInitializedError(Object error) {
   return error is PlatformException &&
       error.code == 'environment_already_initialized';
+}
+
+/// Initializes the shared WebView2 environment, tolerating an environment
+/// that another WebView already created.
+///
+/// The WebView2 environment is process-wide and immutable: once some other
+/// WebView has created it, this WebView reuses it and its own requested
+/// args (user-data folder, browser executable, additional arguments) are
+/// NOT applied — a `debugPrint` in debug builds surfaces that divergence.
+/// Any other [PlatformException] is rethrown: only
+/// `environment_already_initialized` is safe to ignore.
+@visibleForTesting
+Future<void> ensureWebView2Environment(WebViewEnvironmentInitArgs args) async {
+  try {
+    await WebviewController.initializeEnvironment(
+      userDataPath: args.userDataPath,
+      browserExePath: args.browserExePath,
+      additionalArguments: args.additionalArguments,
+    );
+  } on PlatformException catch (error) {
+    if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+    if (kDebugMode) {
+      debugPrint(
+        'zikzak_inappwebview_windows: WebView2 environment already initialized '
+        'by another WebView; reusing it. Requested args were NOT applied '
+        '(userDataPath: ${args.userDataPath}, browserExePath: '
+        '${args.browserExePath}, additionalArguments: '
+        '${args.additionalArguments}).',
+      );
+    }
+  }
 }
 
 class _VirtualHostMappingInfo {
@@ -107,16 +140,8 @@ class _InAppWebViewWindowsWidgetStateImpl
 
       // The WebView2 environment is shared by all controllers and can only be
       // initialized once. Reusing it is valid when another WebView already
-      // initialized the process-wide environment.
-      try {
-        await WebviewController.initializeEnvironment(
-          userDataPath: args.userDataPath,
-          browserExePath: args.browserExePath,
-          additionalArguments: args.additionalArguments,
-        );
-      } on PlatformException catch (error) {
-        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
-      }
+      // initialized the process-wide environment; any other failure rethrows.
+      await ensureWebView2Environment(args);
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
+++ b/zikzak_inappwebview_windows/lib/src/in_app_webview_windows_platform.dart
@@ -2,12 +2,18 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show PlatformException;
 
 import 'package:path_provider/path_provider.dart';
 import 'package:webview_windows/webview_windows.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 
 import 'in_app_webview_windows_controller.dart';
+
+bool isEnvironmentAlreadyInitializedError(Object error) {
+  return error is PlatformException &&
+      error.code == 'environment_already_initialized';
+}
 
 class _VirtualHostMappingInfo {
   final String folderPath;
@@ -99,12 +105,18 @@ class _InAppWebViewWindowsWidgetStateImpl
         defaultUserDataFolder: () => defaultUserDataFolder,
       );
 
-      // Initialize the shared WebView2 environment with the resolved args.
-      await WebviewController.initializeEnvironment(
-        userDataPath: args.userDataPath,
-        browserExePath: args.browserExePath,
-        additionalArguments: args.additionalArguments,
-      );
+      // The WebView2 environment is shared by all controllers and can only be
+      // initialized once. Reusing it is valid when another WebView already
+      // initialized the process-wide environment.
+      try {
+        await WebviewController.initializeEnvironment(
+          userDataPath: args.userDataPath,
+          browserExePath: args.browserExePath,
+          additionalArguments: args.additionalArguments,
+        );
+      } on PlatformException catch (error) {
+        if (!isEnvironmentAlreadyInitializedError(error)) rethrow;
+      }
 
       await _controller.initialize();
 

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_controller_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_controller_test.dart
@@ -48,10 +48,7 @@ void main() {
       final controller = _buildController();
       addTearDown(controller.dispose);
 
-      expect(
-        controller.hasJavaScriptHandler(handlerName: 'missing'),
-        false,
-      );
+      expect(controller.hasJavaScriptHandler(handlerName: 'missing'), false);
     });
   });
 
@@ -61,10 +58,7 @@ void main() {
       addTearDown(controller.dispose);
 
       dynamic received(List<dynamic> args) => 'pong';
-      controller.addJavaScriptHandler(
-        handlerName: 'ping',
-        callback: received,
-      );
+      controller.addJavaScriptHandler(handlerName: 'ping', callback: received);
 
       final removed = controller.removeJavaScriptHandler(handlerName: 'ping');
       expect(identical(removed, received), true);

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -1,9 +1,30 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
 import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
 import 'package:zikzak_inappwebview_windows/src/in_app_webview_windows_platform.dart';
 
 void main() {
   const defaultFolder = '/tmp/default-zikzak-webview2-data';
+
+  group('WebView2 environment initialization', () {
+    test('recognizes an already initialized environment', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'environment_already_initialized'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('does not swallow unrelated platform errors', () {
+      expect(
+        isEnvironmentAlreadyInitializedError(
+          PlatformException(code: 'other_error'),
+        ),
+        isFalse,
+      );
+    });
+  });
 
   group('resolveEnvironmentInitArgs', () {
     group('issue #178 regression — additionalBrowserArguments', () {
@@ -20,7 +41,8 @@ void main() {
           // `WebViewEnvironmentInitArgs.additionalArguments` so the
           // caller can forward it to
           // `WebviewController.initializeEnvironment(additionalArguments:)`.
-          const args = '--disable-web-security '
+          const args =
+              '--disable-web-security '
               '--allow-running-insecure-content '
               '--use-fake-ui-for-media-stream '
               '--use-fake-device-for-media-stream';
@@ -100,20 +122,23 @@ void main() {
       expect(resolved.additionalArguments, isNull);
     });
 
-    test('defaultUserDataFolder is NOT invoked when settings.userDataFolder is set', () {
-      var defaultInvoked = 0;
-      resolveEnvironmentInitArgs(
-        settings: WebViewEnvironmentSettings(
-          userDataFolder: '/tmp/explicit',
-          additionalBrowserArguments: '--disable-web-security',
-        ),
-        defaultUserDataFolder: () {
-          defaultInvoked++;
-          return defaultFolder;
-        },
-      );
+    test(
+      'defaultUserDataFolder is NOT invoked when settings.userDataFolder is set',
+      () {
+        var defaultInvoked = 0;
+        resolveEnvironmentInitArgs(
+          settings: WebViewEnvironmentSettings(
+            userDataFolder: '/tmp/explicit',
+            additionalBrowserArguments: '--disable-web-security',
+          ),
+          defaultUserDataFolder: () {
+            defaultInvoked++;
+            return defaultFolder;
+          },
+        );
 
-      expect(defaultInvoked, 0);
-    });
+        expect(defaultInvoked, 0);
+      },
+    );
   });
 }

--- a/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
+++ b/zikzak_inappwebview_windows/test/in_app_webview_windows_environment_args_test.dart
@@ -24,6 +24,69 @@ void main() {
         isFalse,
       );
     });
+
+    test('does not match non-PlatformException errors', () {
+      expect(isEnvironmentAlreadyInitializedError(StateError('boom')), isFalse);
+    });
+  });
+
+  group('ensureWebView2Environment (reuse wiring)', () {
+    const pluginChannel = MethodChannel('io.jns.webview.win');
+
+    tearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pluginChannel, null);
+    });
+
+    test('completes silently when the environment is already initialized '
+        '(reuse path)', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      var initializeCalls = 0;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pluginChannel, (call) async {
+            if (call.method == 'initializeEnvironment') {
+              initializeCalls++;
+              throw PlatformException(code: 'environment_already_initialized');
+            }
+            return null;
+          });
+
+      await ensureWebView2Environment(
+        const WebViewEnvironmentInitArgs(userDataPath: '/tmp/reuse-test'),
+      );
+
+      expect(
+        initializeCalls,
+        1,
+        reason:
+            'the upstream initializeEnvironment must still be attempted '
+            'exactly once before the reuse decision',
+      );
+    });
+
+    test('rethrows unrelated platform errors', () async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(pluginChannel, (call) async {
+            if (call.method == 'initializeEnvironment') {
+              throw PlatformException(code: 'environment_creation_failed');
+            }
+            return null;
+          });
+
+      await expectLater(
+        ensureWebView2Environment(
+          const WebViewEnvironmentInitArgs(userDataPath: '/tmp/rethrow-test'),
+        ),
+        throwsA(
+          isA<PlatformException>().having(
+            (e) => e.code,
+            'code',
+            'environment_creation_failed',
+          ),
+        ),
+      );
+    });
   });
 
   group('resolveEnvironmentInitArgs', () {

--- a/zikzak_inappwebview_windows/test/screenshot_pdf_delegation_test.dart
+++ b/zikzak_inappwebview_windows/test/screenshot_pdf_delegation_test.dart
@@ -26,10 +26,7 @@ void main() {
 
       // takeScreenshot on Windows is a stub: it must complete and return null
       // rather than throw (regression guard against issue #177-style gaps).
-      await expectLater(
-        controller.takeScreenshot(),
-        completion(isNull),
-      );
+      await expectLater(controller.takeScreenshot(), completion(isNull));
     });
   });
 }


### PR DESCRIPTION
## Summary
Companion/alternative to **#300** (`fix(windows): reuse initialized WebView2 environment` by @HsukqiLee). The detailed review is posted on #300: the approach and the `environment_already_initialized` code are **verified correct** against `webview_windows 0.4.0` native source (`windows/webview_windows_plugin.cc:31`). This PR carries #300's commit plus the review fixes, so it can be merged as-is — or the original author can cherry-pick/merge this branch into `fix/windows-reuse-webview-environment-only`.

## Review fixes on top of #300
- **Testable seam (MED from review):** extracted `@visibleForTesting ensureWebView2Environment(WebViewEnvironmentInitArgs args)`; the widget now calls it. Previously deleting the `try/catch` kept the suite green — now the reuse path *is* the tested production path.
- **Observable divergence (MED from review):** when the environment is reused, the second WebView silently runs under the *first* environment's `userDataPath`/`browserExePath`/`additionalArguments` (process-wide, immutable). A `kDebugMode`-guarded `debugPrint` now reports that the requested args were NOT applied.
- **New tests:** reuse path completes via mocked `io.jns.webview.win` channel (`environment_already_initialized` → silent success), unrelated codes rethrow (`environment_creation_failed`), and the predicate rejects non-`PlatformException` errors.

## Verification
- `flutter test` (zikzak_inappwebview_windows): **19 passed, 0 failed** (was 15)
- `flutter analyze`: no new issues (only the pre-existing `invalid_dependency` pubspec warning)
- `dart format lib test`: stable

Closes the actionable items of the review on #300; refs #300.