### PR TITLE
fix(320): add profileId param to _FakePlatformProxyController.clearProxyOverride

### DIFF
--- a/zikzak_inappwebview/test/proxy_tracing_controllers_test.dart
+++ b/zikzak_inappwebview/test/proxy_tracing_controllers_test.dart
@@ -21,7 +21,7 @@ class _FakePlatformProxyController extends PlatformProxyController {
   }
 
   @override
-  Future<void> clearProxyOverride() async {
+  Future<void> clearProxyOverride({String? profileId}) async {
     clearOverrideCount++;
   }
 


### PR DESCRIPTION
## Summary

Adds the missing `{String? profileId}` named parameter to `_FakePlatformProxyController.clearProxyOverride()` in the proxy tracing controllers test.

## Problem

The umbrella package test suite failed to compile because the test fake's `clearProxyOverride()` method signature was missing the `profileId` parameter that the platform interface requires.

## Fix

One-line signature update to match the platform interface contract.

Closes #320