### PR TITLE
fix(ios): make the evaluateJavaScript override portable across SDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,20 +80,37 @@ jobs:
         working-directory: zikzak_inappwebview_web
         run: flutter test --platform chrome
 
-  # NOTE: an iOS device build job is deliberately absent.
+  # The iOS Swift sources are only compiled by a real iOS build, and only
+  # through a consuming app (the plugin's Package.swift expects the
+  # FlutterFramework package Flutter generates into the app). The example
+  # resolves the platform packages from pub.dev, so the override below is what
+  # makes this job compile *this* checkout — without it the published iOS
+  # package would be compiled instead, which is how the 6.0.0 scope error went
+  # unnoticed.
   #
-  # PR #329 added one (`flutter build ios --release --no-codesign` on
-  # macos-14, with a pubspec_overrides.yaml pointing the example at this
-  # checkout). It failed immediately, and correctly: on the SDK shipped with
-  # the runner's Xcode, `InAppWebView.evaluateJavaScript(_:completionHandler:)`
-  # does not override its superclass — it is declared with a
-  # `@MainActor @Sendable` closure parameter that only matches the newer SDK —
-  # and the resulting extra overload makes every single-argument
-  # `evaluateJavaScript(...)` call ambiguous. That is 10 real compile errors in
-  # zikzak_inappwebview_ios/.../InAppWebView/InAppWebView.swift (lines 2010,
-  # 1426, 1429, 1448, 1451, 1890, 2583, 3692, 3717, 3829 as of 7cc96fdc), and
-  # they mean consumers on older Xcode cannot build the iOS plugin at all.
-  #
-  # It needs its own fix and a toolchain that reproduces it; the analyze and
-  # test matrix entries above still cover zikzak_inappwebview_ios in the
-  # meantime. Restore this job once the override is SDK-portable.
+  # This job earns its keep: on its first run it caught
+  # InAppWebView.evaluateJavaScript(_:completionHandler:) failing to override on
+  # the runner's SDK, which is a hard build failure for consumers on older Xcode
+  # (see the signature note in InAppWebView.swift).
+  build-ios:
+    name: "build: zikzak_inappwebview_ios (iOS)"
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+      - name: Point the example at this checkout
+        working-directory: zikzak_inappwebview/example
+        run: |
+          cat > pubspec_overrides.yaml <<'YAML'
+          dependency_overrides:
+            zikzak_inappwebview_ios:
+              path: ../../zikzak_inappwebview_ios
+          YAML
+      - name: flutter pub get
+        working-directory: zikzak_inappwebview/example
+        run: flutter pub get
+      - name: flutter build ios --release --no-codesign
+        working-directory: zikzak_inappwebview/example
+        run: flutter build ios --release --no-codesign

--- a/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
+++ b/zikzak_inappwebview_ios/ios/zikzak_inappwebview_ios/Sources/zikzak_inappwebview_ios/InAppWebView/InAppWebView.swift
@@ -2008,9 +2008,17 @@ public class InAppWebView: WKWebView, UIScrollViewDelegate, WKUIDelegate,
         }
     }
 
+    // Signature note: the completion handler is declared without `@MainActor`
+    // and `@Sendable` on purpose. The SDK bundled with recent Xcode annotates
+    // WKWebView's parameter that way, but the older SDKs do not, and a
+    // parameter type that carries those attributes does not override the
+    // superclass method there — `override` then fails outright ("method does
+    // not override any method from its superclass") and the extra overload it
+    // leaves behind makes every single-argument `evaluateJavaScript(...)` call
+    // in this file ambiguous. The unannotated form is what both SDKs accept.
     public override func evaluateJavaScript(
         _ javaScriptString: String,
-        completionHandler: (@MainActor @Sendable (Any?, (any Error)?) -> Void)? = nil
+        completionHandler: ((Any?, Error?) -> Void)? = nil
     ) {
         if let applePayAPIEnabled = settings?.applePayAPIEnabled, applePayAPIEnabled {
             completionHandler?(nil, nil)


### PR DESCRIPTION
Fixes the iOS build failure that the `build-ios` job from #329 caught on its first run — a hard build break for consumers on older Xcode.

## What fails

`InAppWebView.evaluateJavaScript(_:completionHandler:)` declared its completion handler as `@MainActor @Sendable (Any?, (any Error)?) -> Void`. Only the SDK bundled with recent Xcode annotates `WKWebView`'s parameter that way. On older SDKs that is a *different function type*, so the method stops overriding its superclass and two things break:

- the declaration itself — `Method does not override any method from its superclass` (`InAppWebView.swift:2010`)
- the surviving extra overload makes every single-argument `evaluateJavaScript(...)` call ambiguous — nine of them (lines 1426, 1429, 1448, 1451, 1890, 2583, 3692, 3717, 3829)

It went unnoticed because the same file compiles clean under Xcode 26.

## Fix

Declare the parameter as the plain `((Any?, Error?) -> Void)?` — the form both SDKs accept, and the one the rest of this file already uses.

## Verification

- compiles under Xcode 26.3 (full `flutter build ios --release --no-codesign` of the example, from this checkout)
- the restored `build-ios` job checks the older runner SDK

## Also

Restores the `build-ios` job that 2d7c61aa removed while this was outstanding. It stays covered: this is exactly the class of failure the other jobs cannot see.