### PR TITLE
fix(ios): keep data store selection flag in shared scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - zikzak_inappwebview_macos
           - zikzak_inappwebview_windows
           - zikzak_inappwebview_linux
+          - zikzak_inappwebview_ios
           - zikzak_inappwebview
     steps:
       - uses: actions/checkout@v4
@@ -48,6 +49,7 @@ jobs:
           - zikzak_inappwebview_macos
           - zikzak_inappwebview_windows
           - zikzak_inappwebview_linux
+          - zikzak_inappwebview_ios
           - zikzak_inappwebview
     steps:
       - uses: actions/checkout@v4
@@ -75,3 +77,33 @@ jobs:
       - name: flutter test --platform chrome
         working-directory: zikzak_inappwebview_web
         run: flutter test --platform chrome
+
+  # The iOS Swift sources are only compiled by a real iOS build, and only
+  # through a consuming app (the plugin's Package.swift expects the
+  # FlutterFramework package Flutter generates into the app). The example
+  # resolves the platform packages from pub.dev, so the override below is what
+  # makes this job compile *this* checkout — without it the published iOS
+  # package would be compiled instead, which is how the 6.0.0 scope error went
+  # unnoticed.
+  build-ios:
+    name: "build: zikzak_inappwebview_ios (iOS)"
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Point the example at this checkout
+        working-directory: zikzak_inappwebview/example
+        run: |
+          cat > pubspec_overrides.yaml <<'YAML'
+          dependency_overrides:
+            zikzak_inappwebview_ios:
+              path: ../../zikzak_inappwebview_ios
+          YAML
+      - name: flutter pub get
+        working-directory: zikzak_inappwebview/example
+        run: flutter pub get
+      - name: flutter build ios --release --no-codesign
+        working-directory: zikzak_inappwebview/example
+        run: flutter build ios --release --no-codesign

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -811,6 +811,7 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                     settings.allowFileAccessFromFileURLs, forKey: "allowFileAccessFromFileURLs")
             }
 
+            var dataStoreWasSelected = false
             if #available(iOS 9.0, *) {
                 // Per-instance persistent, isolated WKWebsiteDataStore
                 // (iOS 17+/macOS 14+). Same persistentStoreIdentifier
@@ -825,7 +826,6 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
                 // websiteDataStore is immutable post-init, so a later
                 // `setSettings` cannot change it (see issue #253
                 // acceptance criteria).
-                var dataStoreWasSelected = false
                 if settings.incognito {
                     configuration.websiteDataStore = WKWebsiteDataStore.nonPersistent()
                     dataStoreWasSelected = true

--- a/zikzak_inappwebview_ios/test/swift_availability_usage_test.dart
+++ b/zikzak_inappwebview_ios/test/swift_availability_usage_test.dart
@@ -149,6 +149,39 @@ List<String> scanAvailabilityUsage(String source) {
   return violations;
 }
 
+/// Returns the text between the `{` that opens the braces-delimited block at or
+/// after [start] and its matching `}`. Returns the empty string when the block
+/// is unterminated, so the caller's index lookups fail loudly rather than
+/// silently passing.
+String functionBody(String code, int start) {
+  final open = code.indexOf('{', start);
+  if (open == -1) return '';
+  var depth = 0;
+  for (var i = open; i < code.length; i++) {
+    if (code[i] == '{') {
+      depth++;
+    } else if (code[i] == '}') {
+      depth--;
+      if (depth == 0) return code.substring(open + 1, i);
+    }
+  }
+  return '';
+}
+
+/// Number of `{`-blocks still open at [index] in [code] — the brace depth of
+/// the character at that position.
+int braceDepthAt(String code, int index) {
+  var depth = 0;
+  for (var i = 0; i < index && i < code.length; i++) {
+    if (code[i] == '{') {
+      depth++;
+    } else if (code[i] == '}') {
+      depth--;
+    }
+  }
+  return depth;
+}
+
 /// Locates the iOS package root (`ios/zikzak_inappwebview_ios`) relative to the
 /// current working directory, walking up at most a few levels so the test works
 /// when invoked from the package dir or the repo root.
@@ -214,11 +247,12 @@ void main() {
         '${iosDir.path}/Sources/zikzak_inappwebview_ios/'
         'InAppWebView/InAppWebView.swift',
       ).readAsStringSync();
-      final functionStart = source.indexOf(
+      final code = stripSwiftNonCode(source);
+      final functionStart = code.indexOf(
         'public static func preWKWebViewConfiguration',
       );
       expect(functionStart, greaterThanOrEqualTo(0));
-      final functionSource = source.substring(functionStart);
+      final functionSource = functionBody(code, functionStart);
 
       final declaration = functionSource.indexOf(
         'var dataStoreWasSelected = false',
@@ -233,13 +267,19 @@ void main() {
       expect(declaration, greaterThanOrEqualTo(0));
       expect(ios9ConfigurationBlock, greaterThanOrEqualTo(0));
       expect(cookieSetupUse, greaterThan(ios9ConfigurationBlock));
+      // Textual order alone is not the invariant: a declaration nested inside a
+      // sibling block that closes before the iOS 9 block is still "above" it,
+      // yet is out of scope for the iOS 11 cookie block and fails to compile.
+      // Equal brace depth proves the declaration sits in the scope that
+      // encloses both availability blocks.
       expect(
-        declaration,
-        lessThan(ios9ConfigurationBlock),
+        braceDepthAt(functionSource, declaration),
+        equals(braceDepthAt(functionSource, ios9ConfigurationBlock)),
         reason:
             'The flag is read by a later iOS 11 availability block, so it must '
-            'be declared in their shared settings scope rather than inside the '
-            'iOS 9 block.',
+            'be declared in their shared settings scope — a sibling of the '
+            'iOS 9 block, not nested inside another block that closes before '
+            'it.',
       );
     },
     timeout: const Timeout(Duration(minutes: 2)),

--- a/zikzak_inappwebview_ios/test/swift_availability_usage_test.dart
+++ b/zikzak_inappwebview_ios/test/swift_availability_usage_test.dart
@@ -205,4 +205,43 @@ void main() {
     },
     timeout: const Timeout(Duration(minutes: 2)),
   );
+
+  test(
+    'data-store selection flag is visible to the iOS 11 cookie setup block',
+    () {
+      final iosDir = packageIosDir();
+      final source = File(
+        '${iosDir.path}/Sources/zikzak_inappwebview_ios/'
+        'InAppWebView/InAppWebView.swift',
+      ).readAsStringSync();
+      final functionStart = source.indexOf(
+        'public static func preWKWebViewConfiguration',
+      );
+      expect(functionStart, greaterThanOrEqualTo(0));
+      final functionSource = source.substring(functionStart);
+
+      final declaration = functionSource.indexOf(
+        'var dataStoreWasSelected = false',
+      );
+      final ios9ConfigurationBlock = functionSource.indexOf(
+        'if #available(iOS 9.0, *) {',
+      );
+      final cookieSetupUse = functionSource.indexOf(
+        'if !dataStoreWasSelected {',
+      );
+
+      expect(declaration, greaterThanOrEqualTo(0));
+      expect(ios9ConfigurationBlock, greaterThanOrEqualTo(0));
+      expect(cookieSetupUse, greaterThan(ios9ConfigurationBlock));
+      expect(
+        declaration,
+        lessThan(ios9ConfigurationBlock),
+        reason:
+            'The flag is read by a later iOS 11 availability block, so it must '
+            'be declared in their shared settings scope rather than inside the '
+            'iOS 9 block.',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 2)),
+  );
 }


### PR DESCRIPTION
## Summary

- move `dataStoreWasSelected` into the settings scope shared by the iOS 9 configuration and iOS 11 cookie setup blocks
- add a regression test that verifies the declaration remains visible to its later use
- fix the Swift compiler error shipped in `zikzak_inappwebview_ios` 6.0.0 after the issue #316 availability-expression fix

## Testing

- `flutter test` in `zikzak_inappwebview_ios` (12 tests passed)
- `flutter build ios --release --no-codesign` in Luotopia with this iOS package resolved from the branch (succeeded)