### PR TITLE
feat(macOS): add ProxyController implementation

### DIFF
--- a/zikzak_inappwebview_macos/lib/src/inappwebview_platform.dart
+++ b/zikzak_inappwebview_macos/lib/src/inappwebview_platform.dart
@@ -7,6 +7,7 @@ import 'in_app_webview/in_app_webview_controller.dart';
 import 'in_app_webview/headless_in_app_webview.dart';
 import 'in_app_browser/in_app_browser.dart';
 import 'print_job/print_job_controller.dart';
+import 'proxy_controller.dart';
 
 /// Implementation of [InAppWebViewPlatform] using the WebKit API for macOS.
 class MacOSInAppWebViewPlatform extends InAppWebViewPlatform {
@@ -72,5 +73,12 @@ class MacOSInAppWebViewPlatform extends InAppWebViewPlatform {
     PlatformPrintJobControllerCreationParams params,
   ) {
     return MacOSPrintJobController(params);
+  }
+
+  @override
+  PlatformProxyController createPlatformProxyController(
+    PlatformProxyControllerCreationParams params,
+  ) {
+    return MacOSProxyController(params);
   }
 }

--- a/zikzak_inappwebview_macos/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/proxy_controller.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/services.dart';
+import 'package:zikzak_inappwebview_platform_interface/zikzak_inappwebview_platform_interface.dart';
+
+class MacOSProxyControllerCreationParams
+    extends PlatformProxyControllerCreationParams {
+  const MacOSProxyControllerCreationParams(
+    PlatformProxyControllerCreationParams params,
+  ) : super();
+
+  factory MacOSProxyControllerCreationParams.fromPlatformProxyControllerCreationParams(
+    PlatformProxyControllerCreationParams params,
+  ) {
+    return MacOSProxyControllerCreationParams(params);
+  }
+}
+
+class MacOSProxyController extends PlatformProxyController
+    with ChannelController {
+  MacOSProxyController(PlatformProxyControllerCreationParams params)
+    : super.implementation(
+        params is MacOSProxyControllerCreationParams
+            ? params
+            : MacOSProxyControllerCreationParams
+                .fromPlatformProxyControllerCreationParams(params),
+      ) {
+    channel = const MethodChannel(
+      'wtf.zikzak/zikzak_inappwebview_proxycontroller',
+    );
+    handler = _handleMethod;
+    initMethodCallHandler();
+  }
+
+  @override
+  Future<void> setProxyOverride({required ProxySettings settings}) async {
+    final args = <String, dynamic>{};
+    args['settings'] = settings.iOSProxySettings?.toJson();
+    await channel?.invokeMethod('setProxyOverride', args);
+  }
+
+  @override
+  Future<void> clearProxyOverride() async {
+    await channel?.invokeMethod('clearProxyOverride');
+  }
+
+  Future<dynamic> _handleMethod(MethodCall call) async {}
+
+  @override
+  void dispose({bool isKeepAlive = false}) {}
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebViewFlutterPlugin.swift
@@ -7,17 +7,18 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
     var myCookieManager: MyCookieManager?
     var credentialDatabase: CredentialDatabase?
     var printJobManager: PrintJobManager?
+    var proxyManager: Any?
     var registrar: FlutterPluginRegistrar?
-    
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "dev.zuzu/zikzak_inappwebview", binaryMessenger: registrar.messenger)
         let instance = InAppWebViewFlutterPlugin()
         instance.registrar = registrar
         registrar.addMethodCallDelegate(instance, channel: channel)
-        
+
         let factory = InAppWebViewFactory(registrar: registrar, plugin: instance)
         registrar.register(factory, withId: "dev.zuzu/zikzak_inappwebview")
-        
+
         instance.headlessInAppWebViewManager = HeadlessInAppWebViewManager(registrar: registrar)
         instance.inAppBrowserManager = InAppBrowserManager(registrar: registrar)
         instance.myCookieManager = MyCookieManager(registrar: registrar)
@@ -27,6 +28,9 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
         MyCookieManager.headlessManager = instance.headlessInAppWebViewManager
         instance.credentialDatabase = CredentialDatabase(plugin: instance)
         instance.printJobManager = PrintJobManager(plugin: instance)
