### PR TITLE
fix(macOS): declare userContentController public to satisfy WKScriptMessageHandler

### DIFF
--- a/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
+++ b/zikzak_inappwebview_macos/macos/zikzak_inappwebview_macos/Sources/zikzak_inappwebview_macos/InAppWebView.swift
@@ -2315,7 +2315,7 @@ public class InAppWebView: WKWebView, WKNavigationDelegate, WKScriptMessageHandl
     // Internal fallback for direct registration. Every zikzak macOS handler is
     // registered via WeakScriptMessageHandler, which calls the sanitized variant
     // below after defensively deserializing the body (#309).
-    func userContentController(
+    public func userContentController(
         _ userContentController: WKUserContentController, didReceive message: WKScriptMessage
     ) {
         let (sanitizedBody, deserializationError) = WeakScriptMessageHandler.defensivelyDeserializeBody(of: message)


### PR DESCRIPTION
Closes #312

## Problem
macOS 5.2.1+ fails to build with:
```
InAppWebView.swift:2318:10: error: method 'userContentController(_:didReceive:)' must be declared public because it matches a requirement in public protocol 'WKScriptMessageHandler'
```

## Root cause
PR #310 added a 2-argument `userContentController(_:didReceive:)` overload to `InAppWebView` (a public class) for defensive deserialization, but omitted the `public` access modifier. Swift requires protocol methods on public types to be public.

## Fix
Single-token change at `InAppWebView.swift:2318` — add `public` to the method declaration. No behavioral changes.

## Verification
- `flutter analyze` (zikzak_inappwebview_macos): 0 errors
- `flutter test` (zikzak_inappwebview_macos): 42/42 tests passed