### PR TITLE
fix(309): macOS crash — defensive deserialization of DOMException in script message handler

### DIFF
--- a/.specify/bugs/309-macos-domexception-crash/assessment.md
+++ b/.specify/bugs/309-macos-domexception-crash/assessment.md
@@ -1,0 +1,84 @@
+# Bug Assessment: macOS crash — WebKit deserialization of DOMException in script message handler
+
+- **Slug**: 309-macos-domexception-crash
+- **Created**: 2026-09-04
+- **Source**: https://github.com/arrrrny/zikzak_inappwebview/issues/309
+- **Verdict**: confirmed-by-report (crash signature and repro path are consistent with the code); reproduction requires macOS hardware
+- **Severity**: critical
+
+## Report (verbatim or summarized)
+
+On macOS, a page whose JavaScript creates a `DOMException` (permission APIs,
+notifications, service workers, fetch errors) and passes it through the zikzak
+bridge crashes the host app with `EXC_BAD_ACCESS (SIGSEGV)` inside
+`WebCore::CloneDeserializer::readDOMException`, reached via
+`SerializedScriptValue::deserialize` → `ScriptMessageHandlerDelegate::didPostMessage`.
+
+## Symptom
+
+Intermittent hard crash (SIGSEGV, not a catchable exception) of the whole Flutter
+app on macOS, only when page JS posts fragile/non-cloneable values (DOMException
+and friends) into a script message handler registered by the plugin.
+
+## Reproduction
+
+macOS only. Run any Flutter app embedding the zikzak macOS webview; load a page
+that executes e.g.
+`window.webkit.messageHandlers.consoleHandler.postMessage(new DOMException('x','SecurityError'))`
+(or triggers the same through the bridge), and the process dies inside WebKit's
+clone deserializer. Cannot be reproduced on Linux/Windows — WebKit is required.
+
+## Suspected Code Paths
+
+- `zikzak_inappwebview_macos/macos/.../WeakScriptMessageHandler.swift` — the
+  registration wrapper for **every** macOS script message handler
+  (`consoleHandler`, `callHandler`, `onFindResultReceived`,
+  `onWebMessagePortMessageReceived`, `onWebMessageListenerPostMessageReceived`,
+  `onScrollChangedReceived`). It forwards `WKScriptMessage` untouched; nothing
+  guards the `message.body` deserialization.
+- `zikzak_inappwebview_macos/macos/.../InAppWebView.swift`
+  `userContentController(_:didReceive:)` (line ~2315) — every branch casts
+  `message.body as? [String: Any]` and passes nested values straight into
+  `invokeMethod`, so both WebKit deserialization and the Flutter standard message
+  codec are exposed to non-cloneable values.
+
+## Root Cause Hypothesis
+
+`WKScriptMessage.body` is consumed without any defensive layer. WebKit's
+deserializer (`CloneDeserializer::readDOMException`) has a memory-unsafe path for
+`DOMException` payloads; values that do deserialize but are foreign to the Flutter
+standard message codec (or arrive as opaque objects) put a second, catchable
+crash vector behind the same unguarded read.
+
+## Proposed Remediation
+
+Make the macOS `WeakScriptMessageHandler` a defensive choke point (macOS
+equivalent of the iOS reference path):
+
+1. Read `message.body` exactly once per message, wrapped in an ObjC
+   `@try/@catch` shim so WebKit exceptions thrown during deserialization become a
+   normal string error instead of propagating.
+2. Recursively convert values that are not expressible in the Flutter standard
+   message codec (non-cloneable objects, dates, URLs, opaque types) to their
+   string representation before anything reaches Dart.
+3. On deserialization failure, report a plain string error to Dart
+   (`onConsoleMessage`, ERROR level) instead of crashing or dropping silently.
+
+Hard constraints: fix ONLY the macOS script message handler deserialization; do
+not change iOS/Android/other platform handlers; one PR for the bug.
+
+## Risks & Considerations
+
+- The SIGSEGV itself occurs inside WebKit's C++ frame; no userspace handler can
+  catch a true memory fault. The fix removes the catchable failure modes at the
+  Swift boundary and guarantees a string report; it cannot make a WebKit-internal
+  segfault survivable, and that limitation is recorded in verification.
+- The ObjC exception shim must not disturb the plugin's SwiftPM build layout.
+- Behavioral risk is low: sanitized bodies keep the documented
+  `[String: Any]` shape for all legitimate plugin traffic (the official
+  `callHandler` bridge already posts JSON strings).
+
+## Open Questions
+
+- None blocking. Whether macOS CI exists to run the WebKit-level repro is
+  recorded as a verification gap if absent.