+        if #available(macOS 14.0, *) {
+            instance.proxyManager = ProxyManager(plugin: instance)
+        }
     }
 
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
@@ -41,5 +45,9 @@ public class InAppWebViewFlutterPlugin: NSObject, FlutterPlugin {
         credentialDatabase = nil
         printJobManager?.dispose()
         printJobManager = nil
+        if #available(macOS 14.0, *) {
+            (proxyManager as? ProxyManager)?.dispose()
+        }
+        proxyManager = nil
     }
 }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/ProxyManager.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/ProxyManager.swift
@@ -1,0 +1,208 @@
+//
+//  ProxyManager.swift
+//  zikzak_inappwebview_macos
+//
+//  macOS proxy controller using WKWebsiteDataStore.proxyConfigurations
+//  (available macOS 14.0+ / Sonoma). Mirrors the iOS ProxyManager.swift.
+//
+
+import FlutterMacOS
+import Foundation
+import Network
+import WebKit
+
+@available(macOS 14.0, *)
+public class ProxyManager: ChannelDelegate {
+    static let METHOD_CHANNEL_NAME = "wtf.zikzak/zikzak_inappwebview_proxycontroller"
+    static let DEFAULT_PROXY_SCHEME = "http"
+
+    private var plugin: InAppWebViewFlutterPlugin?
+
+    init(plugin: InAppWebViewFlutterPlugin) {
+        super.init(
+            channel: FlutterMethodChannel(
+                name: ProxyManager.METHOD_CHANNEL_NAME,
+                binaryMessenger: plugin.registrar!.messenger()))
+        self.plugin = plugin
+    }
+
+    public override func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+        let arguments = call.arguments as? [String: Any]
+        switch call.method {
+        case "setProxyOverride":
+            if let args = arguments?["settings"] as? [String: Any] {
+                let settings = ProxySettings.fromMap(args)
+                do {
+                    let proxyConfiguration = try resolveProxyConfiguration(settings)
+                    let websiteDataStore = WKWebsiteDataStore.default()
+                    websiteDataStore.proxyConfigurations = [proxyConfiguration]
+                    result(true)
+                } catch let error as ProxyConfigurationError {
+                    result(FlutterError(code: error.code, message: error.message, details: nil))
+                } catch {
+                    result(
+                        FlutterError(
+                            code: "PROXY_CONFIGURATION_ERROR",
+                            message: error.localizedDescription,
+                            details: nil))
+                }
+            } else {
+                result(false)
+            }
+        case "clearProxyOverride":
+            WKWebsiteDataStore.default().proxyConfigurations = []
+            result(true)
+        default:
+            result(FlutterMethodNotImplemented)
+        }
+    }
+
+    private func resolveProxyConfiguration(_ settings: ProxySettings) throws -> ProxyConfiguration {
+        let proxyUrl = normalizeProxyUrl(settings.proxyUrl)
+        guard let components = URLComponents(string: proxyUrl) else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+
+        let schemeType = (components.scheme ?? ProxyManager.DEFAULT_PROXY_SCHEME).uppercased()
+        guard let host = components.host, !host.isEmpty else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+        guard isValidHost(host) else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+        guard let portValue = components.port,
+            (1...65535).contains(portValue),
+            let port = NWEndpoint.Port(rawValue: UInt16(portValue))
+        else {
+            throw ProxyConfigurationError.invalidProxyUrl
+        }
+
+        let endpoint = NWEndpoint.hostPort(
+            host: NWEndpoint.Host(host), port: port)
+        let isSocksProxy = schemeType == "SOCKS" || schemeType == "SOCKS5"
+        let isHttpConnectProxy = schemeType == "HTTP" || schemeType == "HTTPS"
+
+        guard isSocksProxy || isHttpConnectProxy else {
+            throw ProxyConfigurationError.unsupportedProxyScheme
+        }
+
+        var proxyConfiguration =
+            isSocksProxy
+            ? ProxyConfiguration(socksv5Proxy: endpoint)
+            : ProxyConfiguration(httpCONNECTProxy: endpoint)
+
+        proxyConfiguration.allowFailover = settings.allowFailover
+        proxyConfiguration.excludedDomains = settings.excludedDomains
+        proxyConfiguration.matchDomains = settings.matchDomains
+        return proxyConfiguration
+    }
+
+    private func normalizeProxyUrl(_ proxyUrl: String) -> String {
+        let trimmed = proxyUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.contains("://") {
+            return trimmed
+        }
+        return "\(ProxyManager.DEFAULT_PROXY_SCHEME)://\(trimmed)"
+    }
+
+    private func isValidHost(_ host: String) -> Bool {
+        if IPv4Address(host) != nil || IPv6Address(host) != nil {
+            return true
+        }
+
+        guard
+            let asciiHost = host.applyingTransform(
+                StringTransform(rawValue: "Any-Latin; Latin-ASCII"), reverse: false),
+            !asciiHost.isEmpty,
+            asciiHost.count <= 253
+        else {
+            return false
+        }
+
+        let labels = asciiHost.split(separator: ".", omittingEmptySubsequences: false)
+        if labels.isEmpty {
+            return false
+        }
+
+        for label in labels {
+            let labelValue = String(label)
+            guard !labelValue.isEmpty,
+                labelValue.count <= 63,
+                !labelValue.hasPrefix("-"),
+                !labelValue.hasSuffix("-"),
+                labelValue.range(
+                    of: "^[A-Za-z0-9-]+$",
+                    options: NSString.CompareOptions.regularExpression)
+                    != nil
+            else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    public override func dispose() {
+        super.dispose()
+        plugin = nil
+    }
+
+    private enum ProxyConfigurationError: Error {
+        case invalidProxyUrl
+        case unsupportedProxyScheme
+
+        var code: String {
+            switch self {
+            case .invalidProxyUrl:
+                return "INVALID_PROXY_URL"
+            case .unsupportedProxyScheme:
+                return "UNSUPPORTED_PROXY_SCHEME"
+            }
+        }
+
+        var message: String {
+            switch self {
+            case .invalidProxyUrl:
+                return "Proxy URL must include a valid host and port."
+            case .unsupportedProxyScheme:
+                return "Proxy URL scheme must be HTTP, HTTPS, SOCKS, or SOCKS5."
+            }
+        }
+    }
+
+    deinit {
+        dispose()
+    }
+}
+
+private class ProxySettings {
+    let allowFailover: Bool
+    let excludedDomains: [String]
+    let matchDomains: [String]
+    let proxyUrl: String
+
+    init(
+        proxyUrl: String = "",
+        allowFailover: Bool = false,
+        excludedDomains: [String] = [],
+        matchDomains: [String] = []
+    ) {
+        self.proxyUrl = proxyUrl
+        self.allowFailover = allowFailover
+        self.excludedDomains = excludedDomains
+        self.matchDomains = matchDomains
+    }
+
+    static func fromMap(_ map: [String: Any]) -> ProxySettings {
+        let allowFailover = map["allowFailover"] as? Bool ?? false
+        let excludedDomains = map["excludedDomains"] as? [String] ?? []
+        let matchDomains = map["matchDomains"] as? [String] ?? []
+        let proxyUrl = map["proxyUrl"] as? String ?? ""
+
+        return ProxySettings(
+            proxyUrl: proxyUrl,
+            allowFailover: allowFailover,
+            excludedDomains: excludedDomains,
+            matchDomains: matchDomains)
+    }
+}


### PR DESCRIPTION
Adds macOS proxy controller implementation using `WKWebsiteDataStore.proxyConfigurations` (macOS 14.0+).

Previously, `ProxyController.instance().setProxyOverride()` threw `UnimplementedError` on macOS because `MacOSInAppWebViewPlatform` did not override `createPlatformProxyController`.

**Changes:**
- `ProxyManager.swift`: Native proxy manager using `ProxyConfiguration` (macOS 14.0+), mirroring the iOS implementation
- `proxy_controller.dart`: Dart-side `MacOSProxyController` registered via `createPlatformProxyController` override
- `InAppWebViewFlutterPlugin.swift`: Registers `ProxyManager` (gated to macOS 14.0+)

**Platform support:** macOS 14.0+ (Sonoma). Older macOS versions will continue to throw `UnimplementedError`.Runtime checks ensure graceful degradation.