### PR TITLE
fix(321): correct loadSimulatedRequest test — urlResponse is forwarded, not dropped

### DIFF
--- a/zikzak_inappwebview/test/domain_controllers_behavioral_test.dart
+++ b/zikzak_inappwebview/test/domain_controllers_behavioral_test.dart
@@ -187,11 +187,7 @@ void main() {
       final args = calls.single.args;
       expect(args['urlRequest'], urlRequest);
       expect(args['data'], data);
-      // NOTE: the monolithic controller drops urlResponse before reaching the
-      // platform, so the facade inherits that behavior (FR-005: identical to the
-      // monolithic method). The argument is therefore forwarded to the parent
-      // but not to the platform call.
-      expect(args['urlResponse'], isNull);
+      expect(args['urlResponse'], response);
     });
 
     test('U15 reload delegates to parent', () async {


### PR DESCRIPTION
## Summary

Fixes the U14 `loadSimulatedRequest` behavioral test expectation: the `urlResponse` argument is forwarded to the platform, not dropped.

## Problem

The test expected `args['urlResponse']` to be `null`, but both the monolithic controller and `NavigationController` pass `urlResponse` straight through to `platform.loadSimulatedRequest()`. The stale comment claiming it was 'dropped' was incorrect.

## Fix

Changed assertion from `expect(args['urlResponse'], isNull)` to `expect(args['urlResponse'], response)` and removed the misleading comment.

Closes #321