--- a/.specify/bugs/309-macos-domexception-crash/fix.md
+++ b/.specify/bugs/309-macos-domexception-crash/fix.md
@@ -1,0 +1,70 @@
+# Fix Report — 309-macos-domexception-crash
+
+- **Branch**: `fix/309-macos-domexception-crash`
+- **Fixes**: https://github.com/arrrrny/zikzak_inappwebview/issues/309
+- **Constraints honored**: macOS script message handler deserialization only; no
+  iOS/Android/other-platform handler changed; one PR.
+
+## What was wrong
+
+Every zikzak macOS script message handler is registered through
+`WeakScriptMessageHandler`, which forwarded `WKScriptMessage` untouched, and every
+branch of `InAppWebView.userContentController(_:didReceive:)` read
+`message.body` bare (6 read sites). `message.body` is the WebKit
+serialized-value deserialization boundary: a page posting a `DOMException`
+crashes inside `CloneDeserializer::readDOMException` (issue #309), and values
+that do deserialize but are foreign to the Flutter standard message codec put a
+second crash vector behind the same unguarded read.
+
+## The fix (3 files + 1 new shim target)
+
+1. **`Sources/ZikzakExceptionCatcher/`** (new ObjC target):
+   `ZikzakCatchException(block)` — a standard `@try/@catch` shim, because Swift
+   cannot catch `NSException`. Wired into `Package.swift` as a dependency of the
+   existing Swift target (no other build change).
+2. **`WeakScriptMessageHandler.swift`** (rewritten): now the defensive choke
+   point —
+   - `defensivelyDeserializeBody(of:)` reads `message.body` **exactly once**
+     inside `ZikzakCatchException`; if WebKit's deserializer throws, the
+     exception becomes a plain string error (handler name + reason).
+   - `sanitizeValueForMessageCodec(_:)` recursively converts anything the
+     Flutter standard message codec cannot carry (opaque objects such as a
+     DOMException result, `NSDate`, `NSURL`, unsupported nested leaves) to its
+     string representation; plain string/number/bool/data/containers pass
+     through unchanged in shape.
+   - Delegates conforming to the new internal
+     `DefensivelyDeserializedScriptMessageHandling` protocol receive the
+     sanitized body + optional error string; unknown delegates keep legacy
+     forwarding.
+3. **`InAppWebView.swift`** (macOS only): conforms to the protocol; the
+   `WKScriptMessageHandler` entry point now routes through the sanitized
+   variant; all six body reads consume `sanitizedBody`; when
+   `deserializationError != nil` the error is reported to Dart as a normal
+   string via `onConsoleMessage` (level 3 = ERROR) instead of crashing or
+   dropping silently.
+
+## Behavior after the fix
+
+- Legitimate traffic (JSON-string `callHandler` bodies, `[String: Any]`
+  console/find/webmessage/scroll bodies) reaches Dart exactly as before.
+- A body that fails to deserialize → Dart receives a console ERROR string naming
+  the handler; the process stays alive.
+- A body that deserializes but contains non-cloneable leaves → leaves arrive in
+  Dart as strings; the process stays alive.
+
+## Known limitation (recorded, not hidden)
+
+The issue's SIGSEGV occurs inside WebKit's own C++ frame. No userspace catch can
+survive a true memory fault; this fix guarantees (a) every catchable
+deserialization failure becomes a string error, (b) nothing non-cloneable ever
+reaches Dart, and (c) the body is read once through the exception boundary. The
+WebKit-level red/green run remains a recorded gap for macOS CI — see
+`tdd/verification.md` (verdict `PASS_WITH_GAPS`) and `tdd/cycle-log.md` C1.
+
+## Verification summary
+
+Real observed results on this host (Flutter 3.47.2 / Dart 3.13.2, Linux):
+macOS package `flutter test` **42/42 green**; umbrella `flutter test` **236
+passed / 3 failed with all 3 PROVEN pre-existing on clean master**; `git diff
+--check` clean; `swiftc -parse` clean on all changed Swift files. Full audit:
+`tdd/verification.md`.

--- a/.specify/bugs/309-macos-domexception-crash/issue.md
+++ b/.specify/bugs/309-macos-domexception-crash/issue.md
@@ -1,0 +1,40 @@
+# Bug Issue: macOS crash — WebKit deserialization of DOMException in script message handler
+
+- **Slug**: 309-macos-domexception-crash
+- **Fetched**: 2026-09-04T21:45:00
+- **Issue**: 309
+- **URL**: https://github.com/arrrrny/zikzak_inappwebview/issues/309
+- **State**: open
+- **Severity**: critical
+- **Author**: (see GitHub issue)
+- **Labels**: none
+
+## Body
+
+`zuraffa_browser` crashes intermittently on macOS with `EXC_BAD_ACCESS (SIGSEGV)`
+inside WebKit's `CloneDeserializer::readDOMException`.
+
+The crash happens in `ScriptMessageHandlerDelegate::didPostMessage` when a page's
+JavaScript sends a `DOMException` object through the zikzak bridge (e.g. produced
+by permission APIs, notifications, service workers, or fetch errors). The
+`didReceiveScriptMessage` handler does not defensively deserialize the payload —
+`DOMException` and other non-cloneable objects crash the host process.
+
+Stack trace:
+
+```
+WebCore::CloneDeserializer::readDOMException
+  → SerializedScriptValue::deserialize
+  → ScriptMessageHandlerDelegate::didPostMessage
+```
+
+Repro: use any zikzak webview in a macOS Flutter app → navigate to a page whose JS
+creates a `DOMException` and passes it through the bridge → app crashes with SIGSEGV.
+
+Expected: the `didReceiveScriptMessage` handler should defensively deserialize the
+payload — `DOMException` and other non-cloneable objects should be caught and
+reported as a normal string error rather than crashing.
+
+## Comments
+
+None.

--- a/.specify/bugs/309-macos-domexception-crash/spec.md
+++ b/.specify/bugs/309-macos-domexception-crash/spec.md
@@ -1,0 +1,39 @@
+# Bug Spec: Defensive deserialization of script message bodies on macOS (Bug #309)
+
+## Problem
+
+A page's JavaScript can post a `DOMException` (or another value that is fragile or
+not expressible in the Flutter standard message codec) through any zikzak macOS
+script message handler. The macOS handler path reads `WKScriptMessage.body` with
+no defense, so WebKit deserialization failures and non-cloneable values crash the
+host process (issue #309, SIGSEGV in `CloneDeserializer::readDOMException`).
+
+## Acceptance Criteria
+
+1. **AC1 — Guarded read.** Every `WKScriptMessage` delivered to the zikzak macOS
+   plugin is consumed through a single defensive read of `message.body` located in
+   `WeakScriptMessageHandler`; an ObjC `@try/@catch` boundary converts an
+   exception thrown by WebKit's deserializer into a normal string error. The
+   process does not crash for catchable deserialization failures.
+2. **AC2 — String fallback.** On deserialization failure the plugin reports a
+   human-readable string error to Dart (`onConsoleMessage`, ERROR level) instead
+   of crashing or silently dropping the message; legitimate messages are unaffected.
+3. **AC3 — Codec-safe payload.** Values that deserialize but are not expressible
+   by the Flutter standard message codec (opaque objects, dates, URLs, unsupported
+   nested leaves) are recursively converted to their string representation before
+   being passed to Dart.
+4. **AC4 — Platform isolation.** Only macOS files change
+   (`zikzak_inappwebview_macos/**`); iOS, Android, web, Windows, Linux handlers
+   are untouched.
+5. **AC5 — No regression.** `flutter analyze` and `flutter test` pass in the
+   touched Dart packages (`zikzak_inappwebview_macos`, `zikzak_inappwebview`) with
+   no new failures and zero formatting diffs.
+
+## Environment Boundary (recorded, not hidden)
+
+The WebKit-level reproduction (SIGSEGV in `CloneDeserializer::readDOMException`)
+requires macOS + Xcode. This fix was produced in a Linux CI environment where
+Swift/WebKit cannot execute; AC1/AC2/AC3 are implemented at the Swift boundary and
+verified by code review + Swift syntax parse + the Dart-side gates of AC5, but the
+WebKit-level red/green run is NOT PROVED here. The exact macOS reproduction and
+verification commands are recorded in `tdd/cycle-log.md` and `tdd/verification.md`.

--- a/.specify/bugs/309-macos-domexception-crash/tdd/cycle-log.md
+++ b/.specify/bugs/309-macos-domexception-crash/tdd/cycle-log.md
@@ -1,0 +1,72 @@
+# Cycle Log — 309-macos-domexception-crash
+
+Append-only. One entry per cycle. Evidence over intention: entries marked
+`NOT_EXECUTED` were not run, and the reason is recorded. Nothing in this file
+claims a pass that was not observed on this machine.
+
+---
+
+## C1 — RED (reproduce the crash): NOT_EXECUTED — environment
+
+- **Date**: 2026-09-04
+- **Attempted on**: Linux x86_64 CI container (`Linux … 6.x`, no macOS SDK, no
+  Xcode, no WebKit, no Apple GPU process). Flutter 3.47.2 / Dart 3.13.2 (Linux) is
+  the only toolchain available.
+- **Why it cannot run here**: the crash is a WebKit-internal memory fault
+  (`CloneDeserializer::readDOMException`) in the macOS Web Content process/UI
+  process bridge. Reproducing it requires running a real `WKWebView` on macOS.
+- **The reproduction that must run on macOS** (maintainer/CI, exact commands):
+
+  ```bash
+  # 1. On macOS with Flutter + Xcode:
+  cd zikzak_inappwebview_macos/example   # example app hosting the webview
+  flutter run -d macos
+  # 2. In the app, navigate to a page executing:
+  #    <script>
+  #      try { navigator.serviceWorker } catch (e) {}
+  #      window.webkit.messageHandlers.consoleHandler.postMessage(
+  #        new DOMException('boom', 'SecurityError'));
+  #    </script>
+  # 3. EXPECTED (pre-fix): process dies, crash report shows
+  #    WebCore::CloneDeserializer::readDOMException →
+  #    SerializedScriptValue::deserialize →
+  #    ScriptMessageHandlerDelegate::didPostMessage
+  ```
+
+- **Red evidence recorded**: NONE (no executable red on this host). The red
+  state is evidenced indirectly by the unguarded code path
+  (`WeakScriptMessageHandler.swift` forwards `WKScriptMessage` untouched; every
+  branch of `InAppWebView.userContentController(_:didReceive:)` reads
+  `message.body` bare and feeds values straight into the method channel).
+- **Honest status**: red NOT PROVED. No macOS-native test was written to a state
+  of "failing first" on this machine.
+
+---
+
+## C2 — GREEN (fix): fix implemented; runnable gates executed on Linux, WebKit-level gates remain macOS-only
+
+- **Date**: 2026-09-04
+- **Fix**: see `fix.md`. Defensive deserialization choke point in
+  `WeakScriptMessageHandler` (macOS): single guarded `message.body` read behind an
+  ObjC `@try/@catch` shim (`ZikzakExceptionCatcher` target), recursive
+  codec-safety sanitization (non-cloneable leaves → string), and a string error
+  report to Dart (`onConsoleMessage`, ERROR level) when deserialization fails.
+- **Runnable verification executed on this host** (Flutter 3.47.2 / Dart 3.13.2, Linux):
+
+  | Gate | Command | Observed result |
+  | --- | --- | --- |
+  | analyze (macos pkg) | `cd zikzak_inappwebview_macos && flutter analyze` | 4 findings — all pre-existing in untouched files; zero in changed files |
+  | test (macos pkg) | `cd zikzak_inappwebview_macos && flutter test` | **42 passed / 0 failed** ("All tests passed!") |
+  | analyze (umbrella) | `cd zikzak_inappwebview && flutter analyze` | 37 findings — all pre-existing in untouched files (1 error in `test/proxy_tracing_controllers_test.dart`) |
+  | test (umbrella) | `cd zikzak_inappwebview && flutter test` | **236 passed / 3 failed** — the 3 failures re-run on clean master (stash) and fail identically → PROVEN pre-existing |
+  | platform isolation | `git status --porcelain` / `git diff --stat` | macOS files + `.specify/` only |
+  | formatting | `git diff --check` | clean |
+  | swift syntax | `swiftc -parse` (Swift 6.1.2, Linux) | PARSE OK ×3 (`WeakScriptMessageHandler.swift`, `InAppWebView.swift`, `Package.swift`) |
+
+- **WebKit-level green NOT EXECUTED on this host.** Maintainer/CI commands
+  (macOS): same repro as C1 after applying the fix — the process must stay alive
+  and Dart must receive the string error; plus the XCTest commands recorded in
+  `verification.md` Phase 5.
+- **Honest status**: green NOT PROVED for B1–B4/B11 (macOS-only). Green PROVED
+  only for the runnable gates listed in `verification.md` with real observed
+  output.

--- a/.specify/bugs/309-macos-domexception-crash/tdd/test-list.md
+++ b/.specify/bugs/309-macos-domexception-crash/tdd/test-list.md
@@ -1,0 +1,36 @@
+---
+feature: 309-macos-domexception-crash
+loop: inside-out
+profile: .specify/memory/tdd-profile.md
+spec_criteria: 5
+planned_at: 4dbe3171
+updated_at: 4dbe3171
+suite_baseline: green
+---
+
+# Test List — 309-macos-domexception-crash
+
+The crashing behavior lives in macOS-only Swift (`WeakScriptMessageHandler`,
+`InAppWebView.userContentController(_:didReceive:)`). The development environment
+for this fix is Linux (no macOS SDK, no WebKit, no Xcode), so WebKit-level
+behaviors cannot execute here. Behaviors are classified honestly: the runnable
+gates (analyze/format/test in the touched Dart packages) are `RUNNABLE`; the
+WebKit-level behaviors are `MACOS-ONLY` and are recorded as `NOT_EXECUTED` in the
+cycle log with the exact commands a macOS maintainer/CI must run. This list does
+not invent runnable tests to fake red/green for Swift code that cannot link here.
+
+## Behaviors
+
+| ID | Criterion | Behavior | Kind | Level | Test / Gate | Status |
+| --- | --- | --- | --- | --- | --- | --- |
+| B1 | AC1 | A script message whose body deserialization throws does not crash the process; the exception is contained at the ObjC boundary in `WeakScriptMessageHandler` | behavior | unit (Swift, macOS) | macOS-only: Xcode XCTest on `WeakScriptMessageHandlerTests` (commands in cycle-log C2) | MACOS-ONLY / NOT_EXECUTED |
+| B2 | AC2 | On deserialization failure Dart receives a normal string error (`onConsoleMessage`, level 3) containing the handler name | behavior | unit (Swift→Dart, macOS) | macOS-only (cycle-log C2) | MACOS-ONLY / NOT_EXECUTED |
+| B3 | AC3 | Bodies/leaves not expressible in the Flutter standard message codec (DOMException results, NSDate, URL, opaque objects, unsupported nested leaves) are recursively converted to string representation before `invokeMethod` | behavior | unit (Swift, macOS) | macOS-only (cycle-log C2) | MACOS-ONLY / NOT_EXECUTED |
+| B4 | AC3 | Legitimate plugin traffic (JSON-string `callHandler` bodies, `[String: Any]` console bodies) passes through sanitization unchanged in shape | behavior | unit (Swift, macOS) | macOS-only (cycle-log C2) | MACOS-ONLY / NOT_EXECUTED |
+| B5 | AC4 | Only `zikzak_inappwebview_macos/**` files changed vs `master` | gate | repo | `git diff --name-only master...` | RUNNABLE |
+| B6 | AC5 | `flutter analyze` exits 0 in `zikzak_inappwebview_macos` | gate | package | `cd zikzak_inappwebview_macos && flutter analyze` | RUNNABLE |
+| B7 | AC5 | `flutter test` all-green in `zikzak_inappwebview_macos` | gate | package | `cd zikzak_inappwebview_macos && flutter test` | RUNNABLE |
+| B8 | AC5 | `flutter analyze` exits 0 in `zikzak_inappwebview` (umbrella) | gate | package | `cd zikzak_inappwebview && flutter analyze` | RUNNABLE |
+| B9 | AC5 | `flutter test` all-green in `zikzak_inappwebview` (umbrella) | gate | package | `cd zikzak_inappwebview && flutter test` | RUNNABLE |
+| B10 | AC5 | Changed Swift files parse cleanly (syntax gate; no Swift toolchain can typecheck WebKit targets on Linux) | gate | file | `swiftc -parse` if available on host, else documented absence | RUNNABLE* |
+| B11 | AC1–AC3 | WebKit-level red→green: DOMException posted through the bridge crashes before the fix and does not crash after | behavior | integration (macOS app) | macOS-only repro in cycle-log C1 | MACOS-ONLY / NOT_EXECUTED |

--- a/.specify/bugs/309-macos-domexception-crash/tdd/verification.md
+++ b/.specify/bugs/309-macos-domexception-crash/tdd/verification.md
@@ -1,0 +1,86 @@
+# TDD Verification — 309-macos-domexception-crash
+
+- **verified_at**: `4dbe3171` (base) + working tree committed as the fix commit on `fix/309-macos-domexception-crash`
+- **standard**: `.specify/extensions/tdd/templates/tdd-test-quality-rubric.md` (resolved: extension copy; no overrides/presets present)
+- **feature dir**: `.specify/bugs/309-macos-domexception-crash/` (via `.specify/feature.json`)
+- **environment**: Linux x86_64 (Debian 13), Flutter 3.47.2 / Dart 3.13.2 (Linux host), Swift 6.1.2 (Linux, syntax gate only). **No macOS SDK, no Xcode, no WebKit.**
+- **audit independence**: NOT independent — the same session that wrote the fix wrote this report. Fail-closed applies throughout.
+
+## Verdict: PASS_WITH_GAPS
+
+The runnable gates are green and the platform-isolation constraint is PROVEN.
+The WebKit-level red/green cycle (B1–B4, B11) was **not executed** because it
+requires macOS hardware; this is a recorded gap, not a pass. Test strength is
+**unmeasured** (no mutation tooling for Swift on this host; profile records
+`mutation: null`).
+
+## Suite runs (observed on this host)
+
+| Gate | Command | Observed result |
+| --- | --- | --- |
+| analyze (macos pkg) | `cd zikzak_inappwebview_macos && flutter analyze` | 4 findings (1 info, 3 warnings), **all in files untouched by this change** (`lib/src/cookie_manager.dart`, `test/context_menu_test.dart`, `test/headless_repro_test.dart`); zero findings in changed files. Exit non-zero pre-exists. |
+| test (macos pkg) | `cd zikzak_inappwebview_macos && flutter test` | **42 passed / 0 failed** ("All tests passed!") |
+| analyze (umbrella) | `cd zikzak_inappwebview && flutter analyze` | 37 findings incl. 1 error (`test/proxy_tracing_controllers_test.dart:24` invalid_override) — **all pre-existing, file untouched by this change**; package contains none of this diff |
+| test (umbrella) | `cd zikzak_inappwebview && flutter test` | **236 passed / 3 failed**. The 3 failures (U14 loadSimulatedRequest, U9 dispose-forwarding, proxy_tracing load error) were **re-run on a clean master tree (changes stashed) and fail identically** → PROVEN pre-existing, not introduced by this change |
+| formatting | `git diff --check` | clean — zero whitespace/formatting diffs; diff contains functional changes only |
+| swift syntax | `swiftc -parse` (Swift 6.1.2 Linux) | PARSE OK for `WeakScriptMessageHandler.swift`, `InAppWebView.swift`, `Package.swift` |
+| platform isolation | `git status --porcelain` / `git diff --stat` | changes confined to `zikzak_inappwebview_macos/**` + `.specify/` bug artifacts; iOS/Android/web/Windows/Linux untouched |
+
+Note: the task's chained `flutter analyze && flutter test` form stops at analyze
+on both packages because pre-existing analyzer findings make analyze exit
+non-zero. Tests were therefore run as separate commands; counts above are real.
+
+## Test-first evidence (per behavior)
+
+| ID | Behavior | Classification | Basis |
+| --- | --- | --- | --- |
+| B1 (AC1) | Guarded read; ObjC exception boundary in `WeakScriptMessageHandler` | **NO_TEST (macOS-only)** | No macOS XCTest was executed — impossible on this host. Implementation exists and parses. |
+| B2 (AC2) | String error reported to Dart (`onConsoleMessage`, level 3) on deserialization failure | **NO_TEST (macOS-only)** | Same as B1. |
+| B3 (AC3) | Recursive codec-safe conversion of non-cloneable leaves | **NO_TEST (macOS-only)** | Same as B1. |
+| B4 (AC4) | Legitimate traffic passes through unchanged in shape | **NO_TEST (macOS-only)** | Same as B1. Existing 42 macOS-package Dart tests green after the change, but they never exercise the Swift path. |
+| B5 (AC5) | Only macOS files changed | **PROVEN** | `git status --porcelain` inspected directly. |
+| B6 (AC5) | analyze macos pkg | **PROVEN** (pre-existing findings only) | Observed output above. |
+| B7 (AC5) | test macos pkg | **PROVEN** | 42/42 observed. |
+| B8 (AC5) | analyze umbrella | **PROVEN** (pre-existing findings only) | Observed output above. |
+| B9 (AC5) | test umbrella | **PROVEN** (pre-existing failures only) | 236/3 with baseline re-run proof. |
+| B10 (AC5) | Swift syntax gate | **PROVEN (shallow)** | `swiftc -parse` only; **no type-check** against WebKit/FlutterFramework (impossible on Linux). |
+| B11 (AC1–3) | WebKit-level red→green crash repro | **NOT_EXECUTED** | Requires macOS + Xcode; exact commands recorded in `tdd/cycle-log.md` C1. |
+
+## Red-phase evidence
+
+- Red was **not** executed (no macOS). No macOS-native test was authored and
+  left failing first. By the rubric this makes the fix **test-after** for
+  B1–B4/B11. The red repro is fully specified in `tdd/cycle-log.md` C1 for a
+  macOS maintainer/CI to run.
+- Baseline discipline: the umbrella suite's 3 failures were isolated to master
+  before counting them against this change (stash → re-run → same failures →
+  restore).
+
+## Smells / discrepancies found
+
+1. **Structural — test gap in Swift**: `defensivelyDeserializeBody` /
+   `sanitizeValueForMessageCodec` have no executable tests anywhere in the repo
+   (macOS Xcode test target does not exist). Remediation R1.
+2. **Minor — legacy fallback path re-reads the body**: if a foreign
+   (non-sanitizing) delegate is ever registered through
+   `WeakScriptMessageHandler`, its handler still calls `message.body` itself;
+   the defensive read happens once in the wrapper but the foreign delegate's own
+   body read is not intercepted. Today all six zikzak registrations use the
+   sanitizing path, so the exposed surface is empty. Remediation R3.
+3. **Info — pre-existing analyzer/test debt** in both packages (findings listed
+   above) predates this change and is out of scope per the hard constraints
+   (fix only the macOS script message handler deserialization).
+
+## Remediation tasks (do not gate this PR)
+
+- **R1** (high): add an Xcode test target for `zikzak_inappwebview_macos` and
+  port the cycle-log C1/C2 scenarios into XCTest cases
+  (`WeakScriptMessageHandlerTests`: exception-containing body, DOMException-like
+  opaque object, NSDate/URL leaves, plain JSON-string callHandler body).
+- **R2** (high): run the WebKit-level repro (cycle-log C1) on macOS CI and paste
+  the crash-absent result into this file's addendum.
+- **R3** (medium): decide whether foreign delegates should be force-cast to
+  `DefensivelyDeserializedScriptMessageHandling` at registration time so the
+  legacy path can be deleted.
+- **R4** (low): sweep the pre-existing analyzer findings in both packages once a
+  maintainer confirms they are not load-bearing for other in-flight branches.

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/001-screenshot-pdf-export"
+  "feature_directory": ".specify/bugs/309-macos-domexception-crash"
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": ".specify/bugs/309-macos-domexception-crash"
+  "feature_directory": "specs/001-screenshot-pdf-export"
 }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Package.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Package.swift
@@ -13,9 +13,16 @@ let package = Package(
         .package(name: "FlutterFramework", path: "../FlutterFramework"),
     ],
     targets: [
+        // #309: ObjC exception boundary (Swift cannot catch NSException).
+        // Lets WeakScriptMessageHandler contain WebKit deserialization
+        // exceptions and report them as a normal string error to Dart.
+        .target(
+            name: "ZikzakExceptionCatcher"
+        ),
         .target(
             name: "zikzak_inappwebview_macos",
             dependencies: [
+                "ZikzakExceptionCatcher",
                 .product(name: "FlutterFramework", package: "FlutterFramework"),
             ]
         )

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/ZikzakExceptionCatcher/ZikzakExceptionCatcher.m
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/ZikzakExceptionCatcher/ZikzakExceptionCatcher.m
@@ -1,0 +1,11 @@
+#import "include/ZikzakExceptionCatcher.h"
+
+NSException * _Nullable ZikzakCatchException(void (^_Nonnull block)(void)) {
+    @try {
+        block();
+        return nil;
+    }
+    @catch (NSException *exception) {
+        return exception;
+    }
+}

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/ZikzakExceptionCatcher/include/ZikzakExceptionCatcher.h
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/ZikzakExceptionCatcher/include/ZikzakExceptionCatcher.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Runs `block` synchronously and catches any NSException it throws.
+/// Returns the caught NSException, or nil when the block completed normally.
+///
+/// #309: Swift code cannot catch Objective-C exceptions; this ObjC shim is the
+/// exception boundary that lets the macOS script message handler deserialization
+/// path convert a WebKit deserialization exception into a normal string error
+/// instead of crashing the host process.
+NSException * _Nullable ZikzakCatchException(void (^_Nonnull block)(void));
+
+NS_ASSUME_NONNULL_END

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -2312,12 +2312,12 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
         }
     }
 
-    public func userContentController(
+    // Internal fallback for direct registration. Every zikzak macOS handler is
+    // registered via WeakScriptMessageHandler, which calls the sanitized variant
+    // below after defensively deserializing the body (#309).
+    func userContentController(
         _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
     ) {
-        // Fallback for direct registration. Every zikzak macOS handler is
-        // registered via WeakScriptMessageHandler, which calls the sanitized
-        // variant below after defensively deserializing the body (#309).
         let (sanitizedBody, deserializationError) = WeakScriptMessageHandler.defensivelyDeserializeBody(of: message)
         self.userContentController(
             userContentController, didReceive: message,

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -67,7 +67,7 @@ private func persistentUUID(from identifier: String) -> UUID? {
     return nil
 }
 
-public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandler, WKUIDelegate, NSMenuDelegate {
+public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandler, DefensivelyDeserializedScriptMessageHandling, WKUIDelegate, NSMenuDelegate {
     var channel: FlutterMethodChannel!
     var registrar: FlutterPluginRegistrar? = nil
     var plugin: InAppWebViewFlutterPlugin?
@@ -2315,7 +2315,36 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     public func userContentController(
         _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
     ) {
-        if message.name == "consoleHandler", let body = message.body as? [String: Any] {
+        // Fallback for direct registration. Every zikzak macOS handler is
+        // registered via WeakScriptMessageHandler, which calls the sanitized
+        // variant below after defensively deserializing the body (#309).
+        let (sanitizedBody, deserializationError) = WeakScriptMessageHandler.defensivelyDeserializeBody(of: message)
+        self.userContentController(
+            userContentController, didReceive: message,
+            sanitizedBody: sanitizedBody, deserializationError: deserializationError)
+    }
+
+    /// #309 — the only body-consuming entry point on macOS. The body arrives
+    /// already deserialized defensively by `WeakScriptMessageHandler`:
+    /// - an ObjC exception boundary contained any WebKit deserialization
+    ///   exception (`deserializationError != nil`), reported to Dart as a
+    ///   normal string error below;
+    /// - non-cloneable values were converted to their string representation,
+    ///   so the Flutter standard message codec can always encode the payload.
+    public func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage,
+        sanitizedBody: Any,
+        deserializationError: String?
+    ) {
+        if let deserializationError = deserializationError {
+            // #309 — report as a normal string error instead of crashing.
+            channel?.invokeMethod("onConsoleMessage", arguments: [
+                "message": "[ZikzakInAppWebView] \(deserializationError)",
+                "messageLevel": 3,  // ERROR
+            ])
+        }
+        if message.name == "consoleHandler", let body = sanitizedBody as? [String: Any] {
             var arguments: [String: Any] = [:]
             arguments["message"] = (body["message"] as? String) ?? ""
 
@@ -2339,7 +2368,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
             arguments["messageLevel"] = level
             channel?.invokeMethod("onConsoleMessage", arguments: arguments)
         } else if message.name == "callHandler",
-            let bodyString = message.body as? String,
+            let bodyString = sanitizedBody as? String,
             let bodyData = bodyString.data(using: .utf8),
             let body = try? JSONSerialization.jsonObject(with: bodyData) as? [String: Any]
         {
@@ -2416,11 +2445,11 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                         """, completionHandler: nil)
                 }
             }
-        } else if message.name == "onFindResultReceived", let body = message.body as? [String: Any]
+        } else if message.name == "onFindResultReceived", let body = sanitizedBody as? [String: Any]
         {
             findInteractionChannel?.invokeMethod("onFindResultReceived", arguments: body)
         } else if message.name == "onWebMessagePortMessageReceived",
-            let body = message.body as? [String: Any],
+            let body = sanitizedBody as? [String: Any],
             let webMessageChannelId = body["webMessageChannelId"] as? String,
             let index = body["index"] as? Int64
         {
@@ -2440,7 +2469,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                 wmc.channelDelegate?.onMessage(message: webMessage, index: index)
             }
         } else if message.name == "onWebMessageListenerPostMessageReceived",
-            let body = message.body as? [String: Any],
+            let body = sanitizedBody as? [String: Any],
             let jsObjectName = body["jsObjectName"] as? String
         {
             // WebMessageListener page→Dart message (#197).
@@ -2461,7 +2490,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
                     break
                 }
             }
-        } else if message.name == "onScrollChangedReceived", let body = message.body as? [String: Any] {
+        } else if message.name == "onScrollChangedReceived", let body = sanitizedBody as? [String: Any] {
             // onScrollChanged / onContentSizeChanged / onOverScrolled (#197).
             let x = body["x"] as? Int ?? 0
             let y = body["y"] as? Int ?? 0

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/WeakScriptMessageHandler.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/WeakScriptMessageHandler.swift
@@ -1,13 +1,116 @@
 import WebKit
+import ZikzakExceptionCatcher
+
+/// Internal contract for delegates that consume an already-sanitized message
+/// body instead of re-reading `WKScriptMessage.body`.
+///
+/// #309: `WKScriptMessage.body` is the WebKit deserialization boundary for
+/// script messages. Reading it unguarded can crash the host process
+/// (SIGSEGV inside `CloneDeserializer::readDOMException` when a page posts a
+/// `DOMException` through the bridge) or hand values the Flutter standard
+/// message codec cannot carry. `WeakScriptMessageHandler` is the single
+/// registration point for every zikzak macOS script message handler
+/// (`consoleHandler`, `callHandler`, `onFindResultReceived`,
+/// `onWebMessagePortMessageReceived`, `onWebMessageListenerPostMessageReceived`,
+/// `onScrollChangedReceived`), so the defensive deserialization lives here:
+/// the body is read exactly once, inside an ObjC exception boundary, sanitized
+/// for the message codec, and only then passed on.
+protocol DefensivelyDeserializedScriptMessageHandling: WKScriptMessageHandler {
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage,
+        sanitizedBody: Any,
+        deserializationError: String?
+    )
+}
 
 class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
     weak var delegate: WKScriptMessageHandler?
-    
+
     init(delegate: WKScriptMessageHandler) {
         self.delegate = delegate
     }
-    
+
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        self.delegate?.userContentController(userContentController, didReceive: message)
+        guard let delegate = self.delegate else {
+            return
+        }
+
+        // #309 — defensive deserialization choke point (macOS).
+        // Touch `message.body` exactly once, inside the ObjC exception
+        // boundary, and never forward non-cloneable values to Dart.
+        let (sanitizedBody, deserializationError) = Self.defensivelyDeserializeBody(of: message)
+
+        if let defensiveDelegate = delegate as? DefensivelyDeserializedScriptMessageHandling {
+            defensiveDelegate.userContentController(
+                userContentController,
+                didReceive: message,
+                sanitizedBody: sanitizedBody,
+                deserializationError: deserializationError)
+        } else {
+            // Foreign delegate: legacy forwarding, still defensively read so a
+            // fragile body never crosses this boundary unguarded.
+            delegate.userContentController(userContentController, didReceive: message)
+        }
+    }
+
+    // MARK: - #309 defensive deserialization
+
+    /// Reads `message.body` inside an ObjC exception boundary and sanitizes the
+    /// result for the Flutter standard message codec.
+    ///
+    /// - Returns: the sanitized body — plain codec-safe containers whose leaves
+    ///   are strings/numbers/booleans/data (anything else is converted to its
+    ///   string representation) — plus a non-nil error string when WebKit's
+    ///   deserializer threw while producing the body.
+    static func defensivelyDeserializeBody(of message: WKScriptMessage) -> (body: Any, error: String?) {
+        var body: Any? = nil
+        var thrown: NSException? = nil
+        if let exception = ZikzakCatchException({ body = message.body }) {
+            thrown = exception
+        }
+        if let exception = thrown {
+            let reason = exception.reason ?? exception.name.rawValue
+            let errorDescription =
+                "Failed to deserialize script message body for handler '\(message.name)': \(reason)"
+            return (errorDescription, errorDescription)
+        }
+        guard let body = body else {
+            return (NSNull(), nil)
+        }
+        return (sanitizeValueForMessageCodec(body), nil)
+    }
+
+    /// Recursively converts values the Flutter standard message codec cannot
+    /// carry (e.g. a `DOMException` that survived deserialization as a foreign
+    /// class, `NSDate`, `NSURL`, opaque objects, unsupported nested leaves)
+    /// into their string representation (#309).
+    static func sanitizeValueForMessageCodec(_ value: Any) -> Any {
+        switch value {
+        case is NSNull, is String, is NSNumber, is Bool, is Int, is Int32, is Int64,
+            is UInt, is Double, is Float, is Data:
+            return value
+        case let dictionary as NSDictionary:
+            var sanitized: [String: Any] = [:]
+            for (rawKey, rawValue) in dictionary {
+                let key = sanitizeValueForMessageCodec(rawKey)
+                if let stringKey = key as? String {
+                    sanitized[stringKey] = sanitizeValueForMessageCodec(rawValue)
+                } else {
+                    sanitized[String(describing: key)] = sanitizeValueForMessageCodec(rawValue)
+                }
+            }
+            return sanitized
+        case let array as NSArray:
+            return array.map { sanitizeValueForMessageCodec($0) }
+        case is NSDate:
+            return String(describing: value)
+        case is URL:
+            return String(describing: value)
+        default:
+            // Non-cloneable / opaque object: string representation instead of
+            // feeding the method channel codec something it cannot encode.
+            return String(describing: value)
+        }
     }
 }

--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/WeakScriptMessageHandler.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/WeakScriptMessageHandler.swift
@@ -48,8 +48,13 @@ class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
                 sanitizedBody: sanitizedBody,
                 deserializationError: deserializationError)
         } else {
-            // Foreign delegate: legacy forwarding, still defensively read so a
-            // fragile body never crosses this boundary unguarded.
+            // Foreign delegate: legacy forwarding. The delegate reads
+            // message.body directly (unguarded) — this path is only safe if
+            // the delegate itself handles non-cloneable values. All six zikzak
+            // registrations use the sanitizing path above; foreign delegates
+            // must adopt DefensivelyDeserializedScriptMessageHandling to be
+            // crash-safe.
+            NSLog("[ZikzakInAppWebView] Warning: delegate \(type(of: delegate)) does not conform to DefensivelyDeserializedScriptMessageHandling; message body is read unguarded.")
             delegate.userContentController(userContentController, didReceive: message)
         }
     }
@@ -76,7 +81,8 @@ class WeakScriptMessageHandler: NSObject, WKScriptMessageHandler {
             return (errorDescription, errorDescription)
         }
         guard let body = body else {
-            return (NSNull(), nil)
+            let nilError = "Script message body is nil for handler '\(message.name)'"
+            return (nilError, nilError)
         }
         return (sanitizeValueForMessageCodec(body), nil)
     }


### PR DESCRIPTION
Bug #309: macOS webview crashed with SIGSEGV in `CloneDeserializer::readDOMException` when JS sent a `DOMException` through the zikzak bridge. The `didReceiveScriptMessage` handler did not defensively deserialize the payload.

Fix: wrap `WKScriptMessage.body` deserialization in try/catch in `WeakScriptMessageHandler`; non-cloneable objects converted to string representation before passing to Dart.

## Implementation (macOS-only, per issue constraints)
- **New `ZikzakExceptionCatcher` ObjC target** (`@try/@catch` shim) — Swift cannot catch `NSException`; wired into `Package.swift`.
- **`WeakScriptMessageHandler`** is now the defensive choke point: reads `message.body` exactly once inside the exception boundary; recursively converts anything the Flutter standard message codec cannot carry (opaque objects like a DOMException result, `NSDate`, `NSURL`, unsupported nested leaves) to string representation; forwards a sanitized body + optional error string via the internal `DefensivelyDeserializedScriptMessageHandling` protocol.
- **macOS `InAppWebView`**: consumes the sanitized body in all six handler branches; on deserialization failure reports a normal string error to Dart (`onConsoleMessage`, ERROR level) instead of crashing.
- iOS / Android / web / Windows / Linux handlers untouched.

## Verification (Flutter 3.47.2 / Dart 3.13.2)

| Gate | Result |
| --- | --- |
| `flutter test` (zikzak_inappwebview_macos) | **42 / 42 passed** |
| `flutter test` (zikzak_inappwebview) | **236 passed / 3 failed** — all 3 re-run on clean master and fail identically → pre-existing |
| `flutter analyze` (both packages) | findings only in files untouched by this change |
| `swiftc -parse` (changed Swift files) | clean |
| `git diff --check` | clean |
| platform isolation (`git diff --stat`) | only `zikzak_inappwebview_macos/**` + `.specify/` artifacts |

**Environment note (fail-closed):** produced on Linux; the WebKit-level SIGSEGV repro and Swift type-check/build require macOS and were **not executed here** — exact reproduction/verification commands are recorded in `.specify/bugs/309-macos-domexception-crash/tdd/cycle-log.md` (C1) and audited in `tdd/verification.md` (verdict `PASS_WITH_GAPS`). Spec-kit/TDD artifacts: issue, assessment, spec, fix, test-list, cycle-log, verification.

Closes #309