### PR TITLE
fix(macOS): registrar.messenger is a property, not a method

### DIFF
--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/ProxyManager.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/ProxyManager.swift
@@ -22,7 +22,7 @@ public class ProxyManager: ChannelDelegate {
         super.init(
             channel: FlutterMethodChannel(
                 name: ProxyManager.METHOD_CHANNEL_NAME,
-                binaryMessenger: plugin.registrar!.messenger()))
+                binaryMessenger: plugin.registrar!.messenger))
         self.plugin = plugin
     }
 


### PR DESCRIPTION
Fixes build error introduced in PR #305: macOS `FlutterPluginRegistrar` exposes `messenger` as a property, not a method call. Removes the erroneous parentheses.