### PR TITLE
feat: per-profile proxy — apply proxy to custom WKWebsiteDataStore

### DIFF
--- a/zikzak_inappwebview/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview/lib/src/proxy_controller.dart
@@ -35,5 +35,6 @@ class ProxyController {
       platform.setProxyOverride(settings: settings);
 
   ///{@macro zikzak_inappwebview_platform_interface.PlatformProxyController.clearProxyOverride}
-  Future<void> clearProxyOverride() => platform.clearProxyOverride();
+  Future<void> clearProxyOverride({String? profileId}) =>
+      platform.clearProxyOverride(profileId: profileId);
 }

--- a/zikzak_inappwebview_android/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_android/lib/src/proxy_controller.dart
@@ -71,7 +71,7 @@ class AndroidProxyController extends PlatformProxyController
   }
 
   @override
-  Future<void> clearProxyOverride() async {
+  Future<void> clearProxyOverride({String? profileId}) async {
     Map<String, dynamic> args = <String, dynamic>{};
     await channel?.invokeMethod('clearProxyOverride', args);
   }

--- a/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_ios/lib/src/proxy_controller.dart
@@ -58,7 +58,7 @@ class IosProxyController extends PlatformProxyController
   }
 
   @override
-  Future<void> clearProxyOverride() async {
+  Future<void> clearProxyOverride({String? profileId}) async {
     await channel?.invokeMethod('clearProxyOverride');
   }
 

--- a/zikzak_inappwebview_macos/lib/src/proxy_controller.dart
+++ b/zikzak_inappwebview_macos/lib/src/proxy_controller.dart
@@ -32,14 +32,22 @@ class MacOSProxyController extends PlatformProxyController
 
   @override
   Future<void> setProxyOverride({required ProxySettings settings}) async {
-    final args = <String, dynamic>{};
-    args['settings'] = settings.iOSProxySettings?.toJson();
+    final args = <String, dynamic>{
+      'settings': settings.iOSProxySettings?.toJson(),
+    };
+    if (settings.profileId != null) {
+      args['profileId'] = settings.profileId;
+    }
     await channel?.invokeMethod('setProxyOverride', args);
   }
 
   @override
-  Future<void> clearProxyOverride() async {
-    await channel?.invokeMethod('clearProxyOverride');
+  Future<void> clearProxyOverride({String? profileId}) async {
+    final args = <String, dynamic>{};
+    if (profileId != null) {
+      args['profileId'] = profileId;
+    }
+    await channel?.invokeMethod('clearProxyOverride', args);
   }
 
   Future<dynamic> _handleMethod(MethodCall call) async {}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -206,7 +206,13 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                    let id = settingsMap["persistentStoreIdentifier"] as? String,
                    !id.isEmpty,
                    let uuid = persistentUUID(from: id) {
-                    configuration.websiteDataStore = WKWebsiteDataStore(forIdentifier: uuid)
+                    let store = WKWebsiteDataStore(forIdentifier: uuid)
+                    // Apply the per-profile proxy (if any) to this custom
+                    // data store — the Dart ProxyController sets it on the
+                    // default store, but WebViews with a persistent identifier
+                    // use a custom store that misses the proxy otherwise.
+                    ProxyManager.applyProxy(forIdentifier: id, to: store)
+                    configuration.websiteDataStore = store
                 } else if let incognito = settingsMap["incognito"] as? Bool,
                           incognito {
                     configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/ProxyManager.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/ProxyManager.swift
@@ -18,6 +18,11 @@ public class ProxyManager: ChannelDelegate {
 
     private var plugin: InAppWebViewFlutterPlugin?
 
+    /// Per-profile proxy configurations keyed by persistentStoreIdentifier.
+    /// When a WebView is created with a custom data store, the proxy for its
+    /// identifier is applied to that data store.
+    static var profileProxies: [String: ProxyConfiguration] = [:]
+
     init(plugin: InAppWebViewFlutterPlugin) {
         super.init(
             channel: FlutterMethodChannel(
@@ -30,12 +35,15 @@ public class ProxyManager: ChannelDelegate {
         let arguments = call.arguments as? [String: Any]
         switch call.method {
         case "setProxyOverride":
-            if let args = arguments?["settings"] as? [String: Any] {
-                let settings = ProxySettings.fromMap(args)
+            if let settingsMap = arguments?["settings"] as? [String: Any] {
+                let settings = ProxySettings.fromMap(settingsMap)
+                let profileId = arguments?["profileId"] as? String
                 do {
                     let proxyConfiguration = try resolveProxyConfiguration(settings)
-                    let websiteDataStore = WKWebsiteDataStore.default()
-                    websiteDataStore.proxyConfigurations = [proxyConfiguration]
+                    if let pid = profileId, !pid.isEmpty {
+                        ProxyManager.profileProxies[pid] = proxyConfiguration
+                    }
+                    WKWebsiteDataStore.default().proxyConfigurations = [proxyConfiguration]
                     result(true)
                 } catch let error as ProxyConfigurationError {
                     result(FlutterError(code: error.code, message: error.message, details: nil))
@@ -50,11 +58,24 @@ public class ProxyManager: ChannelDelegate {
                 result(false)
             }
         case "clearProxyOverride":
+            if let args = arguments as? [String: Any],
+               let profileId = args["profileId"] as? String {
+                ProxyManager.profileProxies.removeValue(forKey: profileId)
+            } else {
+                ProxyManager.profileProxies.removeAll()
+            }
             WKWebsiteDataStore.default().proxyConfigurations = []
             result(true)
         default:
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    /// Applies the stored proxy configuration for [identifier] to [dataStore].
+    /// Called by the WebView factory when a custom data store is created.
+    public static func applyProxy(forIdentifier identifier: String, to dataStore: WKWebsiteDataStore) {
+        guard let config = profileProxies[identifier] else { return }
+        dataStore.proxyConfigurations = [config]
     }
 
     private func resolveProxyConfiguration(_ settings: ProxySettings) throws -> ProxyConfiguration {

--- a/zikzak_inappwebview_platform_interface/lib/src/domain/entities/platform_proxy_controller/platform_proxy_controller.dart
+++ b/zikzak_inappwebview_platform_interface/lib/src/domain/entities/platform_proxy_controller/platform_proxy_controller.dart
@@ -82,7 +82,7 @@ abstract class PlatformProxyController extends PlatformInterface
   ///Clears the proxy settings.
   ///Network connections are not guaranteed to immediately use the new proxy setting; wait for the method to return before loading a page.
   ///{@endtemplate}
-  Future<void> clearProxyOverride() {
+  Future<void> clearProxyOverride({String? profileId}) {
     throw UnimplementedError(
       'clearProxyOverride is not implemented on the current platform',
     );
@@ -98,7 +98,11 @@ class ProxySettings {
   AndroidProxySettings? androidProxySettings;
   IOSProxySettings? iOSProxySettings;
 
-  ProxySettings({this.androidProxySettings, this.iOSProxySettings});
+  /// Optional profile identifier — when set, the proxy is stored per-profile
+  /// and applied to the WKWebsiteDataStore with that persistent identifier.
+  String? profileId;
+
+  ProxySettings({this.androidProxySettings, this.iOSProxySettings, this.profileId});
 }
 
 @Zorphy(


### PR DESCRIPTION
Fixes the proxy not working for WebViews with `persistentStoreIdentifier`.

**Root cause:** `ProxyController.setProxyOverride` applied the proxy to `WKWebsiteDataStore.default()`, but WebViews using `persistentStoreIdentifier` create custom data stores via `WKWebsiteDataStore(forIdentifier:)`. The proxy on the default store doesn't apply to custom stores.

**Fix:**
- Add `profileId` to `ProxySettings` so Dart can identify which profile's data store to target
- `ProxyManager` stores per-profile proxy configs and applies them to custom data stores when created
- `InAppWebView.swift` calls `ProxyManager.applyProxy(forIdentifier:to:)` when creating a custom data store
- `ProxyController.clearProxyOverride` now accepts optional `profileId